### PR TITLE
Trivia and generic changes post-5.1.

### DIFF
--- a/Documentation/PrettyPrinter.md
+++ b/Documentation/PrettyPrinter.md
@@ -304,8 +304,7 @@ The only types of trivia we are interested in are newlines and comments. Since
 these only appear as leading trivia, we don't need to look at trailing trivia.
 It is important to note that `SwiftSyntax` always attaches comments as the
 leading trivia on the following token.  Spaces are handled directly by inserting
-`break` and `space` tokens, and backticks are handled in the *scan* and *print*
-phases of the algorithm, after token generation.
+`break` and `space` tokens.
 
 When examining trivia for comments, a distinction is made for end-of-line
 comments:

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,9 +23,9 @@
         "package": "SwiftSyntax",
         "repositoryURL": "https://github.com/apple/swift-syntax",
         "state": {
-          "branch": null,
-          "revision": "3e3eb191fcdbecc6031522660c4ed6ce25282c25",
-          "version": "0.50100.0"
+          "branch": "swift-DEVELOPMENT-SNAPSHOT-2019-09-26-m",
+          "revision": "c915603ef6815e0ec09cec33fe120be735798131",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,10 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.4.0"),
-    .package(url: "https://github.com/apple/swift-syntax", .exact("0.50100.0")),
+    .package(
+      url: "https://github.com/apple/swift-syntax",
+      .revision("swift-DEVELOPMENT-SNAPSHOT-2019-09-26-m")
+    ),
   ],
   targets: [
     .target(

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ is also expressed in the `SwiftSyntax` dependency in
 | Xcode Release | Swift Version                           | `swift-format` Branch |
 |:-------------:|:---------------------------------------:|:----------------------|
 | Xcode 11.0    | Swift 5.1                               | `swift-5.1-branch`    |
+| –             | swift-DEVELOPMENT-SNAPSHOT-2019-09-26-a | `master`              |
 
 For example, if you are using Xcode 11.0 (Swift 5.1), you can check out and
 build `swift-format` using the following commands:

--- a/Sources/SwiftFormatCore/Trivia+Convenience.swift
+++ b/Sources/SwiftFormatCore/Trivia+Convenience.swift
@@ -71,13 +71,6 @@ extension Trivia {
     return false
   }
 
-  public var hasBackticks: Bool {
-    for piece in self {
-      if case .backticks = piece { return true }
-    }
-    return false
-  }
-
   /// Returns this set of trivia, without any whitespace characters.
   public func withoutSpaces() -> Trivia {
     return Trivia(
@@ -185,8 +178,6 @@ extension Trivia {
         prev = .verticalTabs(l + r)
       case (.garbageText(let l), .garbageText(let r)):
         prev = .garbageText(l + r)
-      case (.backticks(let l), .backticks(let r)):
-        prev = .backticks(l + r)
       case (.formfeeds(let l), .formfeeds(let r)):
         prev = .formfeeds(l + r)
       default:

--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1513,15 +1513,24 @@ private final class TokenStreamCreator: SyntaxVisitor {
     return .visitChildren
   }
 
-  func visit(_ node: SameTypeRequirementSyntax) -> SyntaxVisitorContinueKind {
+  func visit(_ node: GenericRequirementSyntax) -> SyntaxVisitorContinueKind {
     before(node.firstToken, tokens: .open)
-    before(node.equalityToken, tokens: .break)
-    after(node.equalityToken, tokens: .space)
     if let trailingComma = node.trailingComma {
       after(trailingComma, tokens: .close, .break(.same))
     } else {
       after(node.lastToken, tokens: .close)
     }
+    return .visitChildren
+  }
+
+  func visit(_ node: SameTypeRequirementSyntax) -> SyntaxVisitorContinueKind {
+    before(node.equalityToken, tokens: .break)
+    after(node.equalityToken, tokens: .space)
+    return .visitChildren
+  }
+
+  func visit(_ node: ConformanceRequirementSyntax) -> SyntaxVisitorContinueKind {
+    after(node.colon, tokens: .break)
     return .visitChildren
   }
 
@@ -1577,19 +1586,6 @@ private final class TokenStreamCreator: SyntaxVisitor {
     return .visitChildren
   }
 
-  func visit(_ node: ConformanceRequirementSyntax) -> SyntaxVisitorContinueKind {
-    before(node.firstToken, tokens: .open)
-    after(node.colon, tokens: .break)
-
-    if let trailingComma = node.trailingComma {
-      after(trailingComma, tokens: .close, .break(.same))
-    } else {
-      after(node.lastToken, tokens: .close)
-    }
-
-    return .visitChildren
-  }
-
   func visit(_ node: MatchingPatternConditionSyntax) -> SyntaxVisitorContinueKind {
     before(node.firstToken, tokens: .open)
     after(node.caseKeyword, tokens: .break)
@@ -1626,14 +1622,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
       appendMultilineStringSegments(at: pendingSegmentIndex)
     } else {
       // Otherwise, it's just a regular token, so add the text as-is.
-      let text: String
-      if token.leadingTrivia.hasBackticks && token.trailingTrivia.hasBackticks {
-        text = "`\(token.text)`"
-      } else {
-        text = token.text
-      }
-
-      appendToken(.syntax(text))
+      appendToken(.syntax(token.text))
     }
 
     appendAfterTokensAndTrailingComments(token)


### PR DESCRIPTION
- "master" branch is now building against development snapshot
  `swift-DEVELOPMENT-SNAPSHOT-2019-09-26-a`.
- Backticks have been removed from trivia; they are now part of the
  token text itself.
- The trailing comma of generic where clause elements has been moved
  into a wrapper node.