### PR TITLE
Use the original Syntax node when diagnosing missing blank lines.

### DIFF
--- a/Sources/SwiftFormatRules/BlankLineBetweenMembers.swift
+++ b/Sources/SwiftFormatRules/BlankLineBetweenMembers.swift
@@ -66,7 +66,7 @@ public final class BlankLineBetweenMembers: SyntaxFormatRule {
           leadingTrivia: correctTrivia
         ) as! MemberDeclListItemSyntax
 
-        diagnose(.addBlankLine, on: memberToAdd)
+        diagnose(.addBlankLine, on: member)
       }
 
       membersList.append(memberToAdd)


### PR DESCRIPTION
The diagnostic was using the newly created Syntax node, which fixes the missing blank line. The new node isn't included in the tree yet, and it would be on a different line (since there's an added new line) than the offending statement in the original source. Instead, the original node is used for the diagnostic to get an accurate line number in the message.