### PR TITLE
Don't try to convert classes that look like namespaces to enums.

### DIFF
--- a/Tests/SwiftFormatRulesTests/UseEnumForNamespacingTests.swift
+++ b/Tests/SwiftFormatRulesTests/UseEnumForNamespacingTests.swift
@@ -37,13 +37,13 @@ public class UseEnumForNamespacingTests: DiagnosingTestCase {
                   static func foo() {}
                   private init() {}
                 }
-                enum C {
+                class C {
                   static func foo() {}
                 }
-                public enum D {
+                public final class D {
                   static func bar()
                 }
-                enum E {
+                final class E {
                   static let a = 123
                 }
                 """)


### PR DESCRIPTION
The class could potentially be used as an `AnyClass` argument to an API
like `Bundle(for:)`, so converting it to a value type breaks that.

Converting structs to enums should still be safe, however. I'm not
convinced the rule holds its weight if it only handles structs, but
I decided that leaving it here is better than removing it, which might
cause someone to try to implement it again in the future and run into
the same issue.

Fixes [SR-11111](https://bugs.swift.org/browse/SR-11111).