### PR TITLE
Lint pipeline improvements; fix enabling/disabling of lint rules.

### DIFF
--- a/Sources/SwiftFormat/LintPipeline.swift
+++ b/Sources/SwiftFormat/LintPipeline.swift
@@ -25,4 +25,42 @@ struct LintPipeline: SyntaxVisitor {
   init(context: Context) {
     self.context = context
   }
+
+  /// Calls the `visit` method of a rule for the given node if that rule is enabled for the node.
+  ///
+  /// - Parameters:
+  ///   - visitor: A reference to the `visit` method on the *type* of a `SyntaxLintRule` subclass.
+  ///     The type of the rule in question is inferred from the signature of the method reference.
+  ///   - context: The formatter context that contains information about which rules are enabled or
+  ///     disabled.
+  ///   - node: The syntax node on which the rule will be applied. This lets us check whether the
+  ///     rule is enabled for the particular source range where the node occurs.
+  func visitIfEnabled<Rule: SyntaxLintRule, Node: Syntax>(
+    _ visitor: (Rule) -> (Node) -> SyntaxVisitorContinueKind, in context: Context, for node: Node
+  ) {
+    guard !context.isRuleDisabled(Rule.self.ruleName, node: node) else { return }
+    let rule = Rule(context: context)
+    _ = visitor(rule)(node)
+  }
+
+  /// Calls the `visit` method of a rule for the given node if that rule is enabled for the node.
+  ///
+  /// - Parameters:
+  ///   - visitor: A reference to the `visit` method on the *type* of a `SyntaxFormatRule` subclass.
+  ///     The type of the rule in question is inferred from the signature of the method reference.
+  ///   - context: The formatter context that contains information about which rules are enabled or
+  ///     disabled.
+  ///   - node: The syntax node on which the rule will be applied. This lets us check whether the
+  ///     rule is enabled for the particular source range where the node occurs.
+  func visitIfEnabled<Rule: SyntaxFormatRule, Node: Syntax>(
+    _ visitor: (Rule) -> (Node) -> Any, in context: Context, for node: Node
+  ) {
+    // Note that visitor function type is expressed as `Any` because we ignore the return value, but
+    // more importantly because the `visit` methods return protocol refinements of `Syntax` that
+    // cannot currently be expressed as constraints without duplicating this function for each of
+    // them individually.
+    guard !context.isRuleDisabled(Rule.self.ruleName, node: node) else { return }
+    let rule = Rule(context: context)
+    _ = visitor(rule)(node)
+  }
 }

