### PR TITLE
Support subscripts in AddModifierRewriter.

### DIFF
--- a/Sources/SwiftFormatRules/AddModifierRewriter.swift
+++ b/Sources/SwiftFormatRules/AddModifierRewriter.swift
@@ -132,6 +132,18 @@ private final class AddModifierRewriter: SyntaxRewriter {
     return node.withModifiers(newModifiers)
   }
 
+  override func visit(_ node: SubscriptDeclSyntax) -> DeclSyntax {
+    // Check for modifiers, and, if none, insert the modifier and relocate trivia from the displaced
+    // token.
+    guard let modifiers = node.modifiers else {
+      let nodeWithModifier = node.addModifier(modifierKeyword)
+      return nodeByRelocatingTrivia(in: nodeWithModifier) { $0.modifiers }
+    }
+    guard modifiers.accessLevelModifier == nil else { return node }
+    let newModifiers = modifiers.prepend(modifier: modifierKeyword)
+    return node.withModifiers(newModifiers)
+  }
+
   /// Moves trivia in the given node to correct the placement of potentially displaced trivia in the
   /// node after the first modifier was added to the given node. The added modifier is assumed to be
   /// the first and only modifier of the node. After the first modifier is added to a node, any

--- a/Tests/SwiftFormatRulesTests/NoAccessLevelOnExtensionDeclarationTests.swift
+++ b/Tests/SwiftFormatRulesTests/NoAccessLevelOnExtensionDeclarationTests.swift
@@ -18,10 +18,12 @@ public class NoAccessLevelOnExtensionDeclarationTests: DiagnosingTestCase {
                // Comment 3
                static func someFunc() {}
                init() {}
+               subscript(index: Int) -> Element {}
                protocol SomeProtocol {}
                class SomeClass {}
                struct SomeStruct {}
                enum SomeEnum {}
+               typealias Foo = Bar
              }
              internal extension Bar {
                var a: Int
@@ -38,10 +40,12 @@ public class NoAccessLevelOnExtensionDeclarationTests: DiagnosingTestCase {
                   // Comment 3
                   public static func someFunc() {}
                   public init() {}
+                  public subscript(index: Int) -> Element {}
                   public protocol SomeProtocol {}
                   public class SomeClass {}
                   public struct SomeStruct {}
                   public enum SomeEnum {}
+                  public typealias Foo = Bar
                 }
                 extension Bar {
                   var a: Int


### PR DESCRIPTION
This fixes the `NoAccessLevelOnExtensionDeclaration` rule, where an access level on an `extension` decl was not being moved to subscripts inside it.

This change also adds some test coverage for `typealias`es while I was in here.