### PR TITLE
[SR-11291] Missing space after semicolon in swift-format

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -848,7 +848,8 @@ private final class TokenStreamCreator: SyntaxVisitor {
 
   func visit(_ node: MemberDeclListItemSyntax) -> SyntaxVisitorContinueKind {
     before(node.firstToken, tokens: .open)
-    after(node.lastToken, tokens: .close, .break(.reset, size: 0))
+    let resetSize = node.semicolon != nil ? 1 : 0
+    after(node.lastToken, tokens: .close, .break(.reset, size: resetSize))
     return .visitChildren
   }
 
@@ -934,7 +935,8 @@ private final class TokenStreamCreator: SyntaxVisitor {
 
   func visit(_ node: CodeBlockItemSyntax) -> SyntaxVisitorContinueKind {
     before(node.firstToken, tokens: .open)
-    after(node.lastToken, tokens: .close, .break(.reset, size: 0))
+    let resetSize = node.semicolon != nil ? 1 : 0
+    after(node.lastToken, tokens: .close, .break(.reset, size: resetSize))
     return .visitChildren
   }
 

--- a/Tests/SwiftFormatPrettyPrintTests/SemicolonTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/SemicolonTests.swift
@@ -1,0 +1,32 @@
+public class SemiColonTypeTests: PrettyPrintTestCase {
+  public func testSemicolon() {
+    let input =
+      """
+      var foo = false
+      guard !foo else { return }; defer { foo = true }
+
+      struct Foo {
+        var foo = false; var bar = true; var baz = false
+      }
+      """
+
+    assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 50)
+  }
+    
+  public func testNoSemicolon() {
+    let input =
+      """
+       var foo = false
+       guard !foo else { return }
+       defer { foo = true }
+
+       struct Foo {
+         var foo = false
+         var bar = true
+         var baz = false
+       }
+       """
+
+    assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 50)
+  }
+}


### PR DESCRIPTION
Missing space only if two code block items exist in one line with semicolon

Fixes [SR-11291](https://bugs.swift.org/browse/SR-11291).