### PR TITLE
Don't break before `[` or `{` in single argument (labeled) function calls.

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/ClosureExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ClosureExprTests.swift
@@ -21,48 +21,38 @@ public class ClosureExprTests: PrettyPrintTestCase {
       funcCall(closure: <)
       funcCall(closure: { 4 })
       funcCall(closure: { $0 < $1 })
-      funcCall(
-        closure: { s1, s2 in
-          s1 < s2
-        }
-      )
-      funcCall(
-        closure: { s1, s2 in
-          return s1 < s2
-        }
-      )
-      funcCall(
-        closure: { s1, s2, s3, s4, s5, s6 in
-          return s1
-        }
-      )
-      funcCall(
-        closure: {
-          s1,
-          s2,
-          s3,
-          s4,
-          s5,
-          s6,
-          s7,
-          s8,
-          s9,
-          s10 in
-          return s1
-        }
-      )
+      funcCall(closure: { s1, s2 in s1 < s2 })
+      funcCall(closure: { s1, s2 in
+        return s1 < s2
+      })
+      funcCall(closure: {
+        s1,
+        s2,
+        s3,
+        s4,
+        s5,
+        s6 in return s1
+      })
+      funcCall(closure: {
+        s1,
+        s2,
+        s3,
+        s4,
+        s5,
+        s6,
+        s7,
+        s8,
+        s9,
+        s10 in return s1
+      })
       funcCall(
         param1: 123,
-        closure: { s1, s2, s3 in
-          return s1
-        }
+        closure: { s1, s2, s3 in return s1 }
       )
-      funcCall(
-        closure: {
-          (s1: String, s2: String) -> Bool in
-          return s1 > s2
-        }
-      )
+      funcCall(closure: {
+        (s1: String, s2: String) -> Bool in
+        return s1 > s2
+      })
 
       """
 
@@ -90,34 +80,24 @@ public class ClosureExprTests: PrettyPrintTestCase {
       funcCall(closure: <)
       funcCall(closure: { 4 })
       funcCall(closure: { $0 < $1 })
-      funcCall(
-        closure: { s1, s2 in
-          s1 < s2
-        })
-      funcCall(
-        closure: { s1, s2 in
-          return s1 < s2
-        })
-      funcCall(
-        closure: { s1, s2, s3, s4, s5, s6 in
-          return s1
-        })
-      funcCall(
-        closure: {
-          s1, s2, s3, s4, s5, s6, s7, s8, s9,
-          s10 in
-          return s1
-        })
+      funcCall(closure: { s1, s2 in s1 < s2 })
+      funcCall(closure: { s1, s2 in
+        return s1 < s2
+      })
+      funcCall(closure: {
+        s1, s2, s3, s4, s5, s6 in return s1
+      })
+      funcCall(closure: {
+        s1, s2, s3, s4, s5, s6, s7, s8, s9, s10
+        in return s1
+      })
       funcCall(
         param1: 123,
-        closure: { s1, s2, s3 in
-          return s1
-        })
-      funcCall(
-        closure: {
-          (s1: String, s2: String) -> Bool in
-          return s1 > s2
-        })
+        closure: { s1, s2, s3 in return s1 })
+      funcCall(closure: {
+        (s1: String, s2: String) -> Bool in
+        return s1 > s2
+      })
 
       """
 
@@ -143,8 +123,7 @@ public class ClosureExprTests: PrettyPrintTestCase {
         return s1
       }
       funcCall(param1: 2) {
-        s1, s2, s3, s4, s5 in
-        return s1
+        s1, s2, s3, s4, s5 in return s1
       }
 
       """
@@ -281,11 +260,7 @@ public class ClosureExprTests: PrettyPrintTestCase {
 
     let expected =
       """
-      let a = [
-        { a, b in
-          someFunc(a, b)
-        }
-      ]
+      let a = [{ a, b in someFunc(a, b) }]
 
       """
 

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
@@ -139,24 +139,25 @@ public class FunctionCallTests: PrettyPrintTestCase {
       myFunc(someArray: [1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000])
       myFunc(someDictionary: ["foo": "bar", "baz": "quux", "glip": "glop"])
       myFunc(someClosure: { foo, bar in baz(1000, 2000, 3000, 4000, 5000) })
+      myFunc(someArray: [1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000]) { foo in bar() }
       """
 
     let expected =
       """
-      myFunc(
-        someArray: [
-          1000, 2000, 3000, 4000, 5000, 6000, 7000,
-          8000
-        ])
-      myFunc(
-        someDictionary: [
-          "foo": "bar", "baz": "quux",
-          "glip": "glop"
-        ])
-      myFunc(
-        someClosure: { foo, bar in
-          baz(1000, 2000, 3000, 4000, 5000)
-        })
+      myFunc(someArray: [
+        1000, 2000, 3000, 4000, 5000, 6000, 7000,
+        8000
+      ])
+      myFunc(someDictionary: [
+        "foo": "bar", "baz": "quux", "glip": "glop"
+      ])
+      myFunc(someClosure: { foo, bar in
+        baz(1000, 2000, 3000, 4000, 5000)
+      })
+      myFunc(someArray: [
+        1000, 2000, 3000, 4000, 5000, 6000, 7000,
+        8000
+      ]) { foo in bar() }
 
       """
 
@@ -187,9 +188,7 @@ public class FunctionCallTests: PrettyPrintTestCase {
       myFunc([
         1000, 2000, 3000, 4000, 5000, 6000, 7000,
         8000
-      ]) { foo in
-        bar()
-      }
+      ]) { foo in bar() }
 
       """
 

--- a/Tests/SwiftFormatPrettyPrintTests/IfStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/IfStmtTests.swift
@@ -215,4 +215,25 @@ public class IfStmtTests: PrettyPrintTestCase {
     // The line length ends on the last paren of .Stuff()
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 44)
   }
+
+  public func testHangingOpenBreakIsTreatedLikeContinuation() {
+    let input =
+      """
+      if let foo = someFunction(someArgumentLabel: someValue) {
+        // do stuff
+      }
+      """
+
+    let expected =
+      """
+      if let foo = someFunction(
+        someArgumentLabel: someValue)
+      {
+        // do stuff
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/SubscriptExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/SubscriptExprTests.swift
@@ -52,14 +52,11 @@ public class SubscriptExprTests: PrettyPrintTestCase {
       """
       let a = myCollection[index] { $0 < $1 }
       let a = myCollection[label: index] {
-        arg1, arg2 in
-        foo()
+        arg1, arg2 in foo()
       }
       let a = myCollection[
         index, default: someDefaultValue
-      ] { arg1, arg2 in
-        foo()
-      }
+      ] { arg1, arg2 in foo() }
 
       """
 
@@ -82,9 +79,7 @@ public class SubscriptExprTests: PrettyPrintTestCase {
       } = someValue
       myCollection[
         index, default: someDefaultValue
-      ] { arg1, arg2 in
-        foo()
-      } = someValue
+      ] { arg1, arg2 in foo() } = someValue
 
       """
 

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -259,6 +259,7 @@ extension IfStmtTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__IfStmtTests = [
+        ("testHangingOpenBreakIsTreatedLikeContinuation", testHangingOpenBreakIsTreatedLikeContinuation),
         ("testIfElseStatement_breakBeforeElse", testIfElseStatement_breakBeforeElse),
         ("testIfElseStatement_noBreakBeforeElse", testIfElseStatement_noBreakBeforeElse),
         ("testIfLetStatements", testIfLetStatements),


### PR DESCRIPTION
This change is like the one in commit 82e3e166c48dc1d054cd960f9878542bf1bf77d2, but allows the line break to be omitted if you have a function call with a single labeled argument whose value is an array/dictionary/closure literal.

Getting this to work ended up revealing a couple other bugs around the way open breaks were handled. Previously, they *unconditionally* increased the indentation level of their scope, which meant that if one break didn't fire but another on the same line did, then the next line would be indented *two* units from the previous line instead of one. Now, an open break only contributes to indentation if it is not followed by another one on the same line.

As a consequence of this, closure literal handling changed slightly. The changes were positive ones, allowing certain short closure literals to be formatted more compactly than the previous algorithm allowed.

Fixes [SR-11106](https://bugs.swift.org/browse/SR-11106).