### PR TITLE
[SR-11115] Missing type annotation on multiple declarations

### DIFF
--- a/Sources/SwiftFormatRules/OneVariableDeclarationPerLine.swift
+++ b/Sources/SwiftFormatRules/OneVariableDeclarationPerLine.swift
@@ -54,8 +54,14 @@ public final class OneVariableDeclarationPerLine: SyntaxFormatRule {
       // The first binding corresponds to the original `var`/`let`
       // declaration, so it should not have its trivia replaced.
       var isFirst = true
+      // The last binding only has type annotation when multiple
+      // declarations in one line, so make a new binding with its type
+      let typeAnnotation = varDecl.bindings.last?.typeAnnotation
       for binding in varDecl.bindings {
-        let newBinding = binding.withTrailingComma(nil)
+        var newBinding = binding.withTrailingComma(nil)
+        if typeAnnotation != nil && binding.typeAnnotation == nil {
+            newBinding = newBinding.withTypeAnnotation(typeAnnotation)
+        }
         let newDecl = varDecl.withBindings(
           SyntaxFactory.makePatternBindingList([newBinding]))
         var finalDecl: Syntax = newDecl

--- a/Sources/SwiftFormatRules/OneVariableDeclarationPerLine.swift
+++ b/Sources/SwiftFormatRules/OneVariableDeclarationPerLine.swift
@@ -60,7 +60,7 @@ public final class OneVariableDeclarationPerLine: SyntaxFormatRule {
       for binding in varDecl.bindings {
         var newBinding = binding.withTrailingComma(nil)
         if typeAnnotation != nil && binding.typeAnnotation == nil {
-            newBinding = newBinding.withTypeAnnotation(typeAnnotation)
+          newBinding = newBinding.withTypeAnnotation(typeAnnotation)
         }
         let newDecl = varDecl.withBindings(
           SyntaxFactory.makePatternBindingList([newBinding]))

--- a/Tests/SwiftFormatRulesTests/OneVariableDeclarationPerLineTests.swift
+++ b/Tests/SwiftFormatRulesTests/OneVariableDeclarationPerLineTests.swift
@@ -12,6 +12,7 @@ public class OneVariableDeclarationPerLineTests: DiagnosingTestCase {
              var a = 0, b = 2, (c, d) = (0, "h")
              let e = 0, f = 2, (g, h) = (0, "h")
              var x: Int { return 3 }
+             let a, b, c: Int
              """,
       expected: """
                 var a = 0
@@ -21,6 +22,9 @@ public class OneVariableDeclarationPerLineTests: DiagnosingTestCase {
                 let f = 2
                 let (g, h) = (0, "h")
                 var x: Int { return 3 }
+                let a: Int
+                let b: Int
+                let c: Int
                 """)
   }
 


### PR DESCRIPTION
Produced source code is missing type annotation only when multiple declarations with only one type because the last one only has it. So I set its type to the rest of decls when necessary 

Fixes [SR-11115](https://bugs.swift.org/browse/SR-11115).