### PR TITLE
[Format Range] Format in a specific range POC

### DIFF
--- a/Sources/SwiftFormat/SwiftFormatter.swift
+++ b/Sources/SwiftFormat/SwiftFormatter.swift
@@ -48,7 +48,7 @@ public final class SwiftFormatter {
   ///     be written.
   /// - Throws: If an unrecoverable error occurs when formatting the code.
   public func format<Output: TextOutputStream>(
-    contentsOf url: URL, to outputStream: inout Output
+    contentsOf url: URL, to outputStream: inout Output, applicationRange: SourceRange? = nil
   ) throws {
     guard FileManager.default.isReadableFile(atPath: url.path) else {
       throw SwiftFormatError.fileNotReadable
@@ -58,7 +58,7 @@ public final class SwiftFormatter {
       throw SwiftFormatError.isDirectory
     }
     let sourceFile = try SyntaxParser.parse(url)
-    try format(syntax: sourceFile, assumingFileURL: url, to: &outputStream)
+    try format(syntax: sourceFile, assumingFileURL: url, to: &outputStream, applicationRange: applicationRange)
   }
 
   /// Formats the given Swift source code and writes the result to an output stream.
@@ -89,13 +89,14 @@ public final class SwiftFormatter {
   ///     be written.
   /// - Throws: If an unrecoverable error occurs when formatting the code.
   public func format<Output: TextOutputStream>(
-    syntax: SourceFileSyntax, assumingFileURL url: URL?, to outputStream: inout Output
+    syntax: SourceFileSyntax, assumingFileURL url: URL?, to outputStream: inout Output,
+    applicationRange: SourceRange? = nil
   ) throws {
     let assumedURL = url ?? URL(fileURLWithPath: "source")
 
     let context = Context(
       configuration: configuration, diagnosticEngine: diagnosticEngine, fileURL: assumedURL,
-      sourceFileSyntax: syntax)
+      sourceFileSyntax: syntax, applicationRange: applicationRange)
     let pipeline = FormatPipeline(context: context)
     let transformedSyntax = pipeline.visit(syntax)
 

--- a/Sources/SwiftFormatCore/Context.swift
+++ b/Sources/SwiftFormatCore/Context.swift
@@ -52,12 +52,18 @@ public class Context {
   /// Contains the rules have been disabled by comments for certain line numbers.
   public let ruleMask: RuleMask
 
+  /// Contains the range of source code to be formatted.
+  ///
+  /// `nil` idicates that the whole file should be formatted
+  public let applicationRange: SourceRange?
+
   /// Creates a new Context with the provided configuration, diagnostic engine, and file URL.
   public init(
     configuration: Configuration,
     diagnosticEngine: DiagnosticEngine?,
     fileURL: URL,
-    sourceFileSyntax: SourceFileSyntax
+    sourceFileSyntax: SourceFileSyntax,
+    applicationRange: SourceRange? = nil
   ) {
     self.configuration = configuration
     self.diagnosticEngine = diagnosticEngine
@@ -69,6 +75,7 @@ public class Context {
       syntaxNode: sourceFileSyntax,
       sourceLocationConverter: sourceLocationConverter
     )
+    self.applicationRange = applicationRange
   }
 
   /// Given a rule's name and the node it is examining, determine if the rule is disabled at this

--- a/Sources/SwiftFormatPrettyPrint/Comment.swift
+++ b/Sources/SwiftFormatPrettyPrint/Comment.swift
@@ -64,7 +64,7 @@ struct Comment {
     }
   }
 
-  func print(indent: [Indent]) -> String {
+  func print() -> String {
     switch self.kind {
     case .line, .docLine:
       let separator = "\n" + kind.prefix

--- a/Sources/SwiftFormatPrettyPrint/Token.swift
+++ b/Sources/SwiftFormatPrettyPrint/Token.swift
@@ -105,7 +105,7 @@ enum BreakKind: Equatable {
 }
 
 enum Token {
-  case syntax(String)
+  case syntax(TokenSyntax)
   case open(GroupBreakStyle)
   case close
   case `break`(BreakKind, size: Int, ignoresDiscretionary: Bool)
@@ -141,5 +141,40 @@ enum Token {
 
   static func verbatim(text: String) -> Token {
     return Token.verbatim(Verbatim(text: text))
+  }
+}
+
+extension TokenSyntax {
+  var printableText: String {
+    if leadingTrivia.hasBackticks && trailingTrivia.hasBackticks {
+      return "`\(text)`"
+    } else {
+      return text
+    }
+  }
+}
+
+extension Trivia: TextOutputStreamable {
+  public func write<Target>(to target: inout Target) where Target : TextOutputStream {
+    forEach { triviaPiece in
+      triviaPiece.write(to: &target)
+    }
+  }
+}
+
+extension Array where Element == Token {
+  func lineInCode() -> [Int] {
+    var result = Array<Int>(repeating: 0, count: self.count)
+    var acc = 1
+    
+    for (idx, token) in self.enumerated() {
+      if case let .newlines(count, _) = token {
+        acc += count
+      }
+      
+      result[idx] = acc
+    }
+    
+    return result
   }
 }

--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -786,7 +786,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
     // TODO: For now, just use the raw text of the node and don't try to format it deeper. In the
     // future, we should find a way to format the expression but without wrapping so that at least
     // internal whitespace is fixed.
-    appendToken(.syntax(node.description))
+    //FIXME: how to handle it? Children?
     // Visiting children is not needed here.
     return .skipChildren
   }
@@ -1518,15 +1518,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
   func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
     extractLeadingTrivia(token)
     appendBeforeTokens(token)
-
-    let text: String
-    if token.leadingTrivia.hasBackticks && token.trailingTrivia.hasBackticks {
-      text = "`\(token.text)`"
-    } else {
-      text = token.text
-    }
-    appendToken(.syntax(text))
-
+    appendToken(.syntax(token))
     appendAfterTokensAndTrailingComments(token)
 
     // It doesn't matter what we return here, tokens do not have children.

--- a/Tests/SwiftFormatPrettyPrintTests/ApplicationRangeTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ApplicationRangeTests.swift
@@ -1,0 +1,160 @@
+import SwiftSyntax
+
+public class ApplicationRangeTests: PrettyPrintTestCase {
+  public func testFormatNestedFunc() {
+    let input =
+      """
+      /// this is doc comment
+      ///
+      /// another line
+      struct X {
+      func f() {
+      func g() {}
+      }
+      }
+      """
+
+    let expected =
+      """
+      /// this is doc comment
+      ///
+      /// another line
+      struct X {
+      func f() {
+        func g() {}
+      }
+      }
+      """
+
+    assertPrettyPrintEqual(input: input,
+                           expected: expected,
+                           linelength: 45,
+                           applicationRangeBuilder: { sourceFileSyntax in
+      let startRange = SourceLocation(offset: 67, converter: SourceLocationConverter(file: "", tree: sourceFileSyntax))
+      let endRange = SourceLocation(offset: 78, converter: SourceLocationConverter(file: "", tree: sourceFileSyntax))
+      return SourceRange(start: startRange, end: endRange)
+    })
+  }
+
+  public func testFormatBothNestedFuncs() {
+    let input =
+      """
+      struct X {
+      func f() {
+      func g() {}
+      }
+      }
+      """
+
+    let expected =
+      """
+      struct X {
+        func f() {
+          func g() {}
+        }
+      }
+      """
+
+    assertPrettyPrintEqual(input: input,
+                           expected: expected,
+                           linelength: 45,
+                           applicationRangeBuilder: { sourceFileSyntax in
+      let startRange = SourceLocation(offset: 11, converter: SourceLocationConverter(file: "", tree: sourceFileSyntax))
+      let endRange = SourceLocation(offset: 34, converter: SourceLocationConverter(file: "", tree: sourceFileSyntax))
+      return SourceRange(start: startRange, end: endRange)
+    })
+  }
+  
+  public func testFormatWholeFileWithRange_isSameAsWithoutRangeSpecified() {
+    let input =
+      """
+      struct X {
+      func f() {
+      func g() {}
+      }
+      }
+      """
+
+    let expected =
+      """
+      struct X {
+        func f() {
+          func g() {}
+        }
+      }
+      """
+
+    assertPrettyPrintEqual(input: input,
+                           expected: expected,
+                           linelength: 45,
+                           applicationRangeBuilder: { sourceFileSyntax in
+      let startRange = SourceLocation(offset: 0, converter: SourceLocationConverter(file: "", tree: sourceFileSyntax))
+      let endRange = SourceLocation(offset: 37, converter: SourceLocationConverter(file: "", tree: sourceFileSyntax))
+      return SourceRange(start: startRange, end: endRange)
+    })
+  }
+  
+  public func testFormatNothingInAlreadyFormatedCode() {
+    let input =
+    """
+    struct X {
+      let y: Int
+    }
+    """
+    
+    let expected =
+    """
+    struct X {
+      let y: Int
+    }
+    """
+    
+    assertPrettyPrintEqual(input: input,
+                           expected: expected,
+                           linelength: 45,
+                           applicationRangeBuilder: { sourceFileSyntax in
+      let startRange = SourceLocation(offset: 0, converter: SourceLocationConverter(file: "", tree: sourceFileSyntax))
+      let endRange = SourceLocation(offset: 25, converter: SourceLocationConverter(file: "", tree: sourceFileSyntax))
+      return SourceRange(start: startRange, end: endRange)
+    })
+  }
+  
+  // This test fails ;(
+  public func testFormatOneStruct() {
+    let input =
+      """
+      struct MyStruct {
+        var memberValue: Int
+        var someValue: Int { get { return memberValue + 2 } set(newValue) { memberValue = newValue } }
+      }
+      struct MyStruct {
+        var memberValue: Int
+        var someValue: Int { @objc get { return memberValue + 2 } @objc(isEnabled) set(newValue) { memberValue = newValue } }
+      }
+      """
+
+    let expected =
+      """
+      struct MyStruct {
+        var memberValue: Int
+        var someValue: Int {
+          get { return memberValue + 2 }
+          set(newValue) { memberValue = newValue }
+        }
+      }
+      struct MyStruct {
+        var memberValue: Int
+        var someValue: Int { @objc get { return memberValue + 2 } @objc(isEnabled) set(newValue) { memberValue = newValue } }
+      }
+      """
+
+    assertPrettyPrintEqual(input: input,
+                           expected: expected,
+                           linelength: 45,
+                           applicationRangeBuilder: { sourceFileSyntax in
+      let startRange = SourceLocation(offset: 0, converter: SourceLocationConverter(file: "", tree: sourceFileSyntax))
+      let endRange = SourceLocation(offset: 140, converter: SourceLocationConverter(file: "", tree: sourceFileSyntax))
+      return SourceRange(start: startRange, end: endRange)
+    })
+  }
+}


### PR DESCRIPTION
- Add application range var to the Formatting Context
- Pass `TokenSyntax` to the PrettyPrinter
- PrettyPrinter uses the leading and trailing trivia in case when token is not in applicable range.
- Verify its work by having some minimal tests

Previous discussions here: https://forums.swift.org/t/range-formatting/28060

PS. I was thinking it would be a good idea still to make a PR and continue discussions here, potentially improving the PR and eventually merging.