### PR TITLE
Improve multiline string wrapping.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/Token.swift
+++ b/Sources/SwiftFormatPrettyPrint/Token.swift
@@ -104,13 +104,36 @@ enum BreakKind: Equatable {
   static let close = BreakKind.close(mustBreak: true)
 }
 
+enum NewlineKind {
+  /// A newline that has been inserted by the formatter independent of the source code given by the
+  /// user (for example, between the getter and setter blocks of a computed property).
+  ///
+  /// Flexible newlines are only printed if a discretionary or mandatory newline has not yet been
+  /// printed at the same location, and only up to the maximum allowed by the formatter
+  /// configuration.
+  case flexible
+
+  /// A newline that was present in the source code given by the user (that is, at the user's
+  /// discretion).
+  ///
+  /// Discretionary newlines are printed after excluding any other consecutive newlines printed thus
+  /// far at the same location, and only up to the maximum allowed by the formatter configuration.
+  case discretionary
+
+  /// A mandatory newline that must always be printed (for example, in a multiline string literal).
+  ///
+  /// Mandatory newlines are never omitted by the pretty printer, even if it would result in a
+  /// number of consecutive newlines that exceeds that allowed by the formatter configuration.
+  case mandatory
+}
+
 enum Token {
   case syntax(String)
   case open(GroupBreakStyle)
   case close
   case `break`(BreakKind, size: Int, ignoresDiscretionary: Bool)
   case space(size: Int, flexible: Bool)
-  case newlines(Int, discretionary: Bool)
+  case newlines(Int, kind: NewlineKind)
   case comment(Comment, wasEndOfLine: Bool)
   case verbatim(Verbatim)
 
@@ -121,10 +144,12 @@ enum Token {
     return Token.open(breakStyle)
   }
 
-  static let newline = Token.newlines(1, discretionary: false)
+  /// A single, flexible newline.
+  static let newline = Token.newlines(1, kind: .flexible)
 
-  static func newline(discretionary: Bool) -> Token {
-    return Token.newlines(1, discretionary: discretionary)
+  /// Returns a single newline with the given kind.
+  static func newline(kind: NewlineKind) -> Token {
+    return Token.newlines(1, kind: kind)
   }
 
   static let space = Token.space(size: 1, flexible: false)

--- a/Tests/SwiftFormatPrettyPrintTests/StringTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/StringTests.swift
@@ -21,4 +21,160 @@ public class StringTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 35)
   }
+
+  public func testMultilineStringOpenQuotesDoNotWrapIfStringIsVeryLong() {
+    let input =
+      #"""
+      let someString = """
+        this string's total
+        length will be longer
+        than the column limit
+        even though none of
+        its individual lines
+        are.
+        """
+      """#
+
+    assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 30)
+  }
+
+  public func testMultilineStringIsReindentedCorrectly() {
+    let input =
+      #"""
+      functionCall(longArgument, anotherLongArgument, """
+            some multi-
+              line string
+            """)
+      """#
+
+    let expected =
+      #"""
+      functionCall(
+        longArgument,
+        anotherLongArgument,
+        """
+        some multi-
+          line string
+        """)
+
+      """#
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 25)
+  }
+
+  public func testMultilineStringInterpolations() {
+    let input =
+      #"""
+      let x = """
+        \(1) 2 3
+        4 \(5) 6
+        7 8 \(9)
+        """
+      """#
+
+    assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 25)
+  }
+
+  public func testMultilineRawString() {
+    let input =
+      ##"""
+      let x = #"""
+        """who would
+        ever do this"""
+        """#
+      """##
+
+    assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 25)
+  }
+
+  public func testMultilineRawStringOpenQuotesWrap() {
+    let input =
+      #"""
+      let aLongVariableName = """
+        some
+        multi-
+        line
+        string
+        """
+      """#
+
+    let expected =
+      #"""
+      let aLongVariableName
+        = """
+        some
+        multi-
+        line
+        string
+        """
+
+      """#
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 25)
+  }
+
+  public func testMultilineStringAutocorrectMisalignedLines() {
+    let input =
+      #"""
+      let x = """
+          the
+        second
+          line is
+          wrong
+          """
+      """#
+
+    let expected =
+      #"""
+      let x = """
+        the
+        second
+        line is
+        wrong
+        """
+
+      """#
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 25)
+  }
+
+  public func testMultilineStringKeepsBlankLines() {
+    // This test not only ensures that the blank lines are retained in the first place, but that
+    // the newlines are mandatory and not collapsed to the maximum number allowed by the formatter
+    // configuration.
+    let input =
+      #"""
+      let x = """
+
+
+          there should be
+
+
+
+
+          gaps all around here
+
+
+          """
+      """#
+
+    let expected =
+      #"""
+      let x = """
+
+
+        there should be
+
+
+
+
+        gaps all around here
+
+
+        """
+
+      """#
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 25)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -405,6 +405,13 @@ extension StringTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__StringTests = [
+        ("testMultilineRawString", testMultilineRawString),
+        ("testMultilineRawStringOpenQuotesWrap", testMultilineRawStringOpenQuotesWrap),
+        ("testMultilineStringAutocorrectMisalignedLines", testMultilineStringAutocorrectMisalignedLines),
+        ("testMultilineStringInterpolations", testMultilineStringInterpolations),
+        ("testMultilineStringIsReindentedCorrectly", testMultilineStringIsReindentedCorrectly),
+        ("testMultilineStringKeepsBlankLines", testMultilineStringKeepsBlankLines),
+        ("testMultilineStringOpenQuotesDoNotWrapIfStringIsVeryLong", testMultilineStringOpenQuotesDoNotWrapIfStringIsVeryLong),
         ("testStrings", testStrings),
     ]
 }


### PR DESCRIPTION
This fixes a couple oddities in the way multiline strings were being
handled:

* Previously, the entire text of the multiline string literal was
  inserted as a single syntax node. This meant that the opening
  quotes (and tokens preceding them up to the closest break) would
  wrap unnecessarily if the string's *total* length was longer than
  the column limit, even if the opening line wasn't.

  Now, we treat each line of the string literal individually, so
  the opening quotes only wrap if they would be the only thing that
  didn't fit on the line.

* The leading whitespace was also preserved before, so we made no
  attempt at reindenting the multiline strings according to what the
  pretty printer was doing. Now we compensate for that so the pretty
  printer ensures that multiline strings line up with other tokens
  based on the current indentation.