--- a/Sources/SwiftFormat/LintPipeline.swift
+++ b/Sources/SwiftFormat/LintPipeline.swift
@@ -38,7 +38,7 @@ struct LintPipeline: SyntaxVisitor {
   func visitIfEnabled<Rule: SyntaxLintRule, Node: Syntax>(
     _ visitor: (Rule) -> (Node) -> SyntaxVisitorContinueKind, in context: Context, for node: Node
   ) {
-    guard !context.isRuleDisabled(Rule.self.ruleName, node: node) else { return }
+    guard context.isRuleEnabled(Rule.self.ruleName, node: node) else { return }
     let rule = Rule(context: context)
     _ = visitor(rule)(node)
   }
@@ -59,7 +59,7 @@ struct LintPipeline: SyntaxVisitor {
     // more importantly because the `visit` methods return protocol refinements of `Syntax` that
     // cannot currently be expressed as constraints without duplicating this function for each of
     // them individually.
-    guard !context.isRuleDisabled(Rule.self.ruleName, node: node) else { return }
+    guard context.isRuleEnabled(Rule.self.ruleName, node: node) else { return }
     let rule = Rule(context: context)
     _ = visitor(rule)(node)
   }

--- a/Sources/SwiftFormat/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Pipelines+Generated.swift
@@ -19,254 +19,254 @@ import SwiftSyntax
 extension LintPipeline {
 
   func visit(_ node: ArrayExprSyntax) -> SyntaxVisitorContinueKind {
-    _ = MultiLineTrailingCommas(context: context).visit(node)
+    visitIfEnabled(MultiLineTrailingCommas.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: AsExprSyntax) -> SyntaxVisitorContinueKind {
-    _ = NeverForceUnwrap(context: context).visit(node)
+    visitIfEnabled(NeverForceUnwrap.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: AssociatedtypeDeclSyntax) -> SyntaxVisitorContinueKind {
-    _ = BeginDocumentationCommentWithOneLineSummary(context: context).visit(node)
-    _ = NoLeadingUnderscores(context: context).visit(node)
+    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, in: context, for: node)
+    visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-    _ = AllPublicDeclarationsHaveDocumentation(context: context).visit(node)
-    _ = BeginDocumentationCommentWithOneLineSummary(context: context).visit(node)
-    _ = DontRepeatTypeInStaticProperties(context: context).visit(node)
-    _ = NoLeadingUnderscores(context: context).visit(node)
-    _ = UseEnumForNamespacing(context: context).visit(node)
-    _ = UseTripleSlashForDocumentationComments(context: context).visit(node)
+    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, in: context, for: node)
+    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, in: context, for: node)
+    visitIfEnabled(DontRepeatTypeInStaticProperties.visit, in: context, for: node)
+    visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
+    visitIfEnabled(UseEnumForNamespacing.visit, in: context, for: node)
+    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
-    _ = OneVariableDeclarationPerLine(context: context).visit(node)
+    visitIfEnabled(OneVariableDeclarationPerLine.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: CodeBlockSyntax) -> SyntaxVisitorContinueKind {
-    _ = AmbiguousTrailingClosureOverload(context: context).visit(node)
-    _ = DoNotUseSemicolons(context: context).visit(node)
-    _ = OneVariableDeclarationPerLine(context: context).visit(node)
+    visitIfEnabled(AmbiguousTrailingClosureOverload.visit, in: context, for: node)
+    visitIfEnabled(DoNotUseSemicolons.visit, in: context, for: node)
+    visitIfEnabled(OneVariableDeclarationPerLine.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: ConditionElementSyntax) -> SyntaxVisitorContinueKind {
-    _ = NoParensAroundConditions(context: context).visit(node)
+    visitIfEnabled(NoParensAroundConditions.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: DeinitializerDeclSyntax) -> SyntaxVisitorContinueKind {
-    _ = AllPublicDeclarationsHaveDocumentation(context: context).visit(node)
-    _ = BeginDocumentationCommentWithOneLineSummary(context: context).visit(node)
-    _ = UseTripleSlashForDocumentationComments(context: context).visit(node)
+    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, in: context, for: node)
+    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, in: context, for: node)
+    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: DictionaryExprSyntax) -> SyntaxVisitorContinueKind {
-    _ = MultiLineTrailingCommas(context: context).visit(node)
+    visitIfEnabled(MultiLineTrailingCommas.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: EnumCaseElementSyntax) -> SyntaxVisitorContinueKind {
-    _ = AlwaysUseLowerCamelCase(context: context).visit(node)
-    _ = NoLeadingUnderscores(context: context).visit(node)
+    visitIfEnabled(AlwaysUseLowerCamelCase.visit, in: context, for: node)
+    visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-    _ = BeginDocumentationCommentWithOneLineSummary(context: context).visit(node)
-    _ = DontRepeatTypeInStaticProperties(context: context).visit(node)
-    _ = FullyIndirectEnum(context: context).visit(node)
-    _ = NoLeadingUnderscores(context: context).visit(node)
-    _ = OneCasePerLine(context: context).visit(node)
-    _ = UseTripleSlashForDocumentationComments(context: context).visit(node)
+    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, in: context, for: node)
+    visitIfEnabled(DontRepeatTypeInStaticProperties.visit, in: context, for: node)
+    visitIfEnabled(FullyIndirectEnum.visit, in: context, for: node)
+    visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
+    visitIfEnabled(OneCasePerLine.visit, in: context, for: node)
+    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
-    _ = DontRepeatTypeInStaticProperties(context: context).visit(node)
-    _ = NoAccessLevelOnExtensionDeclaration(context: context).visit(node)
-    _ = UseTripleSlashForDocumentationComments(context: context).visit(node)
+    visitIfEnabled(DontRepeatTypeInStaticProperties.visit, in: context, for: node)
+    visitIfEnabled(NoAccessLevelOnExtensionDeclaration.visit, in: context, for: node)
+    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: ForcedValueExprSyntax) -> SyntaxVisitorContinueKind {
-    _ = NeverForceUnwrap(context: context).visit(node)
+    visitIfEnabled(NeverForceUnwrap.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
-    _ = NoEmptyTrailingClosureParentheses(context: context).visit(node)
-    _ = OnlyOneTrailingClosureArgument(context: context).visit(node)
+    visitIfEnabled(NoEmptyTrailingClosureParentheses.visit, in: context, for: node)
+    visitIfEnabled(OnlyOneTrailingClosureArgument.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
-    _ = AllPublicDeclarationsHaveDocumentation(context: context).visit(node)
-    _ = AlwaysUseLowerCamelCase(context: context).visit(node)
-    _ = BeginDocumentationCommentWithOneLineSummary(context: context).visit(node)
-    _ = NoLeadingUnderscores(context: context).visit(node)
-    _ = UseTripleSlashForDocumentationComments(context: context).visit(node)
-    _ = ValidateDocumentationComments(context: context).visit(node)
+    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, in: context, for: node)
+    visitIfEnabled(AlwaysUseLowerCamelCase.visit, in: context, for: node)
+    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, in: context, for: node)
+    visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
+    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, in: context, for: node)
+    visitIfEnabled(ValidateDocumentationComments.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: FunctionParameterSyntax) -> SyntaxVisitorContinueKind {
-    _ = NoLeadingUnderscores(context: context).visit(node)
+    visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: FunctionSignatureSyntax) -> SyntaxVisitorContinueKind {
-    _ = NoVoidReturnOnFunctionSignature(context: context).visit(node)
+    visitIfEnabled(NoVoidReturnOnFunctionSignature.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: FunctionTypeSyntax) -> SyntaxVisitorContinueKind {
-    _ = ReturnVoidInsteadOfEmptyTuple(context: context).visit(node)
+    visitIfEnabled(ReturnVoidInsteadOfEmptyTuple.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: GenericParameterSyntax) -> SyntaxVisitorContinueKind {
-    _ = NoLeadingUnderscores(context: context).visit(node)
+    visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: IdentifierPatternSyntax) -> SyntaxVisitorContinueKind {
-    _ = IdentifiersMustBeASCII(context: context).visit(node)
-    _ = NoLeadingUnderscores(context: context).visit(node)
+    visitIfEnabled(IdentifiersMustBeASCII.visit, in: context, for: node)
+    visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: IfStmtSyntax) -> SyntaxVisitorContinueKind {
-    _ = NoParensAroundConditions(context: context).visit(node)
+    visitIfEnabled(NoParensAroundConditions.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
-    _ = AllPublicDeclarationsHaveDocumentation(context: context).visit(node)
-    _ = BeginDocumentationCommentWithOneLineSummary(context: context).visit(node)
-    _ = UseTripleSlashForDocumentationComments(context: context).visit(node)
-    _ = ValidateDocumentationComments(context: context).visit(node)
+    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, in: context, for: node)
+    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, in: context, for: node)
+    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, in: context, for: node)
+    visitIfEnabled(ValidateDocumentationComments.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: IntegerLiteralExprSyntax) -> SyntaxVisitorContinueKind {
-    _ = GroupNumericLiterals(context: context).visit(node)
+    visitIfEnabled(GroupNumericLiterals.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: MemberDeclBlockSyntax) -> SyntaxVisitorContinueKind {
-    _ = AmbiguousTrailingClosureOverload(context: context).visit(node)
-    _ = BlankLineBetweenMembers(context: context).visit(node)
+    visitIfEnabled(AmbiguousTrailingClosureOverload.visit, in: context, for: node)
+    visitIfEnabled(BlankLineBetweenMembers.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: PatternBindingSyntax) -> SyntaxVisitorContinueKind {
-    _ = UseSingleLinePropertyGetter(context: context).visit(node)
+    visitIfEnabled(UseSingleLinePropertyGetter.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: PrecedenceGroupDeclSyntax) -> SyntaxVisitorContinueKind {
-    _ = NoLeadingUnderscores(context: context).visit(node)
+    visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
-    _ = AllPublicDeclarationsHaveDocumentation(context: context).visit(node)
-    _ = BeginDocumentationCommentWithOneLineSummary(context: context).visit(node)
-    _ = DontRepeatTypeInStaticProperties(context: context).visit(node)
-    _ = NoLeadingUnderscores(context: context).visit(node)
-    _ = UseTripleSlashForDocumentationComments(context: context).visit(node)
+    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, in: context, for: node)
+    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, in: context, for: node)
+    visitIfEnabled(DontRepeatTypeInStaticProperties.visit, in: context, for: node)
+    visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
+    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: RepeatWhileStmtSyntax) -> SyntaxVisitorContinueKind {
-    _ = NoParensAroundConditions(context: context).visit(node)
+    visitIfEnabled(NoParensAroundConditions.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: SimpleTypeIdentifierSyntax) -> SyntaxVisitorContinueKind {
-    _ = UseShorthandTypeNames(context: context).visit(node)
+    visitIfEnabled(UseShorthandTypeNames.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
-    _ = AmbiguousTrailingClosureOverload(context: context).visit(node)
-    _ = DoNotUseSemicolons(context: context).visit(node)
-    _ = NeverForceUnwrap(context: context).visit(node)
-    _ = NeverUseForceTry(context: context).visit(node)
-    _ = NeverUseImplicitlyUnwrappedOptionals(context: context).visit(node)
-    _ = OneVariableDeclarationPerLine(context: context).visit(node)
-    _ = OrderedImports(context: context).visit(node)
+    visitIfEnabled(AmbiguousTrailingClosureOverload.visit, in: context, for: node)
+    visitIfEnabled(DoNotUseSemicolons.visit, in: context, for: node)
+    visitIfEnabled(NeverForceUnwrap.visit, in: context, for: node)
+    visitIfEnabled(NeverUseForceTry.visit, in: context, for: node)
+    visitIfEnabled(NeverUseImplicitlyUnwrappedOptionals.visit, in: context, for: node)
+    visitIfEnabled(OneVariableDeclarationPerLine.visit, in: context, for: node)
+    visitIfEnabled(OrderedImports.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: SpecializeExprSyntax) -> SyntaxVisitorContinueKind {
-    _ = UseShorthandTypeNames(context: context).visit(node)
+    visitIfEnabled(UseShorthandTypeNames.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
-    _ = AllPublicDeclarationsHaveDocumentation(context: context).visit(node)
-    _ = BeginDocumentationCommentWithOneLineSummary(context: context).visit(node)
-    _ = DontRepeatTypeInStaticProperties(context: context).visit(node)
-    _ = NoLeadingUnderscores(context: context).visit(node)
-    _ = UseEnumForNamespacing(context: context).visit(node)
-    _ = UseSynthesizedInitializer(context: context).visit(node)
-    _ = UseTripleSlashForDocumentationComments(context: context).visit(node)
+    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, in: context, for: node)
+    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, in: context, for: node)
+    visitIfEnabled(DontRepeatTypeInStaticProperties.visit, in: context, for: node)
+    visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
+    visitIfEnabled(UseEnumForNamespacing.visit, in: context, for: node)
+    visitIfEnabled(UseSynthesizedInitializer.visit, in: context, for: node)
+    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: SubscriptDeclSyntax) -> SyntaxVisitorContinueKind {
-    _ = AllPublicDeclarationsHaveDocumentation(context: context).visit(node)
-    _ = BeginDocumentationCommentWithOneLineSummary(context: context).visit(node)
-    _ = UseTripleSlashForDocumentationComments(context: context).visit(node)
+    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, in: context, for: node)
+    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, in: context, for: node)
+    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: SwitchCaseLabelSyntax) -> SyntaxVisitorContinueKind {
-    _ = NoLabelsInCasePatterns(context: context).visit(node)
-    _ = UseLetInEveryBoundCaseVariable(context: context).visit(node)
+    visitIfEnabled(NoLabelsInCasePatterns.visit, in: context, for: node)
+    visitIfEnabled(UseLetInEveryBoundCaseVariable.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: SwitchStmtSyntax) -> SyntaxVisitorContinueKind {
-    _ = CaseIndentLevelEqualsSwitch(context: context).visit(node)
-    _ = NoCasesWithOnlyFallthrough(context: context).visit(node)
-    _ = NoParensAroundConditions(context: context).visit(node)
+    visitIfEnabled(CaseIndentLevelEqualsSwitch.visit, in: context, for: node)
+    visitIfEnabled(NoCasesWithOnlyFallthrough.visit, in: context, for: node)
+    visitIfEnabled(NoParensAroundConditions.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: TokenSyntax) -> SyntaxVisitorContinueKind {
-    _ = NoBlockComments(context: context).visit(node)
+    visitIfEnabled(NoBlockComments.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: TryExprSyntax) -> SyntaxVisitorContinueKind {
-    _ = NeverUseForceTry(context: context).visit(node)
+    visitIfEnabled(NeverUseForceTry.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
-    _ = AllPublicDeclarationsHaveDocumentation(context: context).visit(node)
-    _ = BeginDocumentationCommentWithOneLineSummary(context: context).visit(node)
-    _ = NoLeadingUnderscores(context: context).visit(node)
-    _ = UseTripleSlashForDocumentationComments(context: context).visit(node)
+    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, in: context, for: node)
+    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, in: context, for: node)
+    visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
+    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, in: context, for: node)
     return .visitChildren
   }
 
   func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
-    _ = AllPublicDeclarationsHaveDocumentation(context: context).visit(node)
-    _ = AlwaysUseLowerCamelCase(context: context).visit(node)
-    _ = BeginDocumentationCommentWithOneLineSummary(context: context).visit(node)
-    _ = NeverUseImplicitlyUnwrappedOptionals(context: context).visit(node)
-    _ = UseTripleSlashForDocumentationComments(context: context).visit(node)
+    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, in: context, for: node)
+    visitIfEnabled(AlwaysUseLowerCamelCase.visit, in: context, for: node)
+    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, in: context, for: node)
+    visitIfEnabled(NeverUseImplicitlyUnwrappedOptionals.visit, in: context, for: node)
+    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, in: context, for: node)
     return .visitChildren
   }
 }

