### PR TITLE
Ensure line breaks between type members wrapped in an `#if` block.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -819,7 +819,11 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   func visit(_ node: MemberDeclBlockSyntax) -> SyntaxVisitorContinueKind {
-    insertTokens(.break(.reset, size: 0), .newline, betweenElementsOf: node.members)
+    return .visitChildren
+  }
+
+  func visit(_ node: MemberDeclListSyntax) -> SyntaxVisitorContinueKind {
+    insertTokens(.break(.reset, size: 0), .newline, betweenElementsOf: node)
     return .visitChildren
   }
 

--- a/Tests/SwiftFormatPrettyPrintTests/IfConfigTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/IfConfigTests.swift
@@ -55,4 +55,29 @@ public class IfConfigTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
   }
+
+  public func testPoundIfAroundMembers() {
+    let input =
+      """
+      class Foo {
+      #if DEBUG
+        var bar: String
+        var baz: String
+      #endif
+      }
+      """
+
+    let expected =
+      """
+      class Foo {
+        #if DEBUG
+          var bar: String
+          var baz: String
+        #endif
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -248,6 +248,7 @@ extension IfConfigTests {
     // to regenerate.
     static let __allTests__IfConfigTests = [
         ("testBasicIfConfig", testBasicIfConfig),
+        ("testPoundIfAroundMembers", testPoundIfAroundMembers),
     ]
 }
 


### PR DESCRIPTION
These were getting collapsed because we were adding the breaks inside
the visitor for `MemberDeclBlock`, but when there is an intervening
`IfConfigClause`, the inner members are only wrapped in a
`MemberDeclList`, not another `MemberDeclBlock`. Updating the token
stream to insert the breaks in the list visitor ensures that this
happens in all cases.

Fixes [SR-11116](https://bugs.swift.org/browse/SR-11116).