### PR TITLE
Prevent extra indentation for trailing closures in specific function …

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
@@ -334,11 +334,11 @@ public class PrettyPrinter {
           // breaks (if they are enabled).
           //
           // Note that in this case, the transformation of the current line into a continuation line
-          // must happen unconditionally, not only if the break fires.
+          // must happen regardless of whether this break fires.
           //
           // Likewise, we need to do this if we popped an old continuation state off the stack,
           // even if the break *doesn't* fire.
-          currentLineIsContinuation = openedOnDifferentLine
+          currentLineIsContinuation = matchingOpenBreak.didIndent && openedOnDifferentLine
         }
 
         // Restore the continuation state of the scope we were in before the open break occurred.

--- a/Tests/SwiftFormatPrettyPrintTests/ClosureExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ClosureExprTests.swift
@@ -133,6 +133,37 @@ public class ClosureExprTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: config)
   }
 
+  public func testClosureArgumentsWithTrailingClosure() {
+    let input =
+      """
+      someFunc({ return s0 }) { return s2 }
+      someLongerFunc({ return s0 }) { input in return s2 }
+      someLongerFunc({ firstInput in someUsefulFunc(firstInput) }) { secondInput in return s2 }
+      someLongerFunc({ firstInput in
+        someUsefulFunc(firstInput) }) { secondInput in return someLineBreakingCall(secondInput) }
+      """
+
+    let expected =
+      """
+      someFunc({ return s0 }) { return s2 }
+      someLongerFunc({ return s0 }) { input in
+        return s2
+      }
+      someLongerFunc({ firstInput in
+        someUsefulFunc(firstInput)
+      }) { secondInput in return s2 }
+      someLongerFunc({ firstInput in
+        someUsefulFunc(firstInput)
+      }) { secondInput in
+        return someLineBreakingCall(
+          secondInput)
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
+  }
+
   public func testClosuresWithIfs() {
     let input =
     """

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
@@ -140,6 +140,7 @@ public class FunctionCallTests: PrettyPrintTestCase {
       myFunc(someDictionary: ["foo": "bar", "baz": "quux", "glip": "glop"])
       myFunc(someClosure: { foo, bar in baz(1000, 2000, 3000, 4000, 5000) })
       myFunc(someArray: [1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000]) { foo in bar() }
+      myFunc(someArray: [1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000]) { foo in someMuchLongerLineBreakingBarFunction() }
       """
 
     let expected =
@@ -158,6 +159,12 @@ public class FunctionCallTests: PrettyPrintTestCase {
         1000, 2000, 3000, 4000, 5000, 6000, 7000,
         8000
       ]) { foo in bar() }
+      myFunc(someArray: [
+        1000, 2000, 3000, 4000, 5000, 6000, 7000,
+        8000
+      ]) { foo in
+        someMuchLongerLineBreakingBarFunction()
+      }
 
       """
 
@@ -171,6 +178,7 @@ public class FunctionCallTests: PrettyPrintTestCase {
       myFunc(["foo": "bar", "baz": "quux", "glip": "glop"])
       myFunc({ foo, bar in baz(1000, 2000, 3000, 4000, 5000) })
       myFunc([1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000]) { foo in bar() }
+      myFunc([1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000]) { foo in someMuchLongerLineBreakingBarFunction() }
       """
 
     let expected =
@@ -189,6 +197,12 @@ public class FunctionCallTests: PrettyPrintTestCase {
         1000, 2000, 3000, 4000, 5000, 6000, 7000,
         8000
       ]) { foo in bar() }
+      myFunc([
+        1000, 2000, 3000, 4000, 5000, 6000, 7000,
+        8000
+      ]) { foo in
+        someMuchLongerLineBreakingBarFunction()
+      }
 
       """
 

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -98,6 +98,7 @@ extension ClosureExprTests {
         ("testBasicFunctionClosures_noPackArguments", testBasicFunctionClosures_noPackArguments),
         ("testBasicFunctionClosures_packArguments", testBasicFunctionClosures_packArguments),
         ("testBodilessClosure", testBodilessClosure),
+        ("testClosureArgumentsWithTrailingClosure", testClosureArgumentsWithTrailingClosure),
         ("testClosureCapture", testClosureCapture),
         ("testClosureCaptureWithoutArguments", testClosureCaptureWithoutArguments),
         ("testClosuresWithIfs", testClosuresWithIfs),


### PR DESCRIPTION
…calls.

Certain kinds of multi-line function arguments were causing trailing closures to have an extra level of indentation when the closure was across multiple lines. This was caused by treating the last line of the function call, where the closure started, as a "continuation". The behavior to treat that line as a continuation allows `reset` breaks to work correctly, but it also means `open` breaks receive an extra level of indentation. See commit 40ab473 for details and background.

To fix this, I've changed the pretty printer to only treat these lines are continuations if the original open contributed to indentation (`didIndent == true`). Intuitively, this means a `close` break only creates a continuation if it's closing a "scope" that was indented.