### PR TITLE
Make members of a private extension fileprivate.

### DIFF
--- a/Tests/SwiftFormatRulesTests/NoAccessLevelOnExtensionDeclarationTests.swift
+++ b/Tests/SwiftFormatRulesTests/NoAccessLevelOnExtensionDeclarationTests.swift
@@ -84,4 +84,20 @@ public class NoAccessLevelOnExtensionDeclarationTests: DiagnosingTestCase {
         """
     )
   }
+
+  public func testPrivateIsEffectivelyFileprivate() {
+    XCTAssertFormatting(
+      NoAccessLevelOnExtensionDeclaration.self,
+      input: """
+        private extension Foo {
+          func f() {}
+        }
+        """,
+      expected: """
+        extension Foo {
+          fileprivate func f() {}
+        }
+        """
+    )
+  }
 }

--- a/Tests/SwiftFormatRulesTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatRulesTests/XCTestManifests.swift
@@ -157,6 +157,7 @@ extension NoAccessLevelOnExtensionDeclarationTests {
     static let __allTests__NoAccessLevelOnExtensionDeclarationTests = [
         ("testExtensionDeclarationAccessLevel", testExtensionDeclarationAccessLevel),
         ("testPreservesCommentOnRemovedModifier", testPreservesCommentOnRemovedModifier),
+        ("testPrivateIsEffectivelyFileprivate", testPrivateIsEffectivelyFileprivate),
     ]
 }
 


### PR DESCRIPTION
Extensions are declared at file scope, so "private" on an extension means
that the members are actually "fileprivate". In this case we need to add
the correct keyword to the individual members, or we'll actually change
their visibility incorrectly.

Fixes [SR-11110](https://bugs.swift.org/browse/SR-11110).