### PR TITLE
[SR-11289] Break rule for generic where clause in swift-format

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -233,7 +233,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
     arrangeBracesAndContents(of: members, contentsKeyPath: \.members)
 
     if let genericWhereClause = genericWhereClause {
-      before(genericWhereClause.firstToken, tokens: .break(.same), .open)
+      before(genericWhereClause.firstToken, tokens: .break(.continue), .open)
       after(members.leftBrace, tokens: .close)
     }
 
@@ -310,7 +310,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
     arrangeAttributeList(node.attributes)
 
     if let genericWhereClause = node.genericWhereClause {
-      before(genericWhereClause.firstToken, tokens: .break(.same), .open)
+      before(genericWhereClause.firstToken, tokens: .break(.continue), .open)
       after(genericWhereClause.lastToken, tokens: .close)
     }
 
@@ -360,7 +360,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
     arrangeBracesAndContents(of: body, contentsKeyPath: bodyContentsKeyPath)
 
     if let genericWhereClause = genericWhereClause {
-      before(genericWhereClause.firstToken, tokens: .break(.same), .open)
+      before(genericWhereClause.firstToken, tokens: .break(.continue), .open)
       after(body?.leftBrace ?? genericWhereClause.lastToken, tokens: .close)
     }
 
@@ -1182,7 +1182,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
     after(node.typealiasKeyword, tokens: .break)
 
     if let genericWhereClause = node.genericWhereClause {
-      before(genericWhereClause.firstToken, tokens: .break(.same), .open)
+      before(genericWhereClause.firstToken, tokens: .break(.continue), .open)
       after(node.lastToken, tokens: .close)
     }
     return .visitChildren
@@ -1344,7 +1344,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
     after(node.associatedtypeKeyword, tokens: .break)
 
     if let genericWhereClause = node.genericWhereClause {
-      before(genericWhereClause.firstToken, tokens: .break(.same), .open)
+      before(genericWhereClause.firstToken, tokens: .break(.continue), .open)
       after(node.lastToken, tokens: .close)
     }
     return .visitChildren

--- a/Tests/SwiftFormatPrettyPrintTests/ClassDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ClassDeclTests.swift
@@ -189,13 +189,14 @@ public class ClassDeclTests: PrettyPrintTestCase {
         let B: Double
       }
       class MyClass<S, T>
