### PR TITLE
Remove extra space for closures with captures but no arguments.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -689,9 +689,16 @@ private final class TokenStreamCreator: SyntaxVisitor {
     }
 
     before(node.firstToken, tokens: .open)
-    after(node.capture?.rightSquare, tokens: .break(.same))
-    before(node.input?.firstToken, tokens: .open(consistency))
-    after(node.input?.lastToken, tokens: .close)
+
+    if let input = node.input {
+      // We unconditionally put a break before the `in` keyword below, so we should only put a break
+      // after the capture list's right bracket if there are arguments following it or we'll end up
+      // with an extra space if the line doesn't wrap.
+      after(node.capture?.rightSquare, tokens: .break(.same))
+      before(input.firstToken, tokens: .open(consistency))
+      after(input.lastToken, tokens: .close)
+    }
+
     before(node.throwsTok, tokens: .break)
     before(node.output?.arrow, tokens: .break)
     after(node.lastToken, tokens: .close)

--- a/Tests/SwiftFormatPrettyPrintTests/ClosureExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ClosureExprTests.swift
@@ -233,6 +233,23 @@ public class ClosureExprTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 60)
   }
 
+  public func testClosureCaptureWithoutArguments() {
+    let input =
+      """
+      let a = { [weak self] in return foo }
+      """
+
+    let expected =
+      """
+      let a = { [weak self] in
+        return foo
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 30)
+  }
+
   public func testBodilessClosure() {
     let input =
       """

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -91,6 +91,7 @@ extension ClosureExprTests {
         ("testBasicFunctionClosures_packArguments", testBasicFunctionClosures_packArguments),
         ("testBodilessClosure", testBodilessClosure),
         ("testClosureCapture", testClosureCapture),
+        ("testClosureCaptureWithoutArguments", testClosureCaptureWithoutArguments),
         ("testClosuresWithIfs", testClosuresWithIfs),
         ("testTrailingClosure", testTrailingClosure),
     ]


### PR DESCRIPTION
Fixes [SR-11105](https://bugs.swift.org/browse/SR-11105).