### PR TITLE
[SR-11109] swift-format produces invalid enum for raw values

### DIFF
--- a/Tests/SwiftFormatRulesTests/OneCasePerLineTests.swift
+++ b/Tests/SwiftFormatRulesTests/OneCasePerLineTests.swift
@@ -17,6 +17,16 @@ public class OneCasePerLineTests: DiagnosingTestCase {
                                  var x: Bool
                                  case leftParen, rightParen = ")", leftBrace, rightBrace = "}"
                                }
+                               public enum Token: Int {
+                                 case a, b, c
+                                 case a = 0, b, c = 5, d
+                                 case a = 0, b = 10, c, d
+                               }
+                               public enum Token: Float {
+                                 case a, b, c
+                                 case a = 0, b, c = 5, d
+                                 case a = 0, b = 10, c, d
+                               }
                                """,
                         expected: """
                                   public enum Token {
@@ -33,6 +43,20 @@ public class OneCasePerLineTests: DiagnosingTestCase {
                                     case leftParen, leftBrace
                                     case rightParen = ")"
                                     case rightBrace = "}"
+                                  }
+                                  public enum Token: Int {
+                                    case a, b, c
+                                    case a = 0, b
+                                    case c = 5, d
+                                    case a = 0
+                                    case b = 10, c, d
+                                  }
+                                  public enum Token: Float {
+                                    case a, b, c
+                                    case a = 0, b
+                                    case c = 5, d
+                                    case a = 0
+                                    case b = 10, c, d
                                   }
                                   """)
   }


### PR DESCRIPTION
## Overview

This PR fixes unexpected format for enum with incremental raw values for `Int` or `Float`.

I applogize that I forgot to assign this issue to me on bugs.swift when I started working on, but I gave it a try to fix the issue. However, this approach doesn't look elegant in my opinion. If that's the case, please ignore this PR since @allevato should be working on the fix as well.

Fixes [SR-11109](https://bugs.swift.org/browse/SR-11109).