### PR TITLE
Do not indent the trailing line comment in a member decl list as a continuation.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -838,7 +838,12 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   func visit(_ node: MemberDeclListSyntax) -> SyntaxVisitorContinueKind {
-    insertTokens(.break(.reset, size: 0), .newline, betweenElementsOf: node)
+    return .visitChildren
+  }
+
+  func visit(_ node: MemberDeclListItemSyntax) -> SyntaxVisitorContinueKind {
+    before(node.firstToken, tokens: .open)
+    after(node.lastToken, tokens: .close, .break(.reset, size: 0))
     return .visitChildren
   }
 

--- a/Tests/SwiftFormatPrettyPrintTests/CommentTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/CommentTests.swift
@@ -435,8 +435,35 @@ public class CommentTests: PrettyPrintTestCase {
           // comment
           && false
       }
+
+      struct Foo {
+        typealias Bar
+          // comment
+          = SomeOtherType
+      }
       """
 
     assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 60)
+  }
+
+  public func testLineCommentAtEndOfMemberDeclList() {
+    let input =
+      """
+      enum Foo {
+        case bar
+          // This should be indented the same as the previous line
+      }
+      """
+
+    let expected =
+      """
+      enum Foo {
+        case bar
+        // This should be indented the same as the previous line
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 100)
   }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -108,6 +108,7 @@ extension CommentTests {
         ("testDocumentationBlockComments", testDocumentationBlockComments),
         ("testDocumentationComments", testDocumentationComments),
         ("testDoesNotInsertExtraNewlinesAfterTrailingComments", testDoesNotInsertExtraNewlinesAfterTrailingComments),
+        ("testLineCommentAtEndOfMemberDeclList", testLineCommentAtEndOfMemberDeclList),
         ("testLineComments", testLineComments),
     ]
 }


### PR DESCRIPTION
This is essentially the same change as 7737a05c3da829834c77cc54139612181d9b5f87, but for `MemberDeclListItem`s instead of `CodeBlockItem`s.

Fixes [SR-11205](https://bugs.swift.org/browse/SR-11205).