### PR TITLE
Support formatting and linting from standard input.

### DIFF
--- a/Sources/SwiftFormat/SwiftLinter.swift
+++ b/Sources/SwiftFormat/SwiftLinter.swift
@@ -64,7 +64,7 @@ public final class SwiftLinter {
   ///   - url: A file URL denoting the filename/path that should be assumed for this source code.
   /// - Throws: If an unrecoverable error occurs when formatting the code.
   public func lint(source: String, assumingFileURL url: URL) throws {
-    let sourceFile = try SyntaxParser.parse(url)
+    let sourceFile = try SyntaxParser.parse(source: source)
     try lint(syntax: sourceFile, assumingFileURL: url)
   }
 

--- a/Sources/swift-format/Run.swift
+++ b/Sources/swift-format/Run.swift
@@ -20,21 +20,33 @@ import SwiftSyntax
 /// Runs the linting pipeline over the provided source file.
 ///
 /// If there were any lint diagnostics emitted, this function returns a non-zero exit code.
-/// - Parameter configuration: The `Configuration` that contains user-specific settings.
-/// - Parameter path: The absolute path to the source file to be linted.
+/// - Parameters:
+///   - configuration: The `Configuration` that contains user-specific settings.
+///   - sourceFile: A file handle from which to read the source code to be linted.
+///   - assumingFilename: The filename of the source file, used in diagnostic output.
 /// - Returns: Zero if there were no lint errors, otherwise a non-zero number.
-func lintMain(configuration: Configuration, path: String) -> Int {
-  let url = URL(fileURLWithPath: path)
+func lintMain(configuration: Configuration, sourceFile: FileHandle, assumingFilename: String?)
+  -> Int
+{
   let diagnosticEngine = makeDiagnosticEngine()
   let linter = SwiftLinter(configuration: configuration, diagnosticEngine: diagnosticEngine)
+  let assumingFileURL = URL(fileURLWithPath: assumingFilename ?? "<stdin>")
+
+  guard let source = readSource(from: sourceFile) else {
+    stderrStream.write("Unable to read source for linting from \(assumingFileURL.path).\n")
+    stderrStream.flush()
+    return 1
+  }
 
   do {
-    try linter.lint(contentsOf: url)
+    try linter.lint(source: source, assumingFileURL: assumingFileURL)
   } catch SwiftFormatError.fileNotReadable {
+    let path = assumingFileURL.path
     stderrStream.write("Unable to lint \(path): file is not readable or does not exist.\n")
     stderrStream.flush()
     return 1
   } catch {
+    let path = assumingFileURL.path
     // Workaround: we're unable to directly catch unknownTokenKind errors due to access
     // restrictions. TODO: this can be removed when we update to Swift 5.0.
     if "\(error)" == "unknownTokenKind(\"pound_error\")" {
@@ -53,36 +65,46 @@ func lintMain(configuration: Configuration, path: String) -> Int {
 ///
 /// - Parameters:
 ///   - configuration: The `Configuration` that contains user-specific settings.
-///   - path: The absolute path to the source file to be formatted.
+///   - sourceFile: A file handle from which to read the source code to be linted.
+///   - assumingFilename: The filename of the source file, used in diagnostic output.
 ///   - inPlace: Whether or not to overwrite the current file when formatting.
 ///   - debugOptions: The set containing any debug options that were supplied on the command line.
-/// - Returns: Zero if there were no lint errors, otherwise a non-zero number.
+/// - Returns: Zero if there were no format errors, otherwise a non-zero number.
 func formatMain(
-  configuration: Configuration, path: String, inPlace: Bool, debugOptions: DebugOptions
+  configuration: Configuration, sourceFile: FileHandle, assumingFilename: String?, inPlace: Bool,
+  debugOptions: DebugOptions
 ) -> Int {
-  let url = URL(fileURLWithPath: path)
   let formatter = SwiftFormatter(configuration: configuration, diagnosticEngine: nil)
   formatter.debugOptions = debugOptions
+  let assumingFileURL = URL(fileURLWithPath: assumingFilename ?? "<stdin>")
+
+  guard let source = readSource(from: sourceFile) else {
+    stderrStream.write("Unable to read source for formatting from \(assumingFileURL.path).\n")
+    stderrStream.flush()
+    return 1
+  }
 
   do {
     if inPlace {
       let cwd = FileManager.default.currentDirectoryPath
       var buffer = BufferedOutputByteStream()
-      try formatter.format(contentsOf: url, to: &buffer)
+      try formatter.format(source: source, assumingFileURL: assumingFileURL, to: &buffer)
       buffer.flush()
       try localFileSystem.writeFileContents(
-        AbsolutePath(url.path, relativeTo: AbsolutePath(cwd)),
+        AbsolutePath(assumingFileURL.path, relativeTo: AbsolutePath(cwd)),
         bytes: buffer.bytes
       )
     } else {
-      try formatter.format(contentsOf: url, to: &stdoutStream)
+      try formatter.format(source: source, assumingFileURL: assumingFileURL, to: &stdoutStream)
       stdoutStream.flush()
     }
   } catch SwiftFormatError.fileNotReadable {
+    let path = assumingFileURL.path
     stderrStream.write("Unable to format \(path): file is not readable or does not exist.\n")
     stderrStream.flush()
     return 1
   } catch {
+    let path = assumingFileURL.path
     stderrStream.write("Unable to format \(path): \(error)\n")
     stderrStream.flush()
     exit(1)
@@ -96,4 +118,11 @@ private func makeDiagnosticEngine() -> DiagnosticEngine {
   let consumer = PrintingDiagnosticConsumer()
   engine.addConsumer(consumer)
   return engine
+}
+
+/// Reads from the given file handle until EOF is reached, then returns the contents as a UTF8
+/// encoded string.
+private func readSource(from fileHandle: FileHandle) -> String? {
+  let sourceData = fileHandle.readDataToEndOfFile()
+  return String(data: sourceData, encoding: .utf8)
 }

--- a/Sources/swift-format/ToolMode.swift
+++ b/Sources/swift-format/ToolMode.swift
@@ -28,14 +28,6 @@ enum ToolMode: String, Codable, ArgumentKind {
       ])
   }
 
-  /// Indicates whether the mode requires at least one input file passed as a positional argument.
-  var requiresFiles: Bool {
-    switch self {
-    case .format, .lint: return true
-    case .dumpConfiguration, .version: return false
-    }
-  }
-
   /// Creates a `ToolMode` value from the given command line argument string, throwing an error if
   /// the string is not valid.
   init(argument: String) throws {


### PR DESCRIPTION
Reading standard input is a feature that clang-format supports which is useful for users of swift-format too.

CLI changes:
- You can now not specify any directory/file paths, and the tool will read from standard input up to the first EOF.
- When no directory/file paths are specified, the in-place and recursive options are not allowed.
- You can specify a new assume-filename option if and only if using standard input to provide a filename to include in output diagnostics.

I copied clang-format's approach to invoking standard input mode, where the tool starts reading standard input whenever there were no paths specified.