### PR TITLE
Don't rely on Swift 5.1 optional case elision yet.

### DIFF
--- a/Sources/SwiftFormatRules/BlankLineBetweenMembers.swift
+++ b/Sources/SwiftFormatRules/BlankLineBetweenMembers.swift
@@ -82,7 +82,7 @@ public final class BlankLineBetweenMembers: SyntaxFormatRule {
     guard let leadingTrivia = node.leadingTrivia else {
       return false
     }
-    if case let .newlines(count) = leadingTrivia.withoutSpaces().suffix(1).first {
+    if case let .newlines(count)? = leadingTrivia.withoutSpaces().suffix(1).first {
       return count > 1
     }
     return false


### PR DESCRIPTION
At Google, we can still build swift-format with Swift 5.0 because
we build the syntax parser library from the sources pulled into our
monorepo, so our users aren't required to use the Xcode 11 betas
yet. This was caught by our internal CI when we pulled this change
in.