### PR TITLE
Allow for no blank line between members when there's a preceding comm…

### DIFF
--- a/Tests/SwiftFormatRulesTests/BlankLineBetweenMembersTests.swift
+++ b/Tests/SwiftFormatRulesTests/BlankLineBetweenMembersTests.swift
@@ -182,4 +182,48 @@ public class BlankLineBetweenMembersTests: DiagnosingTestCase {
                 }
                 """)
   }
+
+  public func testNoBlankLineBetweenSingleLineMembers() {
+    XCTAssertFormatting(
+        BlankLineBetweenMembers.self,
+        input: """
+               enum Foo {
+                 let bar = 1
+                 let baz = 2
+               }
+               enum Foo {
+
+                 // MARK: - This is an important region of the code.
+
+                 let bar = 1
+                 let baz = 2
+               }
+               enum Foo {
+
+                 // This comment is describing bar.
+                 let bar = 1
+                 let baz = 2
+               }
+               """,
+        expected: """
+                  enum Foo {
+                    let bar = 1
+                    let baz = 2
+                  }
+                  enum Foo {
+
+                    // MARK: - This is an important region of the code.
+
+                    let bar = 1
+                    let baz = 2
+                  }
+                  enum Foo {
+
+                    // This comment is describing bar.
+                    let bar = 1
+
+                    let baz = 2
+                  }
+                  """)
+  }
 }

--- a/Tests/SwiftFormatRulesTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatRulesTests/XCTestManifests.swift
@@ -47,6 +47,7 @@ extension BlankLineBetweenMembersTests {
         ("testBlankLineBeforeFirstChildOrNot", testBlankLineBeforeFirstChildOrNot),
         ("testInvalidBlankLineBetweenMembers", testInvalidBlankLineBetweenMembers),
         ("testNestedMembers", testNestedMembers),
+        ("testNoBlankLineBetweenSingleLineMembers", testNoBlankLineBetweenSingleLineMembers),
         ("testTwoMembers", testTwoMembers),
     ]
 }


### PR DESCRIPTION
…ent + new line.

When the members are preceded by a comment + new line, the comment is probably not directly attached to the first member. Instead, it's likely to be a navigational or organizational construct, such as a "MARK" comment. This change allows members following such a comment to not have a blank line between them.