### PR TITLE
Fix extra indentation on closure variables.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -697,7 +697,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
 
   func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
     if let signature = node.signature {
-      before(signature.firstToken, tokens: .break(.open))
+      after(node.leftBrace, tokens: .break(.open))
       if node.statements.count > 0 {
         after(signature.inTok, tokens: .break(.same))
       } else {

--- a/Tests/SwiftFormatPrettyPrintTests/ClosureExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ClosureExprTests.swift
@@ -283,6 +283,54 @@ public class ClosureExprTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 60)
   }
 
+  public func testClosureVariables() {
+    let input =
+      """
+      var someClosure: (Int, Int, Int) -> Bool = {  // a comment
+        (a, b, c) in
+        foo()
+        return true
+      }
+      var someOtherClosure: (Int, Int, Int) -> Bool = {
+        foo($0, $1, $2)
+        return true
+      }
+      class Bar {
+        private lazy var foo = { Foo() }()
+      }
+      class Foo {
+        private lazy var bar = {
+          // do some computations
+          return Bar()
+        }()
+      }
+      """
+    let expected =
+      """
+      var someClosure: (Int, Int, Int) -> Bool = {  // a comment
+        (a, b, c) in
+        foo()
+        return true
+      }
+      var someOtherClosure: (Int, Int, Int) -> Bool = {
+        foo($0, $1, $2)
+        return true
+      }
+      class Bar {
+        private lazy var foo = { Foo() }()
+      }
+      class Foo {
+        private lazy var bar = {
+          // do some computations
+          return Bar()
+        }()
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 100)
+  }
+
   public func testArrayClosures() {
     let input =
       """

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -102,6 +102,7 @@ extension ClosureExprTests {
         ("testClosureCapture", testClosureCapture),
         ("testClosureCaptureWithoutArguments", testClosureCaptureWithoutArguments),
         ("testClosuresWithIfs", testClosuresWithIfs),
+        ("testClosureVariables", testClosureVariables),
         ("testTrailingClosure", testTrailingClosure),
     ]
 }


### PR DESCRIPTION
Extra indentation was applied to closures because the following sequence of tokens occurs when the closure has a signature:`break(.continue), "{", newlines, break(.open)`. When the `break(.open)` is encountered, the pretty printer pushes 2 indents onto the `indentationStack`. The newline between the breaks causes the pretty printer to incorrectly record that the closure's first line break occurs in a continuation line.

Other structures with braces, including closures without a signature, avoid this problem by inserting the `break(.open)` after their left brace instead of inside of the structure. I have moved the break so that it always precedes any newlines inside of the closure's braces.