### PR TITLE
[Gardening] Rename fill(_:into:) to fill(parseResult:into:)

### DIFF
--- a/Sources/swift-format/CommandLineOptions.swift
+++ b/Sources/swift-format/CommandLineOptions.swift
@@ -143,7 +143,7 @@ func processArguments(commandName: String, _ arguments: [String]) -> CommandLine
   var opts = CommandLineOptions()
   do {
     let args = try parser.parse(arguments)
-    binder.fill(args, into: &opts)
+    try binder.fill(parseResult: args, into: &opts)
 
     if opts.mode.requiresFiles && opts.paths.isEmpty {
       throw ArgumentParserError.expectedArguments(parser, ["filenames or paths"])


### PR DESCRIPTION
## Overview

There is a warning about deprecated method of `fill(_:into:)`. I just renamed it to new one which is `fill(parseResult:into:)`