### PR TITLE
Remove false warnings from synthesized initializer rule.

### DIFF
--- a/Tests/SwiftFormatRulesTests/UseSynthesizedInitializerTests.swift
+++ b/Tests/SwiftFormatRulesTests/UseSynthesizedInitializerTests.swift
@@ -5,50 +5,269 @@ import XCTest
 @testable import SwiftFormatRules
 
 public class UseSynthesizedInitializerTests: DiagnosingTestCase {
-  public func testRedundantCustomInitializer() {
+  public func testMemberwiseInitializerIsDiagnosed() {
     let input =
       """
       public struct Person {
 
-        public var name: String = "John Doe"
-        let phoneNumber: String?
-        private let address: String = "123 Happy St"
+        public var name: String
+        let phoneNumber: String
+        private let address: String
 
-        init(name: String = "John Doe", phoneNumber: String?, address: String) {
+        init(name: String, phoneNumber: String, address: String) {
+          self.name = name
+          self.address = address
+          self.phoneNumber = phoneNumber
+        }
+      }
+      """
+
+    performLint(UseSynthesizedInitializer.self, input: input)
+    XCTAssertDiagnosed(.removeRedundantInitializer)
+    XCTAssertNotDiagnosed(.removeRedundantInitializer)
+  }
+
+  public func testMemberwiseInitializerWithDefaultArgumentIsDiagnosed() {
+     let input =
+       """
+       public struct Person {
+
+         public var name: String = "John Doe"
+         let phoneNumber: String
+         private let address: String
+
+         init(name: String = "John Doe", phoneNumber: String, address: String) {
+           self.name = name
+           self.address = address
+           self.phoneNumber = phoneNumber
+         }
+       }
+       """
+
+     performLint(UseSynthesizedInitializer.self, input: input)
+     XCTAssertDiagnosed(.removeRedundantInitializer)
+     XCTAssertNotDiagnosed(.removeRedundantInitializer)
+   }
+
+  public func testCustomInitializerVoidsSynthesizedInitializerWarning() {
+    // The compiler won't create a memberwise initializer when there are any other initializers.
+    // It's valid to have a memberwise initializer when there are any custom initializers.
+    let input =
+      """
+      public struct Person {
+
+        public var name: String
+        let phoneNumber: String
+        private let address: String
+
+        init(name: String, phoneNumber: String, address: String) {
           self.name = name
           self.address = address
           self.phoneNumber = phoneNumber
         }
 
-        init(name: String, phoneNumber: String?, address: String) {
+        init(name: String, phoneNumber: String, address: String) {
           self.name = name
           self.phoneNumber = "1234578910"
           self.address = address
         }
-        init(name: String, phoneNumber: String? = "123456789", address: String) {
+      }
+      """
+
+    performLint(UseSynthesizedInitializer.self, input: input)
+    XCTAssertNotDiagnosed(.removeRedundantInitializer)
+  }
+
+  public func testMemberwiseInitializerWithDefaultArgument() {
+     let input =
+       """
+       public struct Person {
+
+         public var name: String
+         let phoneNumber: String
+         private let address: String
+
+         init(name: String = "Jane Doe", phoneNumber: String, address: String) {
+           self.name = name
+           self.address = address
+           self.phoneNumber = phoneNumber
+         }
+       }
+       """
+
+    performLint(UseSynthesizedInitializer.self, input: input)
+    XCTAssertNotDiagnosed(.removeRedundantInitializer)
+  }
+
+  public func testMemberwiseInitializerWithNonMatchingDefaultValues() {
+     let input =
+       """
+       public struct Person {
+
+         public var name: String = "John Doe"
+         let phoneNumber: String
+         private let address: String
+
+         init(name: String = "Jane Doe", phoneNumber: String, address: String) {
+           self.name = name
+           self.address = address
+           self.phoneNumber = phoneNumber
+         }
+       }
+       """
+
+    performLint(UseSynthesizedInitializer.self, input: input)
+    XCTAssertNotDiagnosed(.removeRedundantInitializer)
+  }
+
+  public func testMemberwiseInitializerMissingDefaultValues() {
+    // When the initializer doesn't contain a matching default argument, then it isn't equivalent to
+    // the synthesized memberwise initializer.
+    let input =
+      """
+      public struct Person {
+
+        public var name: String
+        var phoneNumber: String = "+15555550101"
+        private let address: String
+
+        init(name: String, phoneNumber: String, address: String) {
           self.name = name
-          self.phoneNumber = phoneNumber
           self.address = address
-        }
-        public init(name: String, phoneNumber: String?, address: String) {
-          self.name = name
           self.phoneNumber = phoneNumber
-          self.address = address
-        }
-        init?(name: String, phoneNumber: String?, address: String) {
-          self.name = name
-          self.phoneNumber = phoneNumber
-          self.address = address
-        }
-        init(name: String, phoneNumber: String?, address: String) throws {
-          self.name = name
-          self.phoneNumber = phoneNumber
-          self.address = address
         }
       }
       """
+
     performLint(UseSynthesizedInitializer.self, input: input)
-    XCTAssertDiagnosed(.removeRedundantInitializer)
+    XCTAssertNotDiagnosed(.removeRedundantInitializer)
+  }
+
+  public func testCustomInitializerWithMismatchedTypes() {
+    let input =
+      """
+      public struct Person {
+
+        public var name: String
+        var phoneNumber: String?
+        private let address: String
+
+        init(name: String, phoneNumber: String, address: String) {
+          self.name = name
+          self.address = address
+          self.phoneNumber = phoneNumber
+        }
+      }
+      """
+
+    performLint(UseSynthesizedInitializer.self, input: input)
+    XCTAssertNotDiagnosed(.removeRedundantInitializer)
+  }
+
+  public func testCustomInitializerWithExtraParameters() {
+    let input =
+      """
+      public struct Person {
+
+        public var name: String
+        var phoneNumber: String?
+        private let address: String
+
+        init(name: String, phoneNumber: String?, address: String, anotherArg: Int) {
+          self.name = name
+          self.address = address
+          self.phoneNumber = phoneNumber
+        }
+      }
+      """
+
+    performLint(UseSynthesizedInitializer.self, input: input)
+    XCTAssertNotDiagnosed(.removeRedundantInitializer)
+  }
+
+  public func testCustomInitializerWithExtraStatements() {
+    let input =
+      #"""
+      public struct Person {
+
+        public var name: String
+        var phoneNumber: String?
+        private let address: String
+
+        init(name: String, phoneNumber: String?, address: String) {
+          self.name = name
+          self.address = address
+          self.phoneNumber = phoneNumber
+
+          print("phoneNumber: \(self.phoneNumber)")
+        }
+      }
+      """#
+
+    performLint(UseSynthesizedInitializer.self, input: input)
+    XCTAssertNotDiagnosed(.removeRedundantInitializer)
+  }
+
+  public func testFailableMemberwiseInitializerIsNotDiagnosed() {
+    let input =
+      """
+      public struct Person {
+
+        public var name: String
+        let phoneNumber: String
+        private let address: String
+
+        init?(name: String, phoneNumber: String, address: String) {
+          self.name = name
+          self.address = address
+          self.phoneNumber = phoneNumber
+        }
+      }
+      """
+
+    performLint(UseSynthesizedInitializer.self, input: input)
+    XCTAssertNotDiagnosed(.removeRedundantInitializer)
+  }
+
+  public func testThrowingMemberwiseInitializerIsNotDiagnosed() {
+    let input =
+      """
+      public struct Person {
+
+        public var name: String
+        let phoneNumber: String
+        private let address: String
+
+        init(name: String, phoneNumber: String, address: String) throws {
+          self.name = name
+          self.address = address
+          self.phoneNumber = phoneNumber
+        }
+      }
+      """
+
+    performLint(UseSynthesizedInitializer.self, input: input)
+    XCTAssertNotDiagnosed(.removeRedundantInitializer)
+  }
+
+  public func testPublicMemberwiseInitializerIsNotDiagnosed() {
+    let input =
+      """
+      public struct Person {
+
+        public var name: String
+        let phoneNumber: String
+        private let address: String
+
+        public init(name: String, phoneNumber: String, address: String) {
+          self.name = name
+          self.address = address
+          self.phoneNumber = phoneNumber
+        }
+      }
+      """
+
+    performLint(UseSynthesizedInitializer.self, input: input)
     XCTAssertNotDiagnosed(.removeRedundantInitializer)
   }
 }

--- a/Tests/SwiftFormatRulesTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatRulesTests/XCTestManifests.swift
@@ -354,7 +354,18 @@ extension UseSynthesizedInitializerTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__UseSynthesizedInitializerTests = [
-        ("testRedundantCustomInitializer", testRedundantCustomInitializer),
+        ("testCustomInitializerVoidsSynthesizedInitializerWarning", testCustomInitializerVoidsSynthesizedInitializerWarning),
+        ("testCustomInitializerWithExtraParameters", testCustomInitializerWithExtraParameters),
+        ("testCustomInitializerWithExtraStatements", testCustomInitializerWithExtraStatements),
+        ("testCustomInitializerWithMismatchedTypes", testCustomInitializerWithMismatchedTypes),
+        ("testFailableMemberwiseInitializerIsNotDiagnosed", testFailableMemberwiseInitializerIsNotDiagnosed),
+        ("testMemberwiseInitializerIsDiagnosed", testMemberwiseInitializerIsDiagnosed),
+        ("testMemberwiseInitializerMissingDefaultValues", testMemberwiseInitializerMissingDefaultValues),
+        ("testMemberwiseInitializerWithDefaultArgument", testMemberwiseInitializerWithDefaultArgument),
+        ("testMemberwiseInitializerWithDefaultArgumentIsDiagnosed", testMemberwiseInitializerWithDefaultArgumentIsDiagnosed),
+        ("testMemberwiseInitializerWithNonMatchingDefaultValues", testMemberwiseInitializerWithNonMatchingDefaultValues),
+        ("testPublicMemberwiseInitializerIsNotDiagnosed", testPublicMemberwiseInitializerIsNotDiagnosed),
+        ("testThrowingMemberwiseInitializerIsNotDiagnosed", testThrowingMemberwiseInitializerIsNotDiagnosed),
     ]
 }
 


### PR DESCRIPTION
The synthesized initializer rule didn't consider two rules of the memberwise initializer for structs:
- The synthesized initializer is only available when there are no initializers.
- The synthesized initializer provides default arguments that exactly match the default values of corresponding properties.

The rule verifies that the struct only contains initializers that can be replaced by synthesized memberwise initializer(s). Otherwise, there is no warning because the synthesized initializer isn't created for structs that have any custom initializers and the custom initializers cannot be removed.

The rule verifies that any default arguments on the parameters match default values on corresponding properties. There was support for verifying that a matching default argument exists on a parameter whose property has a default value, but all other default arguments were ignored.

Finally, I revised the test suite for this rule to independently verify the various conditions that do and do not trigger the diagnostic.