### PR TITLE
Allow format rules to be enabled/disabled.

### DIFF
--- a/Sources/SwiftFormatCore/SyntaxFormatRule.swift
+++ b/Sources/SwiftFormatCore/SyntaxFormatRule.swift
@@ -21,4 +21,11 @@ open class SyntaxFormatRule: SyntaxRewriter, Rule {
   public required init(context: Context) {
     self.context = context
   }
+
+  open override func visitAny(_ node: Syntax) -> Syntax? {
+    // If the rule is not enabled, then return the node unmodified; otherwise, returning nil tells
+    // SwiftSyntax to continue with the standard dispatch.
+    guard context.isRuleEnabled(Self.ruleName, node: node) else { return node }
+    return nil
+  }
 }

--- a/Tests/SwiftFormatRulesTests/DiagnosingTestCase.swift
+++ b/Tests/SwiftFormatRulesTests/DiagnosingTestCase.swift
@@ -72,6 +72,9 @@ public class DiagnosingTestCase: XCTestCase {
 
     self.context = makeContext(sourceFileSyntax: sourceFileSyntax)
 
+    // Force the rule to be enabled while we test it.
+    context!.configuration.rules[type.ruleName] = true
+
     // If we're linting, then indicate that we want to fail for unasserted diagnostics when the test
     // is torn down.
     shouldCheckForUnassertedDiagnostics = true
@@ -109,6 +112,9 @@ public class DiagnosingTestCase: XCTestCase {
     }
 
     context = makeContext(sourceFileSyntax: sourceFileSyntax)
+
+    // Force the rule to be enabled while we test it.
+    context!.configuration.rules[formatType.ruleName] = true
 
     shouldCheckForUnassertedDiagnostics = checkForUnassertedDiagnostics
     let formatter = formatType.init(context: context!)


### PR DESCRIPTION
This mostly completes what was started in https://github.com/apple/swift-format/pull/16, except for the part about giving certain rules finer control than just detection based on the line number of the node being visited.

It also fixes a small bug where an enable/disable comment before the first token was not handled correctly.

Fixes [SR-11114](https://bugs.swift.org/browse/SR-11114).