### PR TITLE
Don't break before `[` or `{` in single argument function calls.

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/CommentTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/CommentTests.swift
@@ -109,6 +109,8 @@ public class CommentTests: PrettyPrintTestCase {
         // Comment 5
       }
 
+      let a = myfun(123 // Cmt 7
+      )
       let a = myfun(var1: 123 // Cmt 7
       )
 
@@ -159,6 +161,9 @@ public class CommentTests: PrettyPrintTestCase {
         // Comment 5
       }
 
+      let a = myfun(
+        123  // Cmt 7
+      )
       let a = myfun(
         var1: 123  // Cmt 7
       )
@@ -342,6 +347,8 @@ public class CommentTests: PrettyPrintTestCase {
 
       let reallyLongVariableName = 123  /* This comment should wrap */
 
+      let a = myfun(123 /* Cmt 5 */
+      )
       let a = myfun(var1: 123 /* Cmt 5 */
       )
 
@@ -366,6 +373,9 @@ public class CommentTests: PrettyPrintTestCase {
       let reallyLongVariableName
         = 123 /* This comment should wrap */
 
+      let a = myfun(
+        123 /* Cmt 5 */
+      )
       let a = myfun(
         var1: 123 /* Cmt 5 */
       )

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
@@ -162,4 +162,37 @@ public class FunctionCallTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
   }
+
+  public func testSingleUnlabeledArgumentWithDelimiters() {
+    let input =
+      """
+      myFunc([1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000])
+      myFunc(["foo": "bar", "baz": "quux", "glip": "glop"])
+      myFunc({ foo, bar in baz(1000, 2000, 3000, 4000, 5000) })
+      myFunc([1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000]) { foo in bar() }
+      """
+
+    let expected =
+      """
+      myFunc([
+        1000, 2000, 3000, 4000, 5000, 6000, 7000,
+        8000
+      ])
+      myFunc([
+        "foo": "bar", "baz": "quux", "glip": "glop"
+      ])
+      myFunc({ foo, bar in
+        baz(1000, 2000, 3000, 4000, 5000)
+      })
+      myFunc([
+        1000, 2000, 3000, 4000, 5000, 6000, 7000,
+        8000
+      ]) { foo in
+        bar()
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -194,6 +194,7 @@ extension FunctionCallTests {
         ("testBasicFunctionCalls_packArguments", testBasicFunctionCalls_packArguments),
         ("testDiscretionaryLineBreakBeforeClosingParenthesis", testDiscretionaryLineBreakBeforeClosingParenthesis),
         ("testDiscretionaryLineBreaksAreSelfCorrecting", testDiscretionaryLineBreaksAreSelfCorrecting),
+        ("testSingleUnlabeledArgumentWithDelimiters", testSingleUnlabeledArgumentWithDelimiters),
     ]
 }
 


### PR DESCRIPTION
This change allows array/dictionary/closure literals that are the sole unlabeled
argument of a function call to keep the opening `[` or `{` character on the same
line as the opening `(`, and likewise for the closing delimiter.

Fixes [SR-11106](https://bugs.swift.org/browse/SR-11106).