### PR TITLE
[SR-11290] Break rule for where clause in swift-format

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1084,7 +1084,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   func visit(_ node: WhereClauseSyntax) -> SyntaxVisitorContinueKind {
-    // We need to special case `where`-clauses associated with `catch` blocks when
+    // We need to treat special case `where`-clauses associated with `for` or `case` and `catch` blocks when
     // `lineBreakBeforeControlFlowKeywords == false`, because that's the one situation where we
     // want the `where` keyword to be treated as a continuation; that way, we get this:
     //
@@ -1102,7 +1102,8 @@ private final class TokenStreamCreator: SyntaxVisitor {
     //     }
     //
     let wherePrecedingBreak: Token
-    if !config.lineBreakBeforeControlFlowKeywords && node.parent is CatchClauseSyntax {
+    if (!config.lineBreakBeforeControlFlowKeywords && node.parent is CatchClauseSyntax)
+      || (node.parent is ForInStmtSyntax || node.parent is CaseItemSyntax) {
       wherePrecedingBreak = .break(.continue)
     } else {
       wherePrecedingBreak = .break(.same)

--- a/Tests/SwiftFormatPrettyPrintTests/ForInStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ForInStmtTests.swift
@@ -56,12 +56,13 @@ public class ForInStmtTests: PrettyPrintTestCase {
         let b = 456
       }
       for i in longerarray
-      where longerarray.isContainer() {
+        where longerarray.isContainer()
+      {
         let a = 123
         let b = 456
       }
       for i in longerarray
-      where longerarray.isContainer()
+        where longerarray.isContainer()
         && anotherCondition
       {
         let a = 123
@@ -86,7 +87,7 @@ public class ForInStmtTests: PrettyPrintTestCase {
       """
       for item
         in aVeryLargeContainterObject
-      where largeObject
+        where largeObject
         .hasProperty() && condition
       {
         let a = 123

--- a/Tests/SwiftFormatPrettyPrintTests/SwitchStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/SwitchStmtTests.swift
@@ -187,7 +187,7 @@ public class SwitchStmtTests: PrettyPrintTestCase {
       case let (x, y) where x == -y:
         print("Opposite sign")
       case let (reallyLongName, anotherLongName)
-      where reallyLongName == -anotherLongName:
+        where reallyLongName == -anotherLongName:
         print("Opposite sign")
       case let (x, y): print("Arbitrary value")
       }


### PR DESCRIPTION
Sometimes it looks like where clause is in wrong place at a glance. However, since this is intended, I would like to make a proposal how the format's changed. See more details in below ticket

Fixes [SR-11290](https://bugs.swift.org/browse/SR-11290).