### PR TITLE
Prevent breaking at the space in `else {` of a `guard` statement.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -410,7 +410,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
   func visit(_ node: GuardStmtSyntax) -> SyntaxVisitorContinueKind {
     after(node.guardKeyword, tokens: .break)
     before(node.elseKeyword, tokens: .break(.reset), .open)
-    after(node.elseKeyword, tokens: .break)
+    after(node.elseKeyword, tokens: .space)
     before(node.body.leftBrace, tokens: .close)
 
     arrangeBracesAndContents(

--- a/Tests/SwiftFormatPrettyPrintTests/GuardStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/GuardStmtTests.swift
@@ -84,4 +84,27 @@ public class GuardStmtTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 35)
   }
+
+  public func testOpenBraceIsGluedToElseKeyword() {
+    let input =
+      """
+      guard let foo = something,
+        let bar = somethingElse else
+      {
+        body()
+      }
+      """
+
+    let expected =
+      """
+      guard let foo = something,
+        let bar = somethingElse
+      else {
+        body()
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 60)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -242,6 +242,7 @@ extension GuardStmtTests {
     static let __allTests__GuardStmtTests = [
         ("testGuardStatement", testGuardStatement),
         ("testGuardWithFuncCall", testGuardWithFuncCall),
+        ("testOpenBraceIsGluedToElseKeyword", testOpenBraceIsGluedToElseKeyword),
     ]
 }
 


### PR DESCRIPTION
Fixes [SR-11202](https://bugs.swift.org/browse/SR-11202).