### PR TITLE
Allow line breaks between Obj-C selector pieces in attributes.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -889,6 +889,11 @@ private final class TokenStreamCreator: SyntaxVisitor {
     return .visitChildren
   }
 
+  func visit(_ node: ObjCSelectorSyntax) -> SyntaxVisitorContinueKind {
+    insertTokens(.break(.same, size: 0), betweenElementsOf: node)
+    return .visitChildren
+  }
+
   func visit(_ node: PrecedenceGroupDeclSyntax) -> SyntaxVisitorContinueKind {
     after(node.precedencegroupKeyword, tokens: .break)
     after(node.identifier, tokens: .break(.reset))

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -45,7 +45,9 @@ extension AttributeTests {
         ("testAttributeFormattingRespectsDiscretionaryLineBreaks", testAttributeFormattingRespectsDiscretionaryLineBreaks),
         ("testAttributeInterArgumentBinPackedLineBreaking", testAttributeInterArgumentBinPackedLineBreaking),
         ("testAttributeParamSpacing", testAttributeParamSpacing),
-        ("testObjCAttributes", testObjCAttributes),
+        ("testObjCAttributesDiscretionaryLineBreaking", testObjCAttributesDiscretionaryLineBreaking),
+        ("testObjCAttributesPerLineBreaking", testObjCAttributesPerLineBreaking),
+        ("testObjCBinPackedAttributes", testObjCBinPackedAttributes),
     ]
 }
 


### PR DESCRIPTION
Previously, Objective-C selector pieces were forced onto 1 line regardless of their length. This is problematic when the selector is verbose or has many arguments, since it will overflow the line length. It's still possible for an Objective-C selector piece whose name is longer than the configured line length to overflow the line length, since it's invalid to break inside of the name of a selector piece.

These breaks are specifically size 0 because Objective-C selector pieces aren't separated by spaces.