### PR TITLE
Detect and delete semicolons nested in code blocks.

### DIFF
--- a/Sources/SwiftFormat/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Pipelines+Generated.swift
@@ -48,9 +48,13 @@ extension LintPipeline {
     return .visitChildren
   }
 
+  func visit(_ node: CodeBlockItemListSyntax) -> SyntaxVisitorContinueKind {
+    visitIfEnabled(DoNotUseSemicolons.visit, in: context, for: node)
+    return .visitChildren
+  }
+
   func visit(_ node: CodeBlockSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(AmbiguousTrailingClosureOverload.visit, in: context, for: node)
-    visitIfEnabled(DoNotUseSemicolons.visit, in: context, for: node)
     visitIfEnabled(OneVariableDeclarationPerLine.visit, in: context, for: node)
     return .visitChildren
   }
@@ -166,6 +170,11 @@ extension LintPipeline {
     return .visitChildren
   }
 
+  func visit(_ node: MemberDeclListSyntax) -> SyntaxVisitorContinueKind {
+    visitIfEnabled(DoNotUseSemicolons.visit, in: context, for: node)
+    return .visitChildren
+  }
+
   func visit(_ node: PatternBindingSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(UseSingleLinePropertyGetter.visit, in: context, for: node)
     return .visitChildren
@@ -197,7 +206,6 @@ extension LintPipeline {
 
   func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(AmbiguousTrailingClosureOverload.visit, in: context, for: node)
-    visitIfEnabled(DoNotUseSemicolons.visit, in: context, for: node)
     visitIfEnabled(NeverForceUnwrap.visit, in: context, for: node)
     visitIfEnabled(NeverUseForceTry.visit, in: context, for: node)
     visitIfEnabled(NeverUseImplicitlyUnwrappedOptionals.visit, in: context, for: node)

--- a/Sources/SwiftFormatRules/SemicolonSyntax.swift
+++ b/Sources/SwiftFormatRules/SemicolonSyntax.swift
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+/// Protocol that declares support for accessing and modifying a token that represents a semicolon.
+protocol SemicolonSyntax {
+  var semicolon: TokenSyntax? { get }
+  func withSemicolon(_ newSemicolon: TokenSyntax?) -> Self
+}
+
+extension MemberDeclListItemSyntax: SemicolonSyntax {}
+extension CodeBlockItemSyntax: SemicolonSyntax {}

--- a/Tests/SwiftFormatRulesTests/DoNotUseSemicolonsTests.swift
+++ b/Tests/SwiftFormatRulesTests/DoNotUseSemicolonsTests.swift
@@ -18,4 +18,79 @@ public class DoNotUseSemicolonsTests: DiagnosingTestCase {
                 print("3")
                 """)
   }
+
+  public func testSemicolonsInNestedStatements() {
+    XCTAssertFormatting(
+      DoNotUseSemicolons.self,
+      input: """
+             guard let someVar = Optional(items.filter ({ a in foo(a); return true; })) else {
+               items.forEach { a in foo(a); }; return;
+             }
+             """,
+      // The formatting in the expected output is unappealing, but that is fixed by the pretty
+      // printer and isn't a concern for the format rule.
+      expected: """
+                guard let someVar = Optional(items.filter ({ a in foo(a)
+                return true})) else {
+                  items.forEach { a in foo(a)}
+                return
+                }
+                """)
+  }
+
+  public func testSemicolonsInMemberLists() {
+    XCTAssertFormatting(
+      DoNotUseSemicolons.self,
+      input: """
+             struct Foo {
+               func foo() {
+                 code()
+               };
+
+               let someVar = 5;let someOtherVar = 6;
+             }
+             """,
+      expected: """
+                struct Foo {
+                  func foo() {
+                    code()
+                  }
+
+                  let someVar = 5
+                let someOtherVar = 6
+                }
+                """)
+  }
+
+  public func testNewlinesAfterSemicolons() {
+    XCTAssertFormatting(
+      DoNotUseSemicolons.self,
+      input: """
+             print("hello");
+             /// This is a doc comment for printing "goodbye".
+             print("goodbye");
+
+             /// This is a doc comment for printing "3".
+             print("3");
+
+             print("4"); /** Inline comment. */ print("5");
+
+             print("6");  // This is an important statement.
+             print("7");
+             """,
+      expected: """
+                print("hello")
+                /// This is a doc comment for printing "goodbye".
+                print("goodbye")
+
+                /// This is a doc comment for printing "3".
+                print("3")
+
+                print("4")
+                /** Inline comment. */ print("5")
+
+                print("6")// This is an important statement.
+                print("7")
+                """)
+  }
 }

--- a/Tests/SwiftFormatRulesTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatRulesTests/XCTestManifests.swift
@@ -68,6 +68,9 @@ extension DoNotUseSemicolonsTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__DoNotUseSemicolonsTests = [
+        ("testNewlinesAfterSemicolons", testNewlinesAfterSemicolons),
+        ("testSemicolonsInMemberLists", testSemicolonsInMemberLists),
+        ("testSemicolonsInNestedStatements", testSemicolonsInNestedStatements),
         ("testSemicolonUse", testSemicolonUse),
     ]
 }


### PR DESCRIPTION
The DoNotUseSemicolons rule previously only removed semicolons that were on the top level code block items inside of a code block item list. It's possible for additional code block item lists to be nested inside of a code block item; see the new test for an example.

The rule now recursively walks through all children of each code block item to find and remove semicolons.

The leading trivia replacement to add a newline was stripping all newlines from the existing trivia, and then adding 1 newline. This is a problem when the leading trivia already contains 2 or more leading newlines, for example to create a blank line between 2 code block items. The previous behavior would remove the intended blank line. Instead, now a single newline is appended to the leading trivia if and only if it doesn't already contain at least 1 leading newline.