-      where S: Collection, T: ReallyLongClassName {
+        where S: Collection, T: ReallyLongClassName
+      {
         let A: Int
         let B: Double
       }
       class MyClass<S, T>
-      where S: Collection, T: ReallyLongClassName,
-        U: LongerClassName
+        where S: Collection, T: ReallyLongClassName,
+          U: LongerClassName
       {
         let A: Int
         let B: Double
@@ -226,7 +227,8 @@ public class ClassDeclTests: PrettyPrintTestCase {
         let B: Double
       }
       class MyClass<S, T>: SuperOne, SuperTwo
-      where S: Collection, T: Protocol {
+        where S: Collection, T: Protocol
+      {
         let A: Int
         let B: Double
       }
@@ -301,9 +303,9 @@ public class ClassDeclTests: PrettyPrintTestCase {
       >: MyContainerSuperclass, MyContainerProtocol,
         SomeoneElsesContainerProtocol,
         SomeFrameworkContainerProtocol
-      where BaseCollection: Collection,
-        BaseCollection.Element: Equatable,
-        BaseCollection.Element: SomeOtherProtocol
+        where BaseCollection: Collection,
+          BaseCollection.Element: Equatable,
+          BaseCollection.Element: SomeOtherProtocol
       {
         let A: Int
         let B: Double

--- a/Tests/SwiftFormatPrettyPrintTests/EnumDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/EnumDeclTests.swift
@@ -268,13 +268,14 @@ public class EnumDeclTests: PrettyPrintTestCase {
         let B: Double
       }
       enum MyEnum<S, T>
-      where S: Collection, T: ReallyLongEnumName {
+        where S: Collection, T: ReallyLongEnumName
+      {
         case firstCase
         let B: Double
       }
       enum MyEnum<S, T>
-      where S: Collection, T: ReallyLongEnumName,
-        U: AnotherLongEnum
+        where S: Collection, T: ReallyLongEnumName,
+          U: AnotherLongEnum
       {
         case firstCase
         let B: Double
@@ -305,7 +306,8 @@ public class EnumDeclTests: PrettyPrintTestCase {
         let B: Double
       }
       enum MyEnum<S, T>: ProtoOne, ProtoTwo
-      where S: Collection, T: Protocol {
+        where S: Collection, T: Protocol
+      {
         case firstCase
         let B: Double
       }
@@ -380,9 +382,9 @@ public class EnumDeclTests: PrettyPrintTestCase {
       >: MyContainerProtocolOne, MyContainerProtocolTwo,
         SomeoneElsesContainerProtocol,
         SomeFrameworkContainerProtocol
-      where BaseCollection: Collection,
-        BaseCollection.Element: Equatable,
-        BaseCollection.Element: SomeOtherProtocol
+        where BaseCollection: Collection,
+          BaseCollection.Element: Equatable,
+          BaseCollection.Element: SomeOtherProtocol
       {
         case firstCase
         let B: Double

--- a/Tests/SwiftFormatPrettyPrintTests/ExtensionDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ExtensionDeclTests.swift
@@ -101,13 +101,14 @@ public class ExtensionDeclTests: PrettyPrintTestCase {
         let B: Double
       }
       extension MyExtension
-      where S: Collection, T: ReallyLongExtensionName {
+        where S: Collection, T: ReallyLongExtensionName
+      {
         let A: Int
         let B: Double
       }
       extension MyExtension
-      where S: Collection, T: ReallyLongExtensionName,
-        U: AnotherLongExtension
+        where S: Collection, T: ReallyLongExtensionName,
+          U: AnotherLongExtension
       {
         let A: Int
         let B: Double
@@ -138,7 +139,8 @@ public class ExtensionDeclTests: PrettyPrintTestCase {
         let B: Double
       }
       extension MyExtension: ProtoOne, ProtoTwo
-      where S: Collection, T: Protocol {
+        where S: Collection, T: Protocol
+      {
         let A: Int
         let B: Double
       }
@@ -214,9 +216,9 @@ public class ExtensionDeclTests: PrettyPrintTestCase {
         MyContainerProtocolTwo,
         SomeoneElsesContainerProtocol,
         SomeFrameworkContainerProtocol
-      where BaseCollection: Collection,
-        BaseCollection.Element: Equatable,
-        BaseCollection.Element: SomeOtherProtocol
+        where BaseCollection: Collection,
+          BaseCollection.Element: Equatable,
+          BaseCollection.Element: SomeOtherProtocol
       {
         let A: Int
         let B: Double

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
@@ -296,7 +296,8 @@ public class FunctionDeclTests: PrettyPrintTestCase {
       public func index<Elements: Collection, Element>(
         of element: Element, in collection: Elements
       ) -> Elements.Index?
-      where Elements.Element == Element {
+        where Elements.Element == Element
+      {
         let a = 123
         let b = "abc"
       }
@@ -305,8 +306,8 @@ public class FunctionDeclTests: PrettyPrintTestCase {
         of element: Element,
         in collection: Elements
       ) -> Elements.Index?
-      where Elements.Element == Element,
-        Element: Equatable
+        where Elements.Element == Element,
+          Element: Equatable
       {
         let a = 123
         let b = "abc"
@@ -466,9 +467,10 @@ public class FunctionDeclTests: PrettyPrintTestCase {
       of element: Element,
       in collection: Elements
     ) -> Elements.Index?
-    where
-      Elements.Element == Element,
-      Element: Equatable
+      where
+        Elements.Element
+          == Element,
+        Element: Equatable
     {
       let a = 123
       let b = "abc"
@@ -600,11 +602,12 @@ public class FunctionDeclTests: PrettyPrintTestCase {
       """
       func name<R>(_ x: Int)
         throws -> R
-      where Foo == Bar
+        where Foo == Bar
 
       func name<R>(_ x: Int)
         throws -> R
-      where Foo == Bar {
+        where Foo == Bar
+      {
         statement
         statement
       }
@@ -626,13 +629,13 @@ public class FunctionDeclTests: PrettyPrintTestCase {
       """
       func name<R>(_ x: Int)
         throws -> R
-      where
-        Fooooooo == Barrrrr
+        where
+          Fooooooo == Barrrrr
 
       func name<R>(_ x: Int)
         throws -> R
-      where
-        Fooooooo == Barrrrr
+        where
+          Fooooooo == Barrrrr
       {
         statement
         statement

--- a/Tests/SwiftFormatPrettyPrintTests/InitializerDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/InitializerDeclTests.swift
@@ -235,8 +235,8 @@ public class InitializerDeclTests: PrettyPrintTestCase {
       public init<Elements: Collection, Element>(
         element: Element, in collection: Elements
       )
-      where Elements.Element == Element,
-        Element: Equatable
+        where Elements.Element == Element,
+          Element: Equatable
       {
         let a = 123
         let b = "abc"
@@ -312,8 +312,8 @@ public class InitializerDeclTests: PrettyPrintTestCase {
           element: Element,
           in collection: Elements
         )
-        where Elements.Element == Element,
-          Element: Equatable
+          where Elements.Element == Element,
+            Element: Equatable
         {
           let a = 123
           let b = "abc"

--- a/Tests/SwiftFormatPrettyPrintTests/StructDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/StructDeclTests.swift
@@ -189,13 +189,14 @@ public class StructDeclTests: PrettyPrintTestCase {
         let B: Double
       }
       struct MyStruct<S, T>
-      where S: Collection, T: ReallyLongStructName {
+        where S: Collection, T: ReallyLongStructName
+      {
         let A: Int
         let B: Double
       }
       struct MyStruct<S, T>
-      where S: Collection, T: ReallyLongStructName,
-        U: AnotherLongStruct
+        where S: Collection, T: ReallyLongStructName,
+          U: AnotherLongStruct
       {
         let A: Int
         let B: Double
@@ -226,7 +227,8 @@ public class StructDeclTests: PrettyPrintTestCase {
         let B: Double
       }
       struct MyStruct<S, T>: ProtoOne, ProtoTwo
-      where S: Collection, T: Protocol {
+        where S: Collection, T: Protocol
+      {
         let A: Int
         let B: Double
       }
@@ -301,9 +303,9 @@ public class StructDeclTests: PrettyPrintTestCase {
       >: MyContainerProtocolOne, MyContainerProtocolTwo,
         SomeoneElsesContainerProtocol,
         SomeFrameworkContainerProtocol
-      where BaseCollection: Collection,
-        BaseCollection.Element: Equatable,
-        BaseCollection.Element: SomeOtherProtocol
+        where BaseCollection: Collection,
+          BaseCollection.Element: Equatable,
+          BaseCollection.Element: SomeOtherProtocol
       {
         let A: Int
         let B: Double

--- a/Tests/SwiftFormatPrettyPrintTests/SubscriptDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/SubscriptDeclTests.swift
@@ -150,8 +150,8 @@ public class SubscriptDeclTests: PrettyPrintTestCase {
         subscript<Elements: Collection, Element>(
           var1: Element, var2: Elements
         ) -> Double
-        where Elements.Element == Element,
-          Element: Equatable
+          where Elements.Element == Element,
+            Element: Equatable
         {
           return 1.23
         }
@@ -248,10 +248,10 @@ public class SubscriptDeclTests: PrettyPrintTestCase {
         var1: Element,
         var2: ManyElements
       ) -> ManyElements.Index?
-      where
-        ManyElements.Element
-          == Element,
-        Element: Equatable
+        where
+          ManyElements.Element
+            == Element,
+          Element: Equatable
       {
         get {
           let out = vals[var1][var2]


### PR DESCRIPTION
Proposal to change format rule for generic where clause to follow the one in Swift documentation. See more details below ticket

Fixes [SR-11289](https://bugs.swift.org/browse/SR-11289).