### PR TITLE
Don't group around function calls that occur after an assignment oper…

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -669,6 +669,13 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+    if let calledMemberAccessExpr = node.calledExpression as? MemberAccessExprSyntax {
+      if let base = calledMemberAccessExpr.base, base is IdentifierExprSyntax {
+        before(base.firstToken, tokens: .open)
+        after(calledMemberAccessExpr.name.lastToken, tokens: .close)
+      }
+    }
+
     let arguments = node.argumentList
     if !arguments.isEmpty {
       // If there is a trailing closure, force the right parenthesis down to the next line so it
@@ -1219,7 +1226,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
       // assignment expressions) are covered by 3-element sequence expressions.
       let binOp = iterator.next()!
       let rhs = iterator.next()!
-      maybeGroupAroundSubexpression(rhs)
+      maybeGroupAroundSubexpression(rhs, combiningOperator: binOp)
 
       if shouldRequireWhitespace(around: binOp) {
         if shouldStackIndentation(after: binOp) {
@@ -2274,14 +2281,47 @@ private final class TokenStreamCreator: SyntaxVisitor {
   /// the expression, keeping the entire expression together when possible, before breaking inside
   /// the expression. This is a hand-crafted list of expressions that generally look better when the
   /// break(s) before the expression fire before breaks inside of the expression.
-  private func maybeGroupAroundSubexpression(_ expr: ExprSyntax) {
+  private func maybeGroupAroundSubexpression(
+    _ expr: ExprSyntax, combiningOperator operatorExpr: ExprSyntax? = nil
+  ) {
     switch expr {
-    case is FunctionCallExprSyntax, is MemberAccessExprSyntax, is SubscriptExprSyntax:
+    case is MemberAccessExprSyntax, is SubscriptExprSyntax:
       before(expr.firstToken, tokens: .open)
       after(expr.lastToken, tokens: .close)
     default:
       break
     }
+
+    // When a function call expression is assigned to an lvalue, we omit the group around the
+    // function call so that the callee and open parenthesis can remain on the same line, if they
+    // fit. This is a frequent enough case that the outcome looks better with the exception in
+    // place.
+    if expr is FunctionCallExprSyntax,
+      let operatorExpr = operatorExpr, !isAssigningOperator(operatorExpr)
+    {
+      before(expr.firstToken, tokens: .open)
+      after(expr.lastToken, tokens: .close)
+    }
+  }
+
+  /// Returns whether the given operator behaves as an assignment, to assign a right-hand-side to a
+  /// left-hand-side in a SequenceExpr.
+  ///
+  /// Assignment is defined as either being an assignment operator (i.e. `=`) or any operator that
+  /// uses "assignment" precedence.
+  private func isAssigningOperator(_ operatorExpr: ExprSyntax) -> Bool {
+    if operatorExpr is AssignmentExprSyntax {
+      return true
+    }
+    if let binaryOperator = operatorExpr as? BinaryOperatorExprSyntax {
+      let operatorText = binaryOperator.operatorToken.text
+      if let precedence = operatorContext.infixOperator(named: operatorText)?.precedenceGroup,
+        precedence === operatorContext.precedenceGroup(named: .assignment)
+      {
+        return true
+      }
+    }
+    return false
   }
 
   /// Returns a value indicating whether indentation should be stacked within subexpressions to the

--- a/Tests/SwiftFormatPrettyPrintTests/AssignmentExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/AssignmentExprTests.swift
@@ -40,4 +40,43 @@ public class AssignmentExprTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 30)
   }
+
+  public func testAssignmentFromFunctionCalls() {
+    let input =
+      """
+      result = firstOp + secondOp + someOpFetchingFunc(foo, bar: bar, baz: baz)
+      result = someOpFetchingFunc(foo, bar: bar, baz: baz)
+      result += someOpFetchingFunc(foo, bar: bar, baz: baz)
+      result = someOpFetchingFunc(foo, bar: bar, baz: baz) + someOtherOperand + andAThirdOneForReasons
+      let result = firstOp + secondOp + someOpFetchingFunc(foo, bar: bar, baz: baz)
+      let result = someOpFetchingFunc(foo, bar: bar, baz: baz)
+      let result = someOpFetchingFunc(foo, bar: bar, baz: baz) + someOtherOperand + andAThirdOneForReasons
+      """
+    let expected =
+      """
+      result = firstOp + secondOp
+        + someOpFetchingFunc(
+          foo, bar: bar, baz: baz)
+      result = someOpFetchingFunc(
+        foo, bar: bar, baz: baz)
+      result += someOpFetchingFunc(
+        foo, bar: bar, baz: baz)
+      result = someOpFetchingFunc(
+        foo, bar: bar, baz: baz)
+        + someOtherOperand
+        + andAThirdOneForReasons
+      let result = firstOp + secondOp
+        + someOpFetchingFunc(
+          foo, bar: bar, baz: baz)
+      let result = someOpFetchingFunc(
+        foo, bar: bar, baz: baz)
+      let result = someOpFetchingFunc(
+        foo, bar: bar, baz: baz)
+        + someOtherOperand
+        + andAThirdOneForReasons
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 35)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -40,6 +40,7 @@ extension AssignmentExprTests {
     // to regenerate.
     static let __allTests__AssignmentExprTests = [
         ("testAssignmentExprsWithGroupedOperators", testAssignmentExprsWithGroupedOperators),
+        ("testAssignmentFromFunctionCalls", testAssignmentFromFunctionCalls),
         ("testBasicAssignmentExprs", testBasicAssignmentExprs),
     ]
 }


### PR DESCRIPTION
…ator.

Grouping around these function calls results in suboptimal formatting for expressions that simply assign the result of a function call. There was also inconsistent between assignments and declarations (e.g. using let or var), because there may be SequenceExpr when using let/var decl.

I opted to also exclude the grouping when the function call is the first item in an expression list, because the indentation of following items isn't confusing whereas the indentation would be confusing when the function call follows other operands.