### PR TITLE
Use length instead of value of literals to add delimiters.

### DIFF
--- a/Sources/SwiftFormatRules/GroupNumericLiterals.swift
+++ b/Sources/SwiftFormatRules/GroupNumericLiterals.swift
@@ -43,15 +43,13 @@ public final class GroupNumericLiterals: SyntaxFormatRule {
     case "0x":
       // Hexadecimal
       let digitsNoPrefix = String(digits.dropFirst(2))
-      guard let intDigits = Int(digitsNoPrefix, radix: 16) else { return node }
-      guard intDigits >= 0x1000_0000 else { return node }
+      guard digitsNoPrefix.count >= 8 else { return node }
       diagnose(.groupNumericLiteral(byStride: 4), on: node)
       newDigits = "0x" + groupDigitsByStride(digits: digitsNoPrefix, stride: 4)
     case "0b":
       // Binary
       let digitsNoPrefix = String(digits.dropFirst(2))
-      guard let intDigits = Int(digitsNoPrefix, radix: 2) else { return node }
-      guard intDigits >= 0b1_000000000 else { return node }
+      guard digitsNoPrefix.count >= 10 else { return node }
       diagnose(.groupNumericLiteral(byStride: 8), on: node)
       newDigits = "0b" + groupDigitsByStride(digits: digitsNoPrefix, stride: 8)
     case "0o":
@@ -59,8 +57,7 @@ public final class GroupNumericLiterals: SyntaxFormatRule {
       return node
     default:
       // Decimal
-      guard let intDigits = Int(digits) else { return node }
-      guard intDigits >= 1_000_000 else { return node }
+      guard digits.count >= 7 else { return node }
       diagnose(.groupNumericLiteral(byStride: 3), on: node)
       newDigits = groupDigitsByStride(digits: digits, stride: 3)
     }

--- a/Tests/SwiftFormatRulesTests/GroupNumericLiteralsTests.swift
+++ b/Tests/SwiftFormatRulesTests/GroupNumericLiteralsTests.swift
@@ -18,6 +18,10 @@ public class GroupNumericLiteralsTests: DiagnosingTestCase {
              let g = 11_15_1999
              let h = 0o21743
              let i = -53096828347
+             let j = 0000123
+             let k = 0x00000012
+             let l = 0x0000012
+             let m = 0b00010010101
              """,
       expected: """
                 let a = 9_876_543_210
@@ -29,12 +33,19 @@ public class GroupNumericLiteralsTests: DiagnosingTestCase {
                 let g = 11_15_1999
                 let h = 0o21743
                 let i = -53_096_828_347
+                let j = 0_000_123
+                let k = 0x0000_0012
+                let l = 0x0000012
+                let m = 0b000_10010101
                 """)
+    XCTAssertDiagnosed(.groupNumericLiteral(byStride: 3))
     XCTAssertDiagnosed(.groupNumericLiteral(byStride: 3))
     XCTAssertDiagnosed(.groupNumericLiteral(byStride: 3))
     XCTAssertNotDiagnosed(.groupNumericLiteral(byStride: 3))
     XCTAssertDiagnosed(.groupNumericLiteral(byStride: 4))
+    XCTAssertDiagnosed(.groupNumericLiteral(byStride: 4))
     XCTAssertNotDiagnosed(.groupNumericLiteral(byStride: 4))
+    XCTAssertDiagnosed(.groupNumericLiteral(byStride: 8))
     XCTAssertDiagnosed(.groupNumericLiteral(byStride: 8))
     XCTAssertNotDiagnosed(.groupNumericLiteral(byStride: 8))
   }


### PR DESCRIPTION
The rule for grouping numeric literals into segments using "_" delimiters has some hard coded minimum values to determine whether a literal should include delimiters. These values allow writing relatively small literals without delimiters. They don't handle literals with leading 0s very well, because those literals can still be relatively long while having a small magnitude.

I've changed the rule to use the length of the literal, i.e. the number of digits, so that 0 padded literals will include delimiters. The length values match previous behavior, using the length of the previous minimum values.