### PR TITLE
Indent line comments correctly when they precede a continuation line.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
@@ -313,7 +313,6 @@ public class PrettyPrinter {
       spaceRemaining -= text.count
 
     case .comment(let comment, let wasEndOfLine):
-      currentLineIsContinuation = false
       lastBreak = false
 
       write(comment.print(indent: currentIndentation))

--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -877,13 +877,12 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   func visit(_ node: CodeBlockItemListSyntax) -> SyntaxVisitorContinueKind {
-    insertTokens(.break(.reset, size: 0), .newline, betweenElementsOf: node)
     return .visitChildren
   }
 
   func visit(_ node: CodeBlockItemSyntax) -> SyntaxVisitorContinueKind {
     before(node.firstToken, tokens: .open)
-    after(node.lastToken, tokens: .close)
+    after(node.lastToken, tokens: .close, .break(.reset, size: 0))
     return .visitChildren
   }
 

--- a/Tests/SwiftFormatPrettyPrintTests/CommentTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/CommentTests.swift
@@ -416,4 +416,17 @@ public class CommentTests: PrettyPrintTestCase {
     
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 100)
   }
+
+  public func testCommentOnContinuationLine() {
+    let input =
+      """
+      func foo() {
+        return true
+          // comment
+          && false
+      }
+      """
+
+    assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 60)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -103,6 +103,7 @@ extension CommentTests {
     // to regenerate.
     static let __allTests__CommentTests = [
         ("testBlockComments", testBlockComments),
+        ("testCommentOnContinuationLine", testCommentOnContinuationLine),
         ("testContainerLineComments", testContainerLineComments),
         ("testDocumentationBlockComments", testDocumentationBlockComments),
         ("testDocumentationComments", testDocumentationComments),


### PR DESCRIPTION
If a line comment occurs after a continuation break, then its indentation depends on what comes on the line following it:

* If the following line is an indented continuation line, then the comment should also be indented as a continuation. For example,

  ```swift
  return true
    // comment
    && false
  ```

* Otherwise, if the following line is not a continuation (such as a new statement, a closing delimiter, or the end of the file), then the comment should not be indented as a continuation:

  ```swift
  {
    return true
    // comment
  }
  ```

This is achieved by adding a reset break after the last item in a code block (rather than just _between_ them) and by not resetting the continuation state unconditionally when printing a comment.

Fixes [SR-11107](https://bugs.swift.org/browse/SR-11107).