### PR TITLE
Ensure a space after `case` in a `for case ... in` statement.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -422,6 +422,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
   func visit(_ node: ForInStmtSyntax) -> SyntaxVisitorContinueKind {
     after(node.labelColon, tokens: .space)
     after(node.forKeyword, tokens: .space)
+    after(node.caseKeyword, tokens: .space)
     before(node.inKeyword, tokens: .break)
     after(node.inKeyword, tokens: .space)
 

--- a/Tests/SwiftFormatPrettyPrintTests/ForInStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ForInStmtTests.swift
@@ -163,4 +163,27 @@ public class ForInStmtTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
   }
+
+  public func testForCase() {
+    let input =
+      """
+      for case let a as String in [] {
+        let a = 123
+        print(i)
+      }
+      """
+
+    let expected =
+      """
+      for case let a
+        as String in []
+      {
+        let a = 123
+        print(i)
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -174,6 +174,7 @@ extension ForInStmtTests {
     // to regenerate.
     static let __allTests__ForInStmtTests = [
         ("testBasicForLoop", testBasicForLoop),
+        ("testForCase", testForCase),
         ("testForLabels", testForLabels),
         ("testForLoopFullWrap", testForLoopFullWrap),
         ("testForWhereLoop", testForWhereLoop),


### PR DESCRIPTION
Fixes [SR-11112](https://bugs.swift.org/browse/SR-11112).