### PR TITLE
Improve method chaining, especially involving trailing closures.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -631,7 +631,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
       before(
         node.rightParen, tokens: .break(.close(mustBreak: breakBeforeRightParen), size: 0), .close)
     }
-    before(node.trailingClosure?.leftBrace, tokens: .break(.reset))
+    before(node.trailingClosure?.leftBrace, tokens: .break(.same))
     return .visitChildren
   }
 

--- a/Tests/SwiftFormatPrettyPrintTests/MemberAccessExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/MemberAccessExprTests.swift
@@ -39,4 +39,42 @@ public class MemberAccessExprTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 15)
   }
+
+  public func testMethodChainingWithClosures() {
+    let input =
+      """
+      let result = [1, 2, 3, 4, 5]
+          .filter{$0 % 2 == 0}
+          .map{$0 * $0}
+      """
+
+    let expected =
+      """
+      let result = [1, 2, 3, 4, 5]
+        .filter { $0 % 2 == 0 }
+        .map { $0 * $0 }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 30)
+  }
+
+  public func testMethodChainingWithClosuresFullWrap() {
+    let input =
+      """
+      let result = [1, 2, 3, 4, 5].filter { $0 % 2 == 0 }.map { $0 * $0 }
+      """
+
+    let expected =
+      """
+      let result = [
+        1, 2, 3, 4, 5
+      ].filter {
+        $0 % 2 == 0
+      }.map { $0 * $0 }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -300,6 +300,8 @@ extension MemberAccessExprTests {
     static let __allTests__MemberAccessExprTests = [
         ("testImplicitMemberAccess", testImplicitMemberAccess),
         ("testMemberAccess", testMemberAccess),
+        ("testMethodChainingWithClosures", testMethodChainingWithClosures),
+        ("testMethodChainingWithClosuresFullWrap", testMethodChainingWithClosuresFullWrap),
     ]
 }
 


### PR DESCRIPTION
There are still some edge cases that can look odd when discretionary
newlines are involved and when wrapping also occurs around them, but
they can be repaired manually for now (and the formatter will preserve
that correction as long as it's also correct according to the rules).
Improving that will require a bit more work.

Fixes [SR-11169](https://bugs.swift.org/browse/SR-11169).