### PR TITLE
Ensure a space after `@unknown` in a default case.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -508,6 +508,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
 
   func visit(_ node: SwitchCaseSyntax) -> SyntaxVisitorContinueKind {
     before(node.firstToken, tokens: .newline)
+    after(node.unknownAttr?.lastToken, tokens: .space)
     after(node.label.lastToken, tokens: .break(.reset, size: 0), .break(.open), .open)
     after(node.lastToken, tokens: .break(.close, size: 0), .close)
     return .visitChildren

--- a/Tests/SwiftFormatPrettyPrintTests/SwitchStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/SwitchStmtTests.swift
@@ -196,4 +196,24 @@ public class SwitchStmtTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
   }
+
+  public func testUnknownDefault() {
+    let input =
+      """
+      switch foo {
+      @unknown default: bar()
+      }
+      """
+
+    let expected =
+      """
+      switch foo {
+      @unknown default:
+        bar()
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -403,6 +403,7 @@ extension SwitchStmtTests {
         ("testSwitchCases", testSwitchCases),
         ("testSwitchCompoundCases", testSwitchCompoundCases),
         ("testSwitchValueBinding", testSwitchValueBinding),
+        ("testUnknownDefault", testUnknownDefault),
     ]
 }
 


### PR DESCRIPTION
Fixes [SR-11113](https://bugs.swift.org/browse/SR-11113).