### PR TITLE
Restore continuation state correctly after indented brace scopes.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
@@ -343,6 +343,7 @@ public class PrettyPrinter {
 
         // Restore the continuation state of the scope we were in before the open break occurred.
         currentLineIsContinuation = currentLineIsContinuation || wasContinuationWhenOpened
+        isContinuationIfBreakFires = wasContinuationWhenOpened
 
       case .continue:
         isContinuationIfBreakFires = true

--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1639,7 +1639,8 @@ private final class TokenStreamCreator: SyntaxVisitor {
       after(node.leftBrace, tokens: .break(.open, size: 1), .open)
       before(node.rightBrace, tokens: .break(.close, size: 1), .close)
     } else {
-      before(node.rightBrace, tokens: .break(.same, size: 0))
+      after(node.leftBrace, tokens: .break(.open, size: 0))
+      before(node.rightBrace, tokens: .break(.close, size: 0))
     }
   }
 
@@ -1668,7 +1669,8 @@ private final class TokenStreamCreator: SyntaxVisitor {
       after(node.leftBrace, tokens: .break(.open, size: 1), .open)
       before(node.rightBrace, tokens: .break(.close, size: 1), .close)
     } else {
-      before(node.rightBrace, tokens: .break(.same, size: 0))
+      after(node.leftBrace, tokens: .break(.open, size: 0))
+      before(node.rightBrace, tokens: .break(.close, size: 0))
     }
   }
 
@@ -1697,7 +1699,8 @@ private final class TokenStreamCreator: SyntaxVisitor {
       after(node.leftBrace, tokens: .break(.open, size: 1), .open)
       before(node.rightBrace, tokens: .break(.close, size: 1), .close)
     } else {
-      before(node.rightBrace, tokens: .break(.same, size: 0))
+      after(node.leftBrace, tokens: .break(.open, size: 0))
+      before(node.rightBrace, tokens: .break(.close, size: 0))
     }
   }
 
@@ -1720,7 +1723,8 @@ private final class TokenStreamCreator: SyntaxVisitor {
       after(node.leftBrace, tokens: .break(.open, size: 1), .open)
       before(node.rightBrace, tokens: .break(.close, size: 1), .close)
     } else {
-      before(node.rightBrace, tokens: .break(.same, size: 0))
+      after(node.leftBrace, tokens: .break(.open, size: 0))
+      before(node.rightBrace, tokens: .break(.close, size: 0))
     }
   }
 

--- a/Tests/SwiftFormatPrettyPrintTests/MemberAccessExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/MemberAccessExprTests.swift
@@ -77,4 +77,33 @@ public class MemberAccessExprTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20)
   }
+
+  public func testContinuationRestorationAfterGroup() {
+    let input =
+      """
+      someLongReceiverName.someEvenLongerMethodName {
+      }
+
+      someLongReceiverName.someEvenLongerMethodName {
+        bar()
+        baz()
+      }
+      """
+
+    let expected =
+      """
+      someLongReceiverName
+        .someEvenLongerMethodName {
+        }
+
+      someLongReceiverName
+        .someEvenLongerMethodName {
+          bar()
+          baz()
+        }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 30)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -299,6 +299,7 @@ extension MemberAccessExprTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__MemberAccessExprTests = [
+        ("testContinuationRestorationAfterGroup", testContinuationRestorationAfterGroup),
         ("testImplicitMemberAccess", testImplicitMemberAccess),
         ("testMemberAccess", testMemberAccess),
         ("testMethodChainingWithClosures", testMethodChainingWithClosures),


### PR DESCRIPTION
Fixes [SR-11206](https://bugs.swift.org/browse/SR-11206).