### PR TITLE
Allow attributes, including `available`, to span multiple lines.

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/AttributeTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/AttributeTests.swift
@@ -1,10 +1,12 @@
+import SwiftFormatConfiguration
+
 public class AttributeTests: PrettyPrintTestCase {
   public func testAttributeParamSpacing() {
     let input =
       """
-      @available(iOS 9.0, *)
+      @available( iOS 9.0,* )
       func f() {}
-      @available(*, unavailable, renamed: "MyRenamedProtocol")
+      @available(*, unavailable ,renamed:"MyRenamedProtocol")
       func f() {}
       @available(iOS 10.0, macOS 10.12, *)
       func f() {}
@@ -21,7 +23,178 @@ public class AttributeTests: PrettyPrintTestCase {
 
       """
 
-    // Attributes should not wrap.
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 15)
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 60)
+  }
+
+  public func testAttributeBinPackedWrapping() {
+    let input =
+      """
+      @available(iOS 9.0, *)
+      func f() {}
+      @available(*,unavailable, renamed:"MyRenamedProtocol")
+      func f() {}
+      @available(iOS 10.0, macOS 10.12, *)
+      func f() {}
+      """
+
+    let expected =
+      """
+      @available(iOS 9.0, *)
+      func f() {}
+      @available(
+        *, unavailable,
+        renamed: "MyRenamedProtocol"
+      )
+      func f() {}
+      @available(
+        iOS 10.0, macOS 10.12, *
+      )
+      func f() {}
+
+      """
+
+    // Attributes should wrap to avoid overflowing the line length, using the following priorities:
+    // 1. Keep the entire attribute together, on 1 line.
+    // 2. Otherwise, try to keep the entire attribute argument list together on 1 line.
+    // 3. Otherwise, use argument list consistency (default: inconsistent) for the arguments.
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 32)
+  }
+
+  public func testAttributeArgumentPerLineWrapping() {
+    let input =
+      """
+      @available(iOS 9.0, *)
+      func f() {}
+      @available(*,unavailable, renamed:"MyRenamedProtocol")
+      func f() {}
+      @available(iOS 10.0, macOS 10.12, *)
+      func f() {}
+      """
+
+    let expected =
+      """
+      @available(iOS 9.0, *)
+      func f() {}
+      @available(
+        *,
+        unavailable,
+        renamed: "MyRenamedProtocol"
+      )
+      func f() {}
+      @available(
+        iOS 10.0,
+        macOS 10.12,
+        *
+      )
+      func f() {}
+
+      """
+
+    let configuration = Configuration()
+    configuration.lineBreakBeforeEachArgument = true
+    assertPrettyPrintEqual(
+      input: input, expected: expected, linelength: 32, configuration: configuration)
+  }
+
+  public func testAttributeFormattingRespectsDiscretionaryLineBreaks() {
+    let input =
+      """
+      @available(
+        iOSApplicationExtension,
+        introduced: 10.0,
+        deprecated: 11.0,
+        message:
+          "Use something else because this is definitely deprecated.")
+      func f2() {}
+      """
+
+    let expected =
+      """
+      @available(
+        iOSApplicationExtension,
+        introduced: 10.0,
+        deprecated: 11.0,
+        message:
+          "Use something else because this is definitely deprecated."
+      )
+      func f2() {}
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
+  }
+
+  public func testAttributeInterArgumentBinPackedLineBreaking() {
+    let input =
+      """
+      @available(iOSApplicationExtension, introduced: 10.0, deprecated: 11.0, message: "Use something else because this is definitely deprecated.")
+      func f2() {}
+      """
+
+    let expected =
+      """
+      @available(
+        iOSApplicationExtension,
+        introduced: 10.0, deprecated: 11.0,
+        message:
+          "Use something else because this is definitely deprecated."
+      )
+      func f2() {}
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
+  }
+
+  public func testAttributArgumentPerLineBreaking() {
+    let input =
+      """
+      @available(iOSApplicationExtension, introduced: 10.0, deprecated: 11.0, message: "Use something else because this is definitely deprecated.")
+      func f2() {}
+      """
+
+    let expected =
+      """
+      @available(
+        iOSApplicationExtension,
+        introduced: 10.0,
+        deprecated: 11.0,
+        message:
+          "Use something else because this is definitely deprecated."
+      )
+      func f2() {}
+
+      """
+
+    let configuration = Configuration()
+    configuration.lineBreakBeforeEachArgument = true
+    assertPrettyPrintEqual(
+      input: input, expected: expected, linelength: 40, configuration: configuration)
+  }
+
+  public func testObjCAttributes() {
+    let input =
+      """
+      @objc func f() {}
+      @objc(foo:bar:baz)
+      func f() {}
+      @objc(thisMethodHasAVeryLongName:andThisArgumentHasANameToo:soDoesThisOne:bar:)
+      func f() {}
+      """
+
+    let expected =
+      """
+      @objc func f() {}
+      @objc(foo:bar:baz)
+      func f() {}
+      @objc(
+        thisMethodHasAVeryLongName:andThisArgumentHasANameToo:soDoesThisOne:bar:
+      )
+      func f() {}
+
+      """
+
+    // TODO: Support line breaks between argument names in Objective-C selectors.
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
   }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -39,7 +39,13 @@ extension AttributeTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__AttributeTests = [
+        ("testAttributArgumentPerLineBreaking", testAttributArgumentPerLineBreaking),
+        ("testAttributeArgumentPerLineWrapping", testAttributeArgumentPerLineWrapping),
+        ("testAttributeBinPackedWrapping", testAttributeBinPackedWrapping),
+        ("testAttributeFormattingRespectsDiscretionaryLineBreaks", testAttributeFormattingRespectsDiscretionaryLineBreaks),
+        ("testAttributeInterArgumentBinPackedLineBreaking", testAttributeInterArgumentBinPackedLineBreaking),
         ("testAttributeParamSpacing", testAttributeParamSpacing),
+        ("testObjCAttributes", testObjCAttributes),
     ]
 }
 


### PR DESCRIPTION
The previous implementation forced all attributes to use a single line, even if the attribute's identifier + contents exceeded the line length. Following some investigation, it appears that the Swift compiler supports multi-line attribute declarations.

The formatter uses the following priority for laying out attributes:
1. Whenever possible, fit the entire attribute on a single line.
2. Otherwise, if the arguments can fit on a line, use line breaks between the attribute's opening paren, the arguments, and the closing paren.
3. Otherwise use the configured argument line breaking option (as is used in argument lists for functions and function like declarations) to add line breaks between the arguments. Prefers keeping individual arguments together, but there's a carve specifically for "labeled availability arguments" to allow breaking at the ":" separator.

In the future, we could add more special case line breaks in specific kinds of attribute arguments (e.g. line breaks between pieces of an Objective-C selector).