--- a/Sources/SwiftFormatCore/Context.swift
+++ b/Sources/SwiftFormatCore/Context.swift
@@ -73,9 +73,16 @@ public class Context {
 
   /// Given a rule's name and the node it is examining, determine if the rule is disabled at this
   /// location or not.
-  public func isRuleDisabled(_ ruleName: String, node: Syntax) -> Bool {
+  public func isRuleEnabled(_ ruleName: String, node: Syntax) -> Bool {
     let loc = node.startLocation(converter: self.sourceLocationConverter)
     guard let line = loc.line else { return false }
-    return self.ruleMask.isDisabled(ruleName, line: line)
+    switch ruleMask.ruleState(ruleName, atLine: line) {
+    case .default:
+      return configuration.rules[ruleName] ?? false
+    case .disabled:
+      return false
+    case .enabled:
+      return true
+    }
   }
 }

--- a/Sources/SwiftFormatCore/Diagnostic+Rule.swift
+++ b/Sources/SwiftFormatCore/Diagnostic+Rule.swift
@@ -17,6 +17,6 @@ extension Diagnostic.Message {
   /// - parameter rule: The rule whose name will be prepended to the diagnostic.
   /// - returns: A new `Diagnostic.Message` with the name of the provided rule prepended.
   public func withRule(_ rule: Rule) -> Diagnostic.Message {
-    return .init(severity, "[\(rule.ruleName)]: \(text)")
+    return .init(severity, "[\(type(of: rule).ruleName)]: \(text)")
   }
 }

--- a/Sources/SwiftFormatCore/Rule.swift
+++ b/Sources/SwiftFormatCore/Rule.swift
@@ -16,7 +16,7 @@ public protocol Rule {
   var context: Context { get }
 
   /// The human-readable name of the rule. This defaults to the class name.
-  var ruleName: String { get }
+  static var ruleName: String { get }
 
   /// Creates a new Rule in a given context.
   init(context: Context)
@@ -26,12 +26,10 @@ private var nameCache = [ObjectIdentifier: String]()
 
 extension Rule {
   /// By default, the `ruleName` is just the name of the implementing rule class.
-  public var ruleName: String {
-    let myType = type(of: self)
-    // TODO(abl): Test and potentially replace with static initialization.
+  public static var ruleName: String {
     return nameCache[
-      ObjectIdentifier(myType),
-      default: String("\(myType)".split(separator: ".").last!)
+      ObjectIdentifier(self),
+      default: String("\(self)".split(separator: ".").last!)
     ]
   }
 }

--- a/Sources/SwiftFormatCore/RuleState.swift
+++ b/Sources/SwiftFormatCore/RuleState.swift
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// The enablement of a lint/format rule based on the presence or absence of comment directives in
+/// the source file.
+public enum RuleState {
+
+  /// There is no explicit information in the source file about whether the rule should be enabled
+  /// or disabled at the requested location, so the configuration default should be used.
+  case `default`
+
+  /// The rule is explicitly enabled at the requested location.
+  case enabled
+
+  /// The rule is explicitly disabled at the requested location.
+  case disabled
+}

--- a/Sources/SwiftFormatCore/SyntaxLintRule.swift
+++ b/Sources/SwiftFormatCore/SyntaxLintRule.swift
@@ -14,7 +14,16 @@ import Foundation
 import SwiftSyntax
 
 /// A rule that lints a given file.
-public protocol SyntaxLintRule: SyntaxVisitor, Rule {}
+open class SyntaxLintRule: SyntaxVisitorBase, Rule {
+
+  /// The context in which the rule is executed.
+  public let context: Context
+
+  /// Creates a new rule in a given context.
+  public required init(context: Context) {
+    self.context = context
+  }
+}
 
 extension Rule {
   /// Emits the provided diagnostic to the diagnostic engine.

--- a/Sources/SwiftFormatRules/AllPublicDeclarationsHaveDocumentation.swift
+++ b/Sources/SwiftFormatRules/AllPublicDeclarationsHaveDocumentation.swift
@@ -19,55 +19,50 @@ import SwiftSyntax
 /// Lint: If a public declaration is missing a documentation comment, a lint error is raised.
 ///
 /// - SeeAlso: https://google.github.io/swift#where-to-document
-public struct AllPublicDeclarationsHaveDocumentation: SyntaxLintRule {
-  public let context: Context
+public final class AllPublicDeclarationsHaveDocumentation: SyntaxLintRule {
 
-  public init(context: Context) {
-    self.context = context
-  }
-
-  public func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseMissingDocComment(node, name: node.fullDeclName, modifiers: node.modifiers)
     return .skipChildren
   }
 
-  public func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseMissingDocComment(node, name: "init", modifiers: node.modifiers)
     return .skipChildren
   }
 
-  public func visit(_ node: DeinitializerDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: DeinitializerDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseMissingDocComment(node, name: "deinit", modifiers: node.modifiers)
     return .skipChildren
   }
 
-  public func visit(_ node: SubscriptDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: SubscriptDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseMissingDocComment(node, name: "subscript", modifiers: node.modifiers)
     return .skipChildren
   }
 
-  public func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseMissingDocComment(node, name: node.identifier.text, modifiers: node.modifiers)
     return .skipChildren
   }
 
-  public func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
     guard let mainBinding = node.bindings.firstAndOnly else { return .skipChildren }
     diagnoseMissingDocComment(node, name: "\(mainBinding.pattern)", modifiers: node.modifiers)
     return .skipChildren
   }
 
-  public func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseMissingDocComment(node, name: node.identifier.text, modifiers: node.modifiers)
     return .skipChildren
   }
 
-  public func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseMissingDocComment(node, name: node.identifier.text, modifiers: node.modifiers)
     return .skipChildren
   }
 
-  public func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseMissingDocComment(node, name: node.identifier.text, modifiers: node.modifiers)
     return .skipChildren
   }

--- a/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
+++ b/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
@@ -21,14 +21,9 @@ import SwiftSyntax
 ///       raised.
 ///
 /// - SeeAlso: https://google.github.io/swift#identifiers
-public struct AlwaysUseLowerCamelCase: SyntaxLintRule {
-  public let context: Context
+public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
 
-  public init(context: Context) {
-    self.context = context
-  }
-
-  public func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
     for binding in node.bindings {
       guard let pat = binding.pattern as? IdentifierPatternSyntax else {
         continue
@@ -38,12 +33,12 @@ public struct AlwaysUseLowerCamelCase: SyntaxLintRule {
     return .skipChildren
   }
 
-  public func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseLowerCamelCaseViolations(node.identifier)
     return .skipChildren
   }
 
-  public func visit(_ node: EnumCaseElementSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: EnumCaseElementSyntax) -> SyntaxVisitorContinueKind {
     diagnoseLowerCamelCaseViolations(node.identifier)
     return .skipChildren
   }

--- a/Sources/SwiftFormatRules/AmbiguousTrailingClosureOverload.swift
+++ b/Sources/SwiftFormatRules/AmbiguousTrailingClosureOverload.swift
@@ -20,12 +20,7 @@ import SwiftSyntax
 ///       error is raised.
 ///
 /// - SeeAlso: https://google.github.io/swift#trailing-closures
-public struct AmbiguousTrailingClosureOverload: SyntaxLintRule {
-  public let context: Context
-
-  public init(context: Context) {
-    self.context = context
-  }
+public final class AmbiguousTrailingClosureOverload: SyntaxLintRule {
 
   func diagnoseBadOverloads(_ overloads: [String: [FunctionDeclSyntax]]) {
     for (_, decls) in overloads where decls.count > 1 {
@@ -59,19 +54,19 @@ public struct AmbiguousTrailingClosureOverload: SyntaxLintRule {
     diagnoseBadOverloads(staticOverloads)
   }
 
-  public func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
     let functions = node.statements.compactMap { $0.item as? FunctionDeclSyntax }
     discoverAndDiagnoseOverloads(functions)
     return .visitChildren
   }
 
-  public func visit(_ node: CodeBlockSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: CodeBlockSyntax) -> SyntaxVisitorContinueKind {
     let functions = node.statements.compactMap { $0.item as? FunctionDeclSyntax }
     discoverAndDiagnoseOverloads(functions)
     return .visitChildren
   }
 
-  public func visit(_ decls: MemberDeclBlockSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ decls: MemberDeclBlockSyntax) -> SyntaxVisitorContinueKind {
     let functions = decls.members.compactMap { $0.decl as? FunctionDeclSyntax }
     discoverAndDiagnoseOverloads(functions)
     return .visitChildren

--- a/Sources/SwiftFormatRules/BeginDocumentationCommentWithOneLineSummary.swift
+++ b/Sources/SwiftFormatRules/BeginDocumentationCommentWithOneLineSummary.swift
@@ -19,7 +19,7 @@ import SwiftSyntax
 /// Lint: If a comment does not begin with a single-line summary, a lint error is raised.
 ///
 /// - SeeAlso: https://google.github.io/swift#single-sentence-summary
-public struct BeginDocumentationCommentWithOneLineSummary: SyntaxLintRule {
+public final class BeginDocumentationCommentWithOneLineSummary: SyntaxLintRule {
 
   /// Unit tests can testably import this module and set this to true in order to force the rule
   /// to use the fallback (simple period separator) mode instead of the `NSLinguisticTag` mode,
@@ -28,63 +28,57 @@ public struct BeginDocumentationCommentWithOneLineSummary: SyntaxLintRule {
   /// This allows test runs on those platforms to test both implementations.
   static var forcesFallbackModeForTesting = false
 
-  public let context: Context
-
-  public init(context: Context) {
-    self.context = context
-  }
-
-  public func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseDocComments(in: node)
     return .skipChildren
   }
 
-  public func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseDocComments(in: node)
     return .skipChildren
   }
 
-  public func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseDocComments(in: node)
     return .skipChildren
   }
 
-  public func visit(_ node: DeinitializerDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: DeinitializerDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseDocComments(in: node)
     return .skipChildren
   }
 
-  public func visit(_ node: SubscriptDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: SubscriptDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseDocComments(in: node)
     return .skipChildren
   }
 
-  public func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseDocComments(in: node)
     return .skipChildren
   }
 
-  public func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseDocComments(in: node)
     return .skipChildren
   }
 
-  public func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseDocComments(in: node)
     return .skipChildren
   }
 
-  public func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseDocComments(in: node)
     return .skipChildren
   }
 
-  public func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseDocComments(in: node)
     return .skipChildren
   }
 
-  public func visit(_ node: AssociatedtypeDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: AssociatedtypeDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseDocComments(in: node)
     return .skipChildren
   }

--- a/Sources/SwiftFormatRules/CaseIndentLevelEqualsSwitch.swift
+++ b/Sources/SwiftFormatRules/CaseIndentLevelEqualsSwitch.swift
@@ -20,15 +20,9 @@ import SwiftSyntax
 ///       lint error is raised.
 ///
 /// - SeeAlso: https://google.github.io/swift#switch-statements
-public struct CaseIndentLevelEqualsSwitch: SyntaxLintRule {
+public final class CaseIndentLevelEqualsSwitch: SyntaxLintRule {
 
-  public let context: Context
-
-  public init(context: Context) {
-    self.context = context
-  }
-
-  public func visit(_ node: SwitchStmtSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: SwitchStmtSyntax) -> SyntaxVisitorContinueKind {
     guard let switchIndentation = node.leadingTrivia?.numberOfSpaces else {
       return .visitChildren
     }

--- a/Sources/SwiftFormatRules/DontRepeatTypeInStaticProperties.swift
+++ b/Sources/SwiftFormatRules/DontRepeatTypeInStaticProperties.swift
@@ -23,35 +23,29 @@ import SwiftSyntax
 /// Lint: Static properties of a type that return that type will yield a lint error.
 ///
 /// - SeeAlso: https://google.github.io/swift#static-and-class-properties
-public struct DontRepeatTypeInStaticProperties: SyntaxLintRule {
+public final class DontRepeatTypeInStaticProperties: SyntaxLintRule {
 
-  public let context: Context
-
-  public init(context: Context) {
-    self.context = context
-  }
-
-  public func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseStaticMembers(node.members.members, endingWith: node.identifier.text)
     return .skipChildren
   }
 
-  public func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseStaticMembers(node.members.members, endingWith: node.identifier.text)
     return .skipChildren
   }
 
-  public func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseStaticMembers(node.members.members, endingWith: node.identifier.text)
     return .skipChildren
   }
 
-  public func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseStaticMembers(node.members.members, endingWith: node.identifier.text)
     return .skipChildren
   }
 
-  public func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
     let members = node.members.members
 
     switch node.extendedType {

--- a/Sources/SwiftFormatRules/IdentifiersMustBeASCII.swift
+++ b/Sources/SwiftFormatRules/IdentifiersMustBeASCII.swift
@@ -19,14 +19,9 @@ import SwiftSyntax
 /// Lint: If an identifier contains non-ASCII characters, a lint error is raised.
 ///
 /// - SeeAlso: https://google.github.io/swift#identifiers
-public struct IdentifiersMustBeASCII: SyntaxLintRule {
-  public let context: Context
+public final class IdentifiersMustBeASCII: SyntaxLintRule {
 
-  public init(context: Context) {
-    self.context = context
-  }
-
-  public func visit(_ node: IdentifierPatternSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: IdentifierPatternSyntax) -> SyntaxVisitorContinueKind {
     let identifier = node.identifier.text
     let invalidCharacters = identifier.unicodeScalars.filter { !$0.isASCII }.map { $0.description }
 

--- a/Sources/SwiftFormatRules/NeverForceUnwrap.swift
+++ b/Sources/SwiftFormatRules/NeverForceUnwrap.swift
@@ -19,27 +19,21 @@ import SwiftSyntax
 ///       TODO(abl): consider having documentation (e.g. a comment) cancel the warning?
 ///
 /// - SeeAlso: https://google.github.io/swift#force-unwrapping-and-force-casts
-public struct NeverForceUnwrap: SyntaxLintRule {
+public final class NeverForceUnwrap: SyntaxLintRule {
 
-  public let context: Context
-
-  public init(context: Context) {
-    self.context = context
-  }
-
-  public func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
     // Tracks whether "XCTest" is imported in the source file before processing the individual
     setImportsXCTest(context: context, sourceFile: node)
     return .visitChildren
   }
 
-  public func visit(_ node: ForcedValueExprSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: ForcedValueExprSyntax) -> SyntaxVisitorContinueKind {
     guard context.importsXCTest == .doesNotImportXCTest else { return .skipChildren }
     diagnose(.doNotForceUnwrap(name: node.expression.description), on: node)
     return .skipChildren
   }
 
-  public func visit(_ node: AsExprSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: AsExprSyntax) -> SyntaxVisitorContinueKind {
     // Only fire if we're not in a test file and if there is an exclamation mark following the `as`
     // keyword.
     guard context.importsXCTest == .doesNotImportXCTest else { return .skipChildren }

--- a/Sources/SwiftFormatRules/NeverUseForceTry.swift
+++ b/Sources/SwiftFormatRules/NeverUseForceTry.swift
@@ -32,9 +32,6 @@ public final class NeverUseForceTry: SyntaxLintRule {
   }
 
   public override func visit(_ node: TryExprSyntax) -> SyntaxVisitorContinueKind {
-    // TODO: Generalize the `isRuleDisabled` check so it doesn't need to be performed manually for
-    // each rule.
-    guard !context.isRuleDisabled(self.ruleName, node: node) else { return .visitChildren }
     guard context.importsXCTest == .doesNotImportXCTest else { return .skipChildren }
     guard let mark = node.questionOrExclamationMark else { return .visitChildren }
     if mark.tokenKind == .exclamationMark {

--- a/Sources/SwiftFormatRules/NeverUseForceTry.swift
+++ b/Sources/SwiftFormatRules/NeverUseForceTry.swift
@@ -24,20 +24,14 @@ import SwiftSyntax
 /// TODO: Create exception for NSRegularExpression
 ///
 /// - SeeAlso: https://google.github.io/swift#error-types
-public struct NeverUseForceTry: SyntaxLintRule {
+public final class NeverUseForceTry: SyntaxLintRule {
 
-  public let context: Context
-
-  public init(context: Context) {
-    self.context = context
-  }
-
-  public func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
     setImportsXCTest(context: context, sourceFile: node)
     return .visitChildren
   }
 
-  public func visit(_ node: TryExprSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: TryExprSyntax) -> SyntaxVisitorContinueKind {
     // TODO: Generalize the `isRuleDisabled` check so it doesn't need to be performed manually for
     // each rule.
     guard !context.isRuleDisabled(self.ruleName, node: node) else { return .visitChildren }

--- a/Sources/SwiftFormatRules/NeverUseImplicitlyUnwrappedOptionals.swift
+++ b/Sources/SwiftFormatRules/NeverUseImplicitlyUnwrappedOptionals.swift
@@ -26,21 +26,15 @@ import SwiftSyntax
 /// Lint: Declaring a property with an implicitly unwrapped type yields a lint error.
 ///
 /// - SeeAlso: https://google.github.io/swift#implicitly-unwrapped-optionals
-public struct NeverUseImplicitlyUnwrappedOptionals: SyntaxLintRule {
-
-  public let context: Context
-
-  public init(context: Context) {
-    self.context = context
-  }
+public final class NeverUseImplicitlyUnwrappedOptionals: SyntaxLintRule {
 
   // Checks if "XCTest" is an import statement
-  public func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
     setImportsXCTest(context: context, sourceFile: node)
     return .visitChildren
   }
 
-  public func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
     guard context.importsXCTest == .doesNotImportXCTest else { return .skipChildren }
     // Ignores IBOutlet variables
     if let attributes = node.attributes {

--- a/Sources/SwiftFormatRules/NoLeadingUnderscores.swift
+++ b/Sources/SwiftFormatRules/NoLeadingUnderscores.swift
@@ -26,40 +26,34 @@ import SwiftSyntax
 /// Lint: Declaring an identifier with a leading underscore yields a lint error.
 ///
 /// - SeeAlso: https://google.github.io/swift#naming-conventions-are-not-access-control
-public struct NoLeadingUnderscores: SyntaxLintRule {
+public final class NoLeadingUnderscores: SyntaxLintRule {
 
-  public let context: Context
-
-  public init(context: Context) {
-    self.context = context
-  }
-
-  public func visit(_ node: AssociatedtypeDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: AssociatedtypeDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseIfNameStartsWithUnderscore(node.identifier)
     return .visitChildren
   }
 
-  public func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseIfNameStartsWithUnderscore(node.identifier)
     return .visitChildren
   }
 
-  public func visit(_ node: EnumCaseElementSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: EnumCaseElementSyntax) -> SyntaxVisitorContinueKind {
     diagnoseIfNameStartsWithUnderscore(node.identifier)
     return .visitChildren
   }
 
-  public func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseIfNameStartsWithUnderscore(node.identifier)
     return .visitChildren
   }
 
-  public func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseIfNameStartsWithUnderscore(node.identifier)
     return .visitChildren
   }
 
-  public func visit(_ node: FunctionParameterSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: FunctionParameterSyntax) -> SyntaxVisitorContinueKind {
     // If both names are provided, we want to check `secondName`, which will be the parameter name
     // (in that case, `firstName` is the label). If only one name is present, then it is recorded in
     // `firstName`, and it is both the label and the parameter name.
@@ -69,32 +63,32 @@ public struct NoLeadingUnderscores: SyntaxLintRule {
     return .visitChildren
   }
 
-  public func visit(_ node: GenericParameterSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: GenericParameterSyntax) -> SyntaxVisitorContinueKind {
     diagnoseIfNameStartsWithUnderscore(node.name)
     return .visitChildren
   }
 
-  public func visit(_ node: IdentifierPatternSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: IdentifierPatternSyntax) -> SyntaxVisitorContinueKind {
     diagnoseIfNameStartsWithUnderscore(node.identifier)
     return .visitChildren
   }
 
-  public func visit(_ node: PrecedenceGroupDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: PrecedenceGroupDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseIfNameStartsWithUnderscore(node.identifier)
     return .visitChildren
   }
 
-  public func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseIfNameStartsWithUnderscore(node.identifier)
     return .visitChildren
   }
 
-  public func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseIfNameStartsWithUnderscore(node.identifier)
     return .visitChildren
   }
 
-  public func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseIfNameStartsWithUnderscore(node.identifier)
     return .visitChildren
   }

--- a/Sources/SwiftFormatRules/OnlyOneTrailingClosureArgument.swift
+++ b/Sources/SwiftFormatRules/OnlyOneTrailingClosureArgument.swift
@@ -20,15 +20,9 @@ import SwiftSyntax
 ///       a lint error is raised.
 ///
 /// - SeeAlso: https://google.github.io/swift#trailing-closures
-public struct OnlyOneTrailingClosureArgument: SyntaxLintRule {
+public final class OnlyOneTrailingClosureArgument: SyntaxLintRule {
 
-  public let context: Context
-
-  public init(context: Context) {
-    self.context = context
-  }
-
-  public func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
     guard (node.argumentList.contains { $0.expression is ClosureExprSyntax }) else {
       return .skipChildren
     }

--- a/Sources/SwiftFormatRules/OrderedImports.swift
+++ b/Sources/SwiftFormatRules/OrderedImports.swift
@@ -64,7 +64,7 @@ public final class OrderedImports: SyntaxFormatRule {
       var lineType = line.type
 
       // Set the line type to codeBlock if the rule is disabled.
-      if let codeblock = line.codeBlock, context.isRuleDisabled(Self.ruleName, node: codeblock) {
+      if let codeblock = line.codeBlock, !context.isRuleEnabled(Self.ruleName, node: codeblock) {
         switch lineType {
         case .comment: ()
         default:
@@ -130,7 +130,7 @@ public final class OrderedImports: SyntaxFormatRule {
       var lineType = line.type
 
       // Set the line type to codeBlock if the rule is disabled.
-      if let codeblock = line.codeBlock, context.isRuleDisabled(Self.ruleName, node: codeblock) {
+      if let codeblock = line.codeBlock, !context.isRuleEnabled(Self.ruleName, node: codeblock) {
         switch lineType {
         case .comment: ()
         default:

--- a/Sources/SwiftFormatRules/OrderedImports.swift
+++ b/Sources/SwiftFormatRules/OrderedImports.swift
@@ -64,7 +64,7 @@ public final class OrderedImports: SyntaxFormatRule {
       var lineType = line.type
 
       // Set the line type to codeBlock if the rule is disabled.
-      if let codeblock = line.codeBlock, context.isRuleDisabled(self.ruleName, node: codeblock) {
+      if let codeblock = line.codeBlock, context.isRuleDisabled(Self.ruleName, node: codeblock) {
         switch lineType {
         case .comment: ()
         default:
@@ -130,7 +130,7 @@ public final class OrderedImports: SyntaxFormatRule {
       var lineType = line.type
 
       // Set the line type to codeBlock if the rule is disabled.
-      if let codeblock = line.codeBlock, context.isRuleDisabled(self.ruleName, node: codeblock) {
+      if let codeblock = line.codeBlock, context.isRuleDisabled(Self.ruleName, node: codeblock) {
         switch lineType {
         case .comment: ()
         default:

--- a/Sources/SwiftFormatRules/UseLetInEveryBoundCaseVariable.swift
+++ b/Sources/SwiftFormatRules/UseLetInEveryBoundCaseVariable.swift
@@ -24,15 +24,9 @@ import SwiftSyntax
 ///         TODO(abl): This is not a neutral format operation.
 ///
 /// - SeeAlso: https://google.github.io/swift#pattern-matching
-public struct UseLetInEveryBoundCaseVariable: SyntaxLintRule {
+public final class UseLetInEveryBoundCaseVariable: SyntaxLintRule {
 
-  public let context: Context
-
-  public init(context: Context) {
-    self.context = context
-  }
-
-  public func visit(_ node: SwitchCaseLabelSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: SwitchCaseLabelSyntax) -> SyntaxVisitorContinueKind {
     for item in node.caseItems {
       guard item.pattern is ValueBindingPatternSyntax else { continue }
       diagnose(.useLetInBoundCaseVariables, on: node)

--- a/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
+++ b/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
@@ -23,14 +23,9 @@ import SwiftSyntax
 ///       initializer will yield a lint error.
 ///
 /// - SeeAlso: https://google.github.io/swift#initializers-2
-public struct UseSynthesizedInitializer: SyntaxLintRule {
-  public let context: Context
+public final class UseSynthesizedInitializer: SyntaxLintRule {
 
-  public init(context: Context) {
-    self.context = context
-  }
-
-  public func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
     var storedProperties: [VariableDeclSyntax] = []
     var initializers: [InitializerDeclSyntax] = []
 

--- a/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
@@ -22,19 +22,14 @@ import SwiftSyntax
 ///       invalid (uses `Parameters` when there is only one parameter) will yield a lint error.
 ///
 /// - SeeAlso: https://google.github.io/swift#parameter-returns-and-throws-tags
-public struct ValidateDocumentationComments: SyntaxLintRule {
-  public let context: Context
+public final class ValidateDocumentationComments: SyntaxLintRule {
 
-  public init(context: Context) {
-    self.context = context
-  }
-
-  public func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
     return checkFunctionLikeDocumentation(
       node, name: "init", parameters: node.parameters.parameterList)
   }
 
-  public func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
     return checkFunctionLikeDocumentation(
       node, name: node.identifier.text, parameters: node.signature.input.parameterList,
       returnClause: node.signature.output)

--- a/Sources/generate-pipeline/PipelineGenerator.swift
+++ b/Sources/generate-pipeline/PipelineGenerator.swift
@@ -60,7 +60,7 @@ final class PipelineGenerator: FileGenerator {
       for ruleName in lintRules.sorted() {
         handle.write(
           """
-              _ = \(ruleName)(context: context).visit(node)
+              visitIfEnabled(\(ruleName).visit, in: context, for: node)
 
           """)
       }

--- a/Tests/SwiftFormatCoreTests/RuleMaskTests.swift
+++ b/Tests/SwiftFormatCoreTests/RuleMaskTests.swift
@@ -24,9 +24,9 @@ public class RuleMaskTests: XCTestCase {
 
     let mask = createMask(sourceText: text)
 
-    XCTAssertFalse(mask.isDisabled("rule1", line: 1))
-    XCTAssertTrue(mask.isDisabled("rule1", line: 3))
-    XCTAssertFalse(mask.isDisabled("rule1", line: 5))
+    XCTAssertEqual(mask.ruleState("rule1", atLine: 1), .default)
+    XCTAssertEqual(mask.ruleState("rule1", atLine: 3), .disabled)
+    XCTAssertEqual(mask.ruleState("rule1", atLine: 5), .enabled)
   }
 
   public func testTwoRules() {
@@ -45,20 +45,20 @@ public class RuleMaskTests: XCTestCase {
 
     let mask = createMask(sourceText: text)
 
-    XCTAssertFalse(mask.isDisabled("rule1", line: 1))
-    XCTAssertTrue(mask.isDisabled("rule1", line: 3))
-    XCTAssertTrue(mask.isDisabled("rule1", line: 5))
-    XCTAssertFalse(mask.isDisabled("rule1", line: 7))
-    XCTAssertFalse(mask.isDisabled("rule1", line: 9))
+    XCTAssertEqual(mask.ruleState("rule1", atLine: 1), .default)
+    XCTAssertEqual(mask.ruleState("rule1", atLine: 3), .disabled)
+    XCTAssertEqual(mask.ruleState("rule1", atLine: 5), .disabled)
+    XCTAssertEqual(mask.ruleState("rule1", atLine: 7), .enabled)
+    XCTAssertEqual(mask.ruleState("rule1", atLine: 9), .enabled)
 
-    XCTAssertFalse(mask.isDisabled("rule2", line: 1))
-    XCTAssertFalse(mask.isDisabled("rule2", line: 3))
-    XCTAssertTrue(mask.isDisabled("rule2", line: 5))
-    XCTAssertTrue(mask.isDisabled("rule2", line: 7))
-    XCTAssertFalse(mask.isDisabled("rule2", line: 9))
+    XCTAssertEqual(mask.ruleState("rule2", atLine: 1), .default)
+    XCTAssertEqual(mask.ruleState("rule2", atLine: 3), .default)
+    XCTAssertEqual(mask.ruleState("rule2", atLine: 5), .disabled)
+    XCTAssertEqual(mask.ruleState("rule2", atLine: 7), .disabled)
+    XCTAssertEqual(mask.ruleState("rule2", atLine: 9), .enabled)
   }
 
-  public func testWrongOrderFlags() {
+  public func testEnableBeforeDisable() {
     let text =
       """
       let a = 123
@@ -70,9 +70,9 @@ public class RuleMaskTests: XCTestCase {
 
     let mask = createMask(sourceText: text)
 
-    XCTAssertFalse(mask.isDisabled("rule1", line: 1))
-    XCTAssertFalse(mask.isDisabled("rule1", line: 3))
-    XCTAssertFalse(mask.isDisabled("rule1", line: 5))
+    XCTAssertEqual(mask.ruleState("rule1", atLine: 1), .default)
+    XCTAssertEqual(mask.ruleState("rule1", atLine: 3), .enabled)
+    XCTAssertEqual(mask.ruleState("rule1", atLine: 5), .disabled)
   }
 
   public func testDuplicateNested() {
@@ -91,11 +91,11 @@ public class RuleMaskTests: XCTestCase {
 
     let mask = createMask(sourceText: text)
 
-    XCTAssertFalse(mask.isDisabled("rule1", line: 1))
-    XCTAssertTrue(mask.isDisabled("rule1", line: 3))
-    XCTAssertTrue(mask.isDisabled("rule1", line: 5))
-    XCTAssertFalse(mask.isDisabled("rule1", line: 7))
-    XCTAssertFalse(mask.isDisabled("rule1", line: 9))
+    XCTAssertEqual(mask.ruleState("rule1", atLine: 1), .default)
+    XCTAssertEqual(mask.ruleState("rule1", atLine: 3), .disabled)
+    XCTAssertEqual(mask.ruleState("rule1", atLine: 5), .disabled)
+    XCTAssertEqual(mask.ruleState("rule1", atLine: 7), .enabled)
+    XCTAssertEqual(mask.ruleState("rule1", atLine: 9), .enabled)
   }
 
   public func testSingleFlags() {
@@ -110,8 +110,8 @@ public class RuleMaskTests: XCTestCase {
 
     let mask1 = createMask(sourceText: text1)
 
-    XCTAssertFalse(mask1.isDisabled("rule1", line: 1))
-    XCTAssertFalse(mask1.isDisabled("rule1", line: 6))
+    XCTAssertEqual(mask1.ruleState("rule1", atLine: 1), .default)
+    XCTAssertEqual(mask1.ruleState("rule1", atLine: 5), .disabled)
 
     let text2 =
       """
@@ -124,8 +124,8 @@ public class RuleMaskTests: XCTestCase {
 
     let mask2 = createMask(sourceText: text2)
 
-    XCTAssertFalse(mask2.isDisabled("rule1", line: 1))
-    XCTAssertFalse(mask2.isDisabled("rule1", line: 6))
+    XCTAssertEqual(mask2.ruleState("rule1", atLine: 1), .default)
+    XCTAssertEqual(mask2.ruleState("rule1", atLine: 5), .enabled)
   }
 
   public func testSpuriousFlags() {
@@ -140,9 +140,9 @@ public class RuleMaskTests: XCTestCase {
 
     let mask1 = createMask(sourceText: text1)
 
-    XCTAssertFalse(mask1.isDisabled("rule1", line: 1))
-    XCTAssertFalse(mask1.isDisabled("rule1", line: 3))
-    XCTAssertFalse(mask1.isDisabled("rule1", line: 5))
+    XCTAssertEqual(mask1.ruleState("rule1", atLine: 1), .default)
+    XCTAssertEqual(mask1.ruleState("rule1", atLine: 3), .default)
+    XCTAssertEqual(mask1.ruleState("rule1", atLine: 5), .enabled)
 
     let text2 =
       #"""
@@ -158,8 +158,8 @@ public class RuleMaskTests: XCTestCase {
 
     let mask2 = createMask(sourceText: text2)
 
-    XCTAssertFalse(mask2.isDisabled("rule1", line: 1))
-    XCTAssertFalse(mask2.isDisabled("rule1", line: 6))
-    XCTAssertFalse(mask2.isDisabled("rule1", line: 8))
+    XCTAssertEqual(mask2.ruleState("rule1", atLine: 1), .default)
+    XCTAssertEqual(mask2.ruleState("rule1", atLine: 6), .default)
+    XCTAssertEqual(mask2.ruleState("rule1", atLine: 8), .enabled)
   }
 }

--- a/Tests/SwiftFormatCoreTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatCoreTests/XCTestManifests.swift
@@ -7,11 +7,11 @@ extension RuleMaskTests {
     // to regenerate.
     static let __allTests__RuleMaskTests = [
         ("testDuplicateNested", testDuplicateNested),
+        ("testEnableBeforeDisable", testEnableBeforeDisable),
         ("testSingleFlags", testSingleFlags),
         ("testSingleRule", testSingleRule),
         ("testSpuriousFlags", testSpuriousFlags),
         ("testTwoRules", testTwoRules),
-        ("testWrongOrderFlags", testWrongOrderFlags),
     ]
 }
 

--- a/Tests/SwiftFormatRulesTests/NeverUseForceTryTests.swift
+++ b/Tests/SwiftFormatRulesTests/NeverUseForceTryTests.swift
@@ -37,20 +37,4 @@ public class NeverUseForceTryTests: DiagnosingTestCase {
     performLint(NeverUseForceTry.self, input: input)
     XCTAssertNotDiagnosed(.doNotForceTry)
   }
-
-  public func testDisableForceTry() {
-    let input =
-      """
-      let a = 123
-
-      // swift-format-disable: NeverUseForceTry
-      let document = try! Document(path: "important.data")
-      let sheet = try! Paper()
-      // swift-format-enable: NeverUseForceTry
-
-      let b = 456
-      """
-    performLint(NeverUseForceTry.self, input: input)
-    XCTAssertNotDiagnosed(.doNotForceTry)
-  }
 }

--- a/Tests/SwiftFormatRulesTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatRulesTests/XCTestManifests.swift
@@ -137,7 +137,6 @@ extension NeverUseForceTryTests {
     // to regenerate.
     static let __allTests__NeverUseForceTryTests = [
         ("testAllowForceTryInTestCode", testAllowForceTryInTestCode),
-        ("testDisableForceTry", testDisableForceTry),
         ("testInvalidTryExpression", testInvalidTryExpression),
     ]
 }


### PR DESCRIPTION
Have lint rules extend `SyntaxVisitorBase` and make them classes again
instead of using the visitor protocol.

`RuleMask` previously only kept track of rule disablement, assuming that
any range where a rule was not disabled should have it enabled. This
isn't quite correct; it's actually a tri-state of enabled, disabled, and
whatever-is-in-the-configuration.

With these changes, rule enablement/disablement is now handled in the
lint pipeline **(format pipeline coming later),** not in individual rules.
**(This will also be refined later, because some individual rules do
need finer control over that check.)**

Fixes [SR-11114](https://bugs.swift.org/browse/SR-11114).