### PR TITLE
Migrate leading trivia when adding an access-level modifier.

### DIFF
--- a/Sources/SwiftFormatRules/AddModifierRewriter.swift
+++ b/Sources/SwiftFormatRules/AddModifierRewriter.swift
@@ -22,13 +22,11 @@ private final class AddModifierRewriter: SyntaxRewriter {
   }
 
   override func visit(_ node: VariableDeclSyntax) -> DeclSyntax {
-    // Check for modifiers, if none, put accessor keyword before the first token
+    // Check for modifiers, and, if none, insert the modifier and relocate trivia from the displaced
+    // token.
     guard let modifiers = node.modifiers else {
-      guard
-        let newDecl = removeFirstTokLeadingTrivia(node: node)
-        as? VariableDeclSyntax
-      else { return node }
-      return newDecl.addModifier(modifierKeyword)
+      let nodeWithModifier = node.addModifier(modifierKeyword)
+      return nodeByRelocatingTrivia(in: nodeWithModifier) { $0.modifiers }
     }
     // If variable already has an accessor keyword, skip (do not overwrite)
     guard modifiers.accessLevelModifier == nil else { return node }
@@ -39,12 +37,11 @@ private final class AddModifierRewriter: SyntaxRewriter {
   }
 
   override func visit(_ node: FunctionDeclSyntax) -> DeclSyntax {
+    // Check for modifiers, and, if none, insert the modifier and relocate trivia from the displaced
+    // token.
     guard let modifiers = node.modifiers else {
-      guard
-        let newDecl = removeFirstTokLeadingTrivia(node: node)
-        as? FunctionDeclSyntax
-      else { return node }
-      return newDecl.addModifier(modifierKeyword)
+      let nodeWithModifier = node.addModifier(modifierKeyword)
+      return nodeByRelocatingTrivia(in: nodeWithModifier) { $0.modifiers }
     }
     guard modifiers.accessLevelModifier == nil else { return node }
     let newModifiers = modifiers.prepend(modifier: modifierKeyword)
@@ -52,12 +49,11 @@ private final class AddModifierRewriter: SyntaxRewriter {
   }
 
   override func visit(_ node: AssociatedtypeDeclSyntax) -> DeclSyntax {
+    // Check for modifiers, and, if none, insert the modifier and relocate trivia from the displaced
+    // token.
     guard let modifiers = node.modifiers else {
-      guard
-        let newDecl = removeFirstTokLeadingTrivia(node: node)
-        as? AssociatedtypeDeclSyntax
-      else { return node }
-      return newDecl.addModifier(modifierKeyword)
+      let nodeWithModifier = node.addModifier(modifierKeyword)
+      return nodeByRelocatingTrivia(in: nodeWithModifier) { $0.modifiers }
     }
     guard modifiers.accessLevelModifier == nil else { return node }
     let newModifiers = modifiers.prepend(modifier: modifierKeyword)
@@ -65,12 +61,11 @@ private final class AddModifierRewriter: SyntaxRewriter {
   }
 
   override func visit(_ node: ClassDeclSyntax) -> DeclSyntax {
+    // Check for modifiers, and, if none, insert the modifier and relocate trivia from the displaced
+    // token.
     guard let modifiers = node.modifiers else {
-      guard
-        let newDecl = removeFirstTokLeadingTrivia(node: node)
-        as? ClassDeclSyntax
-      else { return node }
-      return newDecl.addModifier(modifierKeyword)
+      let nodeWithModifier = node.addModifier(modifierKeyword)
+      return nodeByRelocatingTrivia(in: nodeWithModifier) { $0.modifiers }
     }
     guard modifiers.accessLevelModifier == nil else { return node }
     let newModifiers = modifiers.prepend(modifier: modifierKeyword)
@@ -78,12 +73,11 @@ private final class AddModifierRewriter: SyntaxRewriter {
   }
 
   override func visit(_ node: EnumDeclSyntax) -> DeclSyntax {
+    // Check for modifiers, and, if none, insert the modifier and relocate trivia from the displaced
+    // token.
     guard let modifiers = node.modifiers else {
-      guard
-        let newDecl = removeFirstTokLeadingTrivia(node: node)
-        as? EnumDeclSyntax
-      else { return node }
-      return newDecl.addModifier(modifierKeyword)
+      let nodeWithModifier = node.addModifier(modifierKeyword)
+      return nodeByRelocatingTrivia(in: nodeWithModifier) { $0.modifiers }
     }
     guard modifiers.accessLevelModifier == nil else { return node }
     let newModifiers = modifiers.prepend(modifier: modifierKeyword)
@@ -91,12 +85,11 @@ private final class AddModifierRewriter: SyntaxRewriter {
   }
 
   override func visit(_ node: ProtocolDeclSyntax) -> DeclSyntax {
+    // Check for modifiers, and, if none, insert the modifier and relocate trivia from the displaced
+    // token.
     guard let modifiers = node.modifiers else {
-      guard
-        let newDecl = removeFirstTokLeadingTrivia(node: node)
-        as? ProtocolDeclSyntax
-      else { return node }
-      return newDecl.addModifier(modifierKeyword)
+      let nodeWithModifier = node.addModifier(modifierKeyword)
+      return nodeByRelocatingTrivia(in: nodeWithModifier) { $0.modifiers }
     }
     guard modifiers.accessLevelModifier == nil else { return node }
     let newModifiers = modifiers.prepend(modifier: modifierKeyword)
@@ -104,12 +97,11 @@ private final class AddModifierRewriter: SyntaxRewriter {
   }
 
   override func visit(_ node: StructDeclSyntax) -> DeclSyntax {
+    // Check for modifiers, and, if none, insert the modifier and relocate trivia from the displaced
+    // token.
     guard let modifiers = node.modifiers else {
-      guard
-        let newDecl = removeFirstTokLeadingTrivia(node: node)
-        as? StructDeclSyntax
-      else { return node }
-      return newDecl.addModifier(modifierKeyword)
+      let nodeWithModifier = node.addModifier(modifierKeyword)
+      return nodeByRelocatingTrivia(in: nodeWithModifier) { $0.modifiers }
     }
     guard modifiers.accessLevelModifier == nil else { return node }
     let newModifiers = modifiers.prepend(modifier: modifierKeyword)
@@ -117,12 +109,11 @@ private final class AddModifierRewriter: SyntaxRewriter {
   }
 
   override func visit(_ node: TypealiasDeclSyntax) -> DeclSyntax {
+    // Check for modifiers, and, if none, insert the modifier and relocate trivia from the displaced
+    // token.
     guard let modifiers = node.modifiers else {
-      guard
-        let newDecl = removeFirstTokLeadingTrivia(node: node)
-        as? TypealiasDeclSyntax
-      else { return node }
-      return newDecl.addModifier(modifierKeyword)
+      let nodeWithModifier = node.addModifier(modifierKeyword)
+      return nodeByRelocatingTrivia(in: nodeWithModifier) { $0.modifiers }
     }
     guard modifiers.accessLevelModifier == nil else { return node }
     let newModifiers = modifiers.prepend(modifier: modifierKeyword)
@@ -130,24 +121,43 @@ private final class AddModifierRewriter: SyntaxRewriter {
   }
 
   override func visit(_ node: InitializerDeclSyntax) -> DeclSyntax {
+    // Check for modifiers, and, if none, insert the modifier and relocate trivia from the displaced
+    // token.
     guard let modifiers = node.modifiers else {
-      guard
-        let newDecl = removeFirstTokLeadingTrivia(node: node)
-        as? InitializerDeclSyntax
-      else { return node }
-      return newDecl.addModifier(modifierKeyword)
+      let nodeWithModifier = node.addModifier(modifierKeyword)
+      return nodeByRelocatingTrivia(in: nodeWithModifier) { $0.modifiers }
     }
     guard modifiers.accessLevelModifier == nil else { return node }
     let newModifiers = modifiers.prepend(modifier: modifierKeyword)
     return node.withModifiers(newModifiers)
   }
 
-  func removeFirstTokLeadingTrivia(node: DeclSyntax) -> DeclSyntax {
-    let withoutLeadTrivia = replaceTrivia(
+  /// Moves trivia in the given node to correct the placement of potentially displaced trivia in the
+  /// node after the first modifier was added to the given node. The added modifier is assumed to be
+  /// the first and only modifier of the node. After the first modifier is added to a node, any
+  /// leading trivia on the token immediately after the modifier is considered displaced. This
+  /// method moves that displaced trivia onto the new modifier. When there is no displaced trivia,
+  /// this method does nothing and returns the given node as-is.
+  /// - Parameter node: A node that was updated to include a new modifier.
+  /// - Parameter modifiersProvider: A closure that returns all modifiers for the given node.
+  func nodeByRelocatingTrivia<NodeType: DeclSyntax>(
+    in node: NodeType,
+    for modifiersProvider: (NodeType) -> ModifierListSyntax?
+  ) -> NodeType {
+    guard let modifier = modifiersProvider(node)?.firstAndOnly,
+      let movingLeadingTrivia = modifier.nextToken?.leadingTrivia
+    else {
+      // Otherwise, there's no trivia that needs to be relocated so the node is fine.
+      return node
+    }
+    let nodeWithTrivia = replaceTrivia(
       on: node,
-      token: node.firstToken,
-      leadingTrivia: []) as! DeclSyntax
-    return withoutLeadTrivia
+      token: modifier.firstToken,
+      leadingTrivia: movingLeadingTrivia) as! NodeType
+    return replaceTrivia(
+      on: nodeWithTrivia,
+      token: modifiersProvider(nodeWithTrivia)?.first?.nextToken,
+      leadingTrivia: []) as! NodeType
   }
 }
 

--- a/Sources/SwiftFormatRules/NoAccessLevelOnExtensionDeclaration.swift
+++ b/Sources/SwiftFormatRules/NoAccessLevelOnExtensionDeclaration.swift
@@ -83,17 +83,16 @@ public final class NoAccessLevelOnExtensionDeclaration: SyntaxFormatRule {
     keyword: DeclModifierSyntax
   ) -> MemberDeclListSyntax {
     var newMembers: [MemberDeclListItemSyntax] = []
+    let formattedKeyword = replaceTrivia(
+      on: keyword,
+      token: keyword.name,
+      leadingTrivia: [])
+      as! DeclModifierSyntax
 
     for memberItem in memDeclBlock.members {
       let member = memberItem.decl
-      guard let firstTokInDecl = member.firstToken else { continue }
-      let formattedKeyword = replaceTrivia(
-        on: keyword,
-        token: keyword.name,
-        leadingTrivia: firstTokInDecl.leadingTrivia)
-        as! DeclModifierSyntax
-
       guard
+        // addModifier relocates trivia for any token(s) displaced by the new modifier.
         let newDecl = addModifier(declaration: member, modifierKeyword: formattedKeyword)
         as? DeclSyntax
       else { continue }

--- a/Tests/SwiftFormatRulesTests/NoAccessLevelOnExtensionDeclarationTests.swift
+++ b/Tests/SwiftFormatRulesTests/NoAccessLevelOnExtensionDeclarationTests.swift
@@ -15,6 +15,7 @@ public class NoAccessLevelOnExtensionDeclarationTests: DiagnosingTestCase {
                internal var y: Bool
                // Comment 2
                static var z: Bool
+               // Comment 3
                static func someFunc() {}
                init() {}
                protocol SomeProtocol {}
@@ -34,6 +35,7 @@ public class NoAccessLevelOnExtensionDeclarationTests: DiagnosingTestCase {
                   internal var y: Bool
                   // Comment 2
                   public static var z: Bool
+                  // Comment 3
                   public static func someFunc() {}
                   public init() {}
                   public protocol SomeProtocol {}
@@ -96,6 +98,146 @@ public class NoAccessLevelOnExtensionDeclarationTests: DiagnosingTestCase {
       expected: """
         extension Foo {
           fileprivate func f() {}
+        }
+        """
+    )
+  }
+
+  public func testExtensionWithAnnotation() {
+    XCTAssertFormatting(
+      NoAccessLevelOnExtensionDeclaration.self,
+      input:
+        """
+        /// This extension has a comment.
+        @objc public extension Foo {
+        }
+        """,
+      expected:
+        """
+        /// This extension has a comment.
+        @objc extension Foo {
+        }
+        """
+    )
+  }
+
+  public func testPreservesInlineAnnotationsBeforeAddedAccessLevelModifiers() {
+    XCTAssertFormatting(
+      NoAccessLevelOnExtensionDeclaration.self,
+      input: """
+            /// This extension has a comment.
+            public extension Foo {
+              /// This property has a doc comment.
+              @objc var x: Bool { get { return true }}
+              // This property has a developer comment.
+              @objc static var z: Bool { get { return false }}
+              /// This static function has a doc comment.
+              @objc static func someStaticFunc() {}
+              @objc init(with foo: Foo) {}
+              @objc func someOtherFunc() {}
+              @objc protocol SomeProtocol {}
+              @objc class SomeClass : NSObject {}
+              @objc associatedtype SomeType
+              @objc enum SomeEnum : Int {
+                case SomeInt = 32
+              }
+            }
+            """,
+      expected: """
+            /// This extension has a comment.
+            extension Foo {
+              /// This property has a doc comment.
+              @objc public var x: Bool { get { return true }}
+              // This property has a developer comment.
+              @objc public static var z: Bool { get { return false }}
+              /// This static function has a doc comment.
+              @objc public static func someStaticFunc() {}
+              @objc public init(with foo: Foo) {}
+              @objc public func someOtherFunc() {}
+              @objc public protocol SomeProtocol {}
+              @objc public class SomeClass : NSObject {}
+              @objc public associatedtype SomeType
+              @objc public enum SomeEnum : Int {
+                case SomeInt = 32
+              }
+            }
+            """
+    )
+  }
+
+  public func testPreservesMultiLineAnnotationsBeforeAddedAccessLevelModifiers() {
+    XCTAssertFormatting(
+      NoAccessLevelOnExtensionDeclaration.self,
+      input: """
+        /// This extension has a comment.
+        public extension Foo {
+          /// This property has a doc comment.
+          @available(iOS 13, *)
+          var x: Bool { get { return true }}
+          // This property has a developer comment.
+          @available(iOS 13, *)
+          static var z: Bool { get { return false }}
+          // This static function has a developer comment.
+          @objc(someStaticFunction)
+          static func someStaticFunc() {}
+          @objc(initWithFoo:)
+          init(with foo: Foo) {}
+          @objc
+          func someOtherFunc() {}
+          @objc
+          protocol SomeProtocol {}
+          @objc
+          class SomeClass : NSObject {}
+          @available(iOS 13, *)
+          associatedtype SomeType
+          @objc
+          enum SomeEnum : Int {
+            case SomeInt = 32
+          }
+
+          // This is a doc comment for a multi-argument method.
+          @objc(
+            doSomethingThatIsVeryComplicatedWithThisFoo:
+            forGoodMeasureUsingThisBar:
+            andApplyingThisBaz:
+          )
+          public func doSomething(_ foo : Foo, bar : Bar, baz : Baz) {}
+        }
+        """,
+      expected: """
+        /// This extension has a comment.
+        extension Foo {
+          /// This property has a doc comment.
+          @available(iOS 13, *)
+          public var x: Bool { get { return true }}
+          // This property has a developer comment.
+          @available(iOS 13, *)
+          public static var z: Bool { get { return false }}
+          // This static function has a developer comment.
+          @objc(someStaticFunction)
+          public static func someStaticFunc() {}
+          @objc(initWithFoo:)
+          public init(with foo: Foo) {}
+          @objc
+          public func someOtherFunc() {}
+          @objc
+          public protocol SomeProtocol {}
+          @objc
+          public class SomeClass : NSObject {}
+          @available(iOS 13, *)
+          public associatedtype SomeType
+          @objc
+          public enum SomeEnum : Int {
+            case SomeInt = 32
+          }
+
+          // This is a doc comment for a multi-argument method.
+          @objc(
+            doSomethingThatIsVeryComplicatedWithThisFoo:
+            forGoodMeasureUsingThisBar:
+            andApplyingThisBaz:
+          )
+          public func doSomething(_ foo : Foo, bar : Bar, baz : Baz) {}
         }
         """
     )

--- a/Tests/SwiftFormatRulesTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatRulesTests/XCTestManifests.swift
@@ -157,7 +157,10 @@ extension NoAccessLevelOnExtensionDeclarationTests {
     // to regenerate.
     static let __allTests__NoAccessLevelOnExtensionDeclarationTests = [
         ("testExtensionDeclarationAccessLevel", testExtensionDeclarationAccessLevel),
+        ("testExtensionWithAnnotation", testExtensionWithAnnotation),
         ("testPreservesCommentOnRemovedModifier", testPreservesCommentOnRemovedModifier),
+        ("testPreservesInlineAnnotationsBeforeAddedAccessLevelModifiers", testPreservesInlineAnnotationsBeforeAddedAccessLevelModifiers),
+        ("testPreservesMultiLineAnnotationsBeforeAddedAccessLevelModifiers", testPreservesMultiLineAnnotationsBeforeAddedAccessLevelModifiers),
         ("testPrivateIsEffectivelyFileprivate", testPrivateIsEffectivelyFileprivate),
     ]
 }


### PR DESCRIPTION

The AddModifierRewriter was previously only removing the leading trivia of the declaration's first token. The assumption that the new modifier must be the declaration's first token is incorrect. Instead, the AddModifierRewriter now transfers trivia from the token immediately following the new modifier without making any assumptions about where the modifier will be placed in the declaration. This transfer of trivia only occurs for the first modifier in a declaration. The code that adds modifiers to an existing list of modifiers already correctly moves trivia when adding modifiers.

This fixes a bug where leadingTrivia that belongs on attributes (e.g. `@objc`) was moved to the access-level modifier. Moving the leadTrivia trivia resulted in breaking up the attributes and modifiers in a declaration.