### PR TITLE
Gracefully transition from function call -> tuple expr.

### DIFF
--- a/Sources/SwiftFormatRules/NoLabelsInCasePatterns.swift
+++ b/Sources/SwiftFormatRules/NoLabelsInCasePatterns.swift
@@ -14,6 +14,20 @@ import Foundation
 import SwiftFormatCore
 import SwiftSyntax
 
+// FIXME: Remove this once we've completely moved up to a version of SwiftSyntax that has
+// consolidated the TupleExprElement and FunctionCallArgument nodes.
+#if HAS_CONSOLIDATED_TUPLE_AND_FUNCTION_CALL_SYNTAX
+fileprivate typealias FunctionCallArgumentSyntax = TupleExprElementSyntax
+
+extension SyntaxFactory {
+  fileprivate static func makeFunctionCallArgumentList(_ arguments: [TupleExprElementSyntax])
+    -> TupleExprElementListSyntax
+  {
+    return makeTupleExprElementList(arguments)
+  }
+}
+#endif
+
 /// Redundant labels are forbidden in case patterns.
 ///
 /// In practice, *all* case pattern labels should be redundant.


### PR DESCRIPTION
Recent changes in the syntax tree folded function call arguments into
tuple expressions. This change introduces some conditional compilation
directives that let us build under old and new toolchains while we
migrate some infrastructure.

This was tested with the 09-26 dev snapshot and the 10-21 snapshot
(which explains the need for the GenericRequirement condition, as it
was reverted during that time and only put back after the 10-21
snapshot was released).