### PR TITLE
Make linter messages more grammatically and structurally consistent.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
@@ -610,5 +610,5 @@ public class PrettyPrinter {
 extension Diagnostic.Message {
 
   static let moveEndOfLineComment = Diagnostic.Message(
-    .warning, "End-of-line comment exceeds the line length")
+    .warning, "move end-of-line comment that exceeds the line length")
 }

--- a/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
+++ b/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
@@ -56,6 +56,6 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
 
 extension Diagnostic.Message {
   static func variableNameMustBeLowerCamelCase(_ name: String) -> Diagnostic.Message {
-    return .init(.warning, "variable '\(name)' must be lower-camel-case")
+    return .init(.warning, "rename variable '\(name)' using lower-camel-case")
   }
 }

--- a/Sources/SwiftFormatRules/IdentifiersMustBeASCII.swift
+++ b/Sources/SwiftFormatRules/IdentifiersMustBeASCII.swift
@@ -39,7 +39,8 @@ extension Diagnostic.Message {
   {
     return .init(
       .warning,
-      "The identifier '\(identifierName)' contains the following non-ASCII characters: \(invalidCharacters.joined(separator: ", "))"
+      "remove non-ASCII characters from '\(identifierName)': "
+        + "\(invalidCharacters.joined(separator: ", "))"
     )
   }
 }

--- a/Sources/SwiftFormatRules/NoBlockComments.swift
+++ b/Sources/SwiftFormatRules/NoBlockComments.swift
@@ -117,9 +117,10 @@ public final class NoBlockComments: SyntaxFormatRule {
 
 extension Diagnostic.Message {
   static let avoidBlockComment = Diagnostic.Message(
-    .warning, "Replace block comment with line comments.")
+    .warning, "replace block comment with line comments")
+
   static let avoidBlockCommentBetweenCode = Diagnostic.Message(
-    .warning, "Remove block comment inline with code")
+    .warning, "remove block comment inline with code")
 }
 
 extension Trivia {

--- a/Sources/SwiftFormatRules/NoCasesWithOnlyFallthrough.swift
+++ b/Sources/SwiftFormatRules/NoCasesWithOnlyFallthrough.swift
@@ -220,8 +220,6 @@ extension TriviaPiece {
 
 extension Diagnostic.Message {
   static func collapseCase(name: String) -> Diagnostic.Message {
-    return .init(
-      .warning,
-      "\(name) only contains 'fallthrough' and can be combined with a following case")
+    return .init(.warning, "combine fallthrough-only case \(name) with a following case")
   }
 }

--- a/Sources/SwiftFormatRules/NoLeadingUnderscores.swift
+++ b/Sources/SwiftFormatRules/NoLeadingUnderscores.swift
@@ -108,6 +108,6 @@ public final class NoLeadingUnderscores: SyntaxLintRule {
 extension Diagnostic.Message {
 
   static func doNotStartWithUnderscore(identifier: String) -> Diagnostic.Message {
-    return .init(.warning, "identifier \(identifier) should not start with '_'")
+    return .init(.warning, "remove leading '_' from identifier '\(identifier)'")
   }
 }

--- a/Sources/SwiftFormatRules/OnlyOneTrailingClosureArgument.swift
+++ b/Sources/SwiftFormatRules/OnlyOneTrailingClosureArgument.swift
@@ -35,5 +35,5 @@ public final class OnlyOneTrailingClosureArgument: SyntaxLintRule {
 extension Diagnostic.Message {
   static let removeTrailingClosure = Diagnostic.Message(
     .warning,
-    "function call shouldn't have both closure arguments and a trailing closure")
+    "revise function call to avoid using both closure arguments and a trailing closure")
 }

--- a/Sources/SwiftFormatRules/OrderedImports.swift
+++ b/Sources/SwiftFormatRules/OrderedImports.swift
@@ -403,11 +403,11 @@ class Line {
 
 extension Diagnostic.Message {
   static let placeAtTopOfFile = Diagnostic.Message(
-    .warning, "Place imports at the top of the file.")
+    .warning, "place imports at the top of the file")
 
   static func groupImports(before: LineType, after: LineType) -> Diagnostic.Message {
-    return Diagnostic.Message(.warning, "Place \(before) imports before \(after) imports.")
+    return Diagnostic.Message(.warning, "place \(before) imports before \(after) imports")
   }
 
-  static let sortImports = Diagnostic.Message(.warning, "Sort import statements lexicographically.")
+  static let sortImports = Diagnostic.Message(.warning, "sort import statements lexicographically")
 }

--- a/Sources/SwiftFormatRules/UseEnumForNamespacing.swift
+++ b/Sources/SwiftFormatRules/UseEnumForNamespacing.swift
@@ -87,9 +87,6 @@ public final class UseEnumForNamespacing: SyntaxFormatRule {
 
 extension Diagnostic.Message {
   static func convertToEnum(kind: String, name: TokenSyntax) -> Diagnostic.Message {
-    return .init(
-      .warning,
-      "\(kind) '\(name.text)' used as a namespace should be an enum"
-    )
+    return .init(.warning, "replace \(kind) '\(name.text)' with an enum when used as a namespace")
   }
 }

--- a/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
+++ b/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
@@ -145,5 +145,5 @@ public final class UseSynthesizedInitializer: SyntaxLintRule {
 extension Diagnostic.Message {
   static let removeRedundantInitializer = Diagnostic.Message(
     .warning,
-    "initializer is the same as synthesized initializer")
+    "remove initializer and use the synthesized initializer")
 }

--- a/Sources/SwiftFormatRules/UseTripleSlashForDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/UseTripleSlashForDocumentationComments.swift
@@ -20,9 +20,9 @@ import SwiftSyntax
 ///
 /// Lint: If a doc block comment appears, a lint error is raised.
 ///
-/// Format: If a doc block comment appears on its own on a line, or if a doc block comment spans multiple
-///         lines without appearing on the same line as code, it will be replaced with multiple
-///         doc line comments.
+/// Format: If a doc block comment appears on its own on a line, or if a doc block comment spans
+///         multiple lines without appearing on the same line as code, it will be replaced with
+///         multiple doc line comments.
 ///
 /// - SeeAlso: https://google.github.io/swift#general-format
 public final class UseTripleSlashForDocumentationComments: SyntaxFormatRule {
@@ -123,5 +123,5 @@ public final class UseTripleSlashForDocumentationComments: SyntaxFormatRule {
 
 extension Diagnostic.Message {
   static let avoidDocBlockComment = Diagnostic.Message(
-    .warning, "Documentation block comments are not allowed")
+    .warning, "replace documentation block comments with documentation line comments")
 }

--- a/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
@@ -137,7 +137,7 @@ extension Diagnostic.Message {
   static func parametersDontMatch(funcName: String) -> Diagnostic.Message {
     return Diagnostic.Message(
       .warning,
-      "the parameters of \(funcName) don't match the parameters in its documentation"
+      "change the parameters of \(funcName)'s documentation to match its parameters"
     )
   }
 

--- a/Sources/SwiftFormatWhitespaceLinter/WhitespaceLinter.swift
+++ b/Sources/SwiftFormatWhitespaceLinter/WhitespaceLinter.swift
@@ -414,21 +414,21 @@ public class WhitespaceLinter {
 
 extension Diagnostic.Message {
   static let trailingWhitespaceError = Diagnostic.Message(
-    .warning, "[TrailingWhitespace]: remove trailing whitespace.")
+    .warning, "[TrailingWhitespace]: remove trailing whitespace")
 
   static func indentationError(_ spaces: Int) -> Diagnostic.Message {
-    return .init(.warning, "[Indentation]: indentation should be \(spaces) spaces.")
+    return .init(.warning, "[Indentation]: indentation should be \(spaces) spaces")
   }
 
   static func spacingError(_ spaces: Int) -> Diagnostic.Message {
-    return .init(.warning, "[Spacing]: should be \(spaces) spaces.")
+    return .init(.warning, "[Spacing]: should be \(spaces) spaces")
   }
 
-  static let removeLineError = Diagnostic.Message(.warning, "[RemoveLine]: remove line break.")
+  static let removeLineError = Diagnostic.Message(.warning, "[RemoveLine]: remove line break")
 
   static func addLinesError(_ lines: Int) -> Diagnostic.Message {
-    return .init(.warning, "[AddLines]: add \(lines) line breaks.")
+    return .init(.warning, "[AddLines]: add \(lines) line breaks")
   }
 
-  static let lineLengthError = Diagnostic.Message(.warning, "[LineLength]: line is too long.")
+  static let lineLengthError = Diagnostic.Message(.warning, "[LineLength]: line is too long")
 }


### PR DESCRIPTION
I read through all of the existing linter messages, and found the following rules to apply in general. The changes here bring these linter messages in sync with the format of the other existing linter messages.

- Use sentence fragments, starting with lowercase and **not** ending with a period.
- Use the [imperative form](https://en.wikipedia.org/wiki/Imperative_mood) so that the message is a command, instructing the user what to change.
- Start with a verb describing what needs to be changed, potentially include the conditions under which the change is necessary and/or a rationale.