### PR TITLE
Fix an index-out-of-bounds error in DontRepeatTypeInStaticProperties.

### DIFF
--- a/Tests/SwiftFormatRulesTests/DontRepeatTypeInStaticPropertiesTests.swift
+++ b/Tests/SwiftFormatRulesTests/DontRepeatTypeInStaticPropertiesTests.swift
@@ -7,33 +7,34 @@ import XCTest
 public class DontRepeatTypeInStaticPropertiesTests: DiagnosingTestCase {
   public func testRepetitiveProperties() {
     let input =
-    """
-    public class UIColor {
-      static let redColor: UIColor
-      public class var blueColor: UIColor
-      var yellowColor: UIColor
-      static let green: UIColor
-      public class var purple: UIColor
-    }
-    enum Sandwich {
-      static let bolognaSandwich: Sandwich
-      static var hamSandwich: Sandwich
-      static var turkey: Sandwich
-    }
-    protocol RANDPerson {
-      var oldPerson: Person
-      static let youngPerson: Person
-    }
-    struct TVGame {
-      static var basketballGame: TVGame
-      static var baseballGame: TVGame
-      static let soccer: TVGame
-      let hockey: TVGame
-    }
-    extension URLSession {
-      class var sharedSession: URLSession
-    }
-    """
+      """
+      public class UIColor {
+        static let redColor: UIColor
+        public class var blueColor: UIColor
+        var yellowColor: UIColor
+        static let green: UIColor
+        public class var purple: UIColor
+      }
+      enum Sandwich {
+        static let bolognaSandwich: Sandwich
+        static var hamSandwich: Sandwich
+        static var turkey: Sandwich
+      }
+      protocol RANDPerson {
+        var oldPerson: Person
+        static let youngPerson: Person
+      }
+      struct TVGame {
+        static var basketballGame: TVGame
+        static var baseballGame: TVGame
+        static let soccer: TVGame
+        let hockey: TVGame
+      }
+      extension URLSession {
+        class var sharedSession: URLSession
+      }
+      """
+
     performLint(DontRepeatTypeInStaticProperties.self, input: input)
     XCTAssertDiagnosed(.removeTypeFromName(name: "redColor", type: "Color"))
     XCTAssertDiagnosed(.removeTypeFromName(name: "blueColor", type: "Color"))
@@ -54,5 +55,29 @@ public class DontRepeatTypeInStaticPropertiesTests: DiagnosingTestCase {
     XCTAssertNotDiagnosed(.removeTypeFromName(name: "hockey", type: "Game"))
     
     XCTAssertDiagnosed(.removeTypeFromName(name: "sharedSession", type: "Session"))
+  }
+
+  public func testSR11123() {
+    let input =
+      """
+      extension A {
+        static let b = C()
+      }
+      """
+
+    performLint(DontRepeatTypeInStaticProperties.self, input: input)
+    XCTAssertNotDiagnosed(.removeTypeFromName(name: "b", type: "A"))
+  }
+
+  public func testDottedExtendedType() {
+    let input =
+      """
+      extension Dotted.Thing {
+        static let defaultThing: Dotted.Thing
+      }
+      """
+
+    performLint(DontRepeatTypeInStaticProperties.self, input: input)
+    XCTAssertDiagnosed(.removeTypeFromName(name: "defaultThing", type: "Thing"))
   }
 }

--- a/Tests/SwiftFormatRulesTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatRulesTests/XCTestManifests.swift
@@ -76,7 +76,9 @@ extension DontRepeatTypeInStaticPropertiesTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__DontRepeatTypeInStaticPropertiesTests = [
+        ("testDottedExtendedType", testDottedExtendedType),
         ("testRepetitiveProperties", testRepetitiveProperties),
+        ("testSR11123", testSR11123),
     ]
 }
 


### PR DESCRIPTION
This commit also does some general cleanup of this rule, improving the
prefix-detection algorithm and adding correct support for extensions
where the extended type is a dotted type name.

Fixes [SR-11123](https://bugs.swift.org/browse/SR-11123).