### PR TITLE
Add new configuration do prioritize keeping function output together

### DIFF
--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -58,6 +58,16 @@ top-level keys and values:
     argument, forcing the entire argument list to be laid out vertically.
     If false (the default), arguments will be laid out horizontally first, with
     line breaks only being fired when the line length would be exceeded.
+    
+*   `prioritizeKeepingFunctionOutputTogether` _(boolean)_: Determines if 
+    function-like declaration outputs should be prioritized to be together with the
+    function signature right (closing) parenthesis. If false (the default), function 
+    output (i.e. throws, return type) is not prioritized to be together with the 
+    signature's right parenthesis, and when the line length would be exceeded,
+    a line break will be fired after the function signature first, indenting the 
+    declaration output one additional level. If true, A line break will be fired 
+    further up in the function's declaration (e.g. generic parameters, 
+    parameters) before breaking on the function's output.  
 
 *   `indentConditionalCompilationBlocks` _(boolean)_: Determines if
     conditional compilation blocks are indented. If this setting is `false` the body

--- a/Sources/SwiftFormatConfiguration/Configuration.swift
+++ b/Sources/SwiftFormatConfiguration/Configuration.swift
@@ -29,6 +29,7 @@ public class Configuration: Codable {
     case blankLineBetweenMembers
     case lineBreakBeforeControlFlowKeywords
     case lineBreakBeforeEachArgument
+    case prioritizeKeepingFunctionOutputTogether
     case indentConditionalCompilationBlocks
     case rules
   }
@@ -88,6 +89,16 @@ public class Configuration: Codable {
   /// each argument, forcing the entire argument list to be laid out vertically.
   public var lineBreakBeforeEachArgument = false
 
+  /// Determines if function-like declaration outputs should be prioritized to be together with the
+  /// function signature right (closing) parenthesis.
+  ///
+  /// If false (the default), function output (i.e. throws, return type) is not prioritized to be
+  /// together with the signature's right parenthesis, and when the line length would be exceeded,
+  /// a line break will be fired after the function signature first, indenting the declaration output
+  /// one additional level. If true, A line break will be fired further up in the function's
+  /// declaration (e.g. generic parameters, parameters) before breaking on the function's output.
+  public var prioritizeKeepingFunctionOutputTogether = false
+
   /// Determines the indentation behavior for `#if`, `#elseif`, and `#else`.
   public var indentConditionalCompilationBlocks = true
 
@@ -129,10 +140,11 @@ public class Configuration: Codable {
       BlankLineBetweenMembersConfiguration.self, forKey: .blankLineBetweenMembers)
       ?? BlankLineBetweenMembersConfiguration()
     self.lineBreakBeforeControlFlowKeywords
-      = try container.decodeIfPresent(Bool.self, forKey: .lineBreakBeforeControlFlowKeywords)
-      ?? true
+      = try container.decodeIfPresent(Bool.self, forKey: .lineBreakBeforeControlFlowKeywords) ?? false
     self.lineBreakBeforeEachArgument
-      = try container.decodeIfPresent(Bool.self, forKey: .lineBreakBeforeEachArgument) ?? true
+      = try container.decodeIfPresent(Bool.self, forKey: .lineBreakBeforeEachArgument) ?? false
+    self.prioritizeKeepingFunctionOutputTogether
+      = try container.decodeIfPresent(Bool.self, forKey: .prioritizeKeepingFunctionOutputTogether) ?? false
     self.indentConditionalCompilationBlocks
       = try container.decodeIfPresent(Bool.self, forKey: .indentConditionalCompilationBlocks) ?? true
     self.rules = try container.decodeIfPresent([String: Bool].self, forKey: .rules) ?? [:]
@@ -148,9 +160,9 @@ public class Configuration: Codable {
     try container.encode(indentation, forKey: .indentation)
     try container.encode(respectsExistingLineBreaks, forKey: .respectsExistingLineBreaks)
     try container.encode(blankLineBetweenMembers, forKey: .blankLineBetweenMembers)
-    try container.encode(
-      lineBreakBeforeControlFlowKeywords, forKey: .lineBreakBeforeControlFlowKeywords)
+    try container.encode(lineBreakBeforeControlFlowKeywords, forKey: .lineBreakBeforeControlFlowKeywords)
     try container.encode(lineBreakBeforeEachArgument, forKey: .lineBreakBeforeEachArgument)
+    try container.encode(prioritizeKeepingFunctionOutputTogether, forKey: .prioritizeKeepingFunctionOutputTogether)
     try container.encode(indentConditionalCompilationBlocks, forKey: .indentConditionalCompilationBlocks)
     try container.encode(rules, forKey: .rules)
   }

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
@@ -552,6 +552,53 @@ public class FunctionDeclTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 33)
   }
 
+  public func testBreaksBeforeOrInsideOutput_prioritizingKeepingOutputTogether() {
+    let input =
+    """
+      func name<R>(_ x: Int) throws -> R
+
+      func name<R>(_ x: Int) throws -> R {
+        statement
+        statement
+      }
+      """
+
+    var expected =
+    """
+      func name<R>(
+        _ x: Int
+      ) throws -> R
+
+      func name<R>(
+        _ x: Int
+      ) throws -> R {
+        statement
+        statement
+      }
+
+      """
+    let config = Configuration()
+    config.prioritizeKeepingFunctionOutputTogether = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 23, configuration: config)
+
+    expected =
+    """
+    func name<R>(
+      _ x: Int
+    ) throws -> R
+
+    func name<R>(
+      _ x: Int
+    ) throws -> R {
+      statement
+      statement
+    }
+
+    """
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 30, configuration: config)
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 33, configuration: config)
+  }
+
   public func testBreaksBeforeOrInsideOutputWithAttributes() {
     let input =
       """
@@ -583,6 +630,42 @@ public class FunctionDeclTests: PrettyPrintTestCase {
 
       """
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 23)
+  }
+
+  public func testBreaksBeforeOrInsideOutputWithAttributes_prioritizingKeepingOutputTogether() {
+    let input =
+    """
+      @objc @discardableResult
+      func name<R>(_ x: Int) throws -> R
+
+      @objc @discardableResult
+      func name<R>(_ x: Int) throws -> R {
+        statement
+        statement
+      }
+      """
+
+    let expected =
+    """
+      @objc
+      @discardableResult
+      func name<R>(
+        _ x: Int
+      ) throws -> R
+
+      @objc
+      @discardableResult
+      func name<R>(
+        _ x: Int
+      ) throws -> R {
+        statement
+        statement
+      }
+
+      """
+    let config = Configuration()
+    config.prioritizeKeepingFunctionOutputTogether = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 23, configuration: config)
   }
 
   public func testBreaksBeforeOrInsideOutputWithWhereClause() {
@@ -640,6 +723,69 @@ public class FunctionDeclTests: PrettyPrintTestCase {
 
       """
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 23)
+  }
+
+  public func testBreaksBeforeOrInsideOutputWithWhereClause_prioritizingKeepingOutputTogether() {
+    var input =
+    """
+      func name<R>(_ x: Int) throws -> R where Foo == Bar
+
+      func name<R>(_ x: Int) throws -> R where Foo == Bar {
+        statement
+        statement
+      }
+      """
+
+    var expected =
+    """
+      func name<R>(
+        _ x: Int
+      ) throws -> R
+      where Foo == Bar
+
+      func name<R>(
+        _ x: Int
+      ) throws -> R
+      where Foo == Bar {
+        statement
+        statement
+      }
+
+      """
+    let config = Configuration()
+    config.prioritizeKeepingFunctionOutputTogether = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 23, configuration: config)
+
+    input =
+    """
+    func name<R>(_ x: Int) throws -> R where Fooooooo == Barrrrr
+
+    func name<R>(_ x: Int) throws -> R where Fooooooo == Barrrrr {
+    statement
+    statement
+    }
+    """
+
+    expected =
+    """
+    func name<R>(
+      _ x: Int
+    ) throws -> R
+    where
+      Fooooooo == Barrrrr
+
+    func name<R>(
+      _ x: Int
+    ) throws -> R
+    where
+      Fooooooo == Barrrrr
+    {
+      statement
+      statement
+    }
+
+    """
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 23, configuration: config)
   }
 
   public func testAttributedTypes() {

--- a/Tests/SwiftFormatPrettyPrintTests/SubscriptDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/SubscriptDeclTests.swift
@@ -219,6 +219,120 @@ public class SubscriptDeclTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 70)
   }
 
+  public func testBreaksBeforeOrInsideOutput() {
+    let input =
+    """
+      protocol MyProtocol {
+        subscript<R>(index: Int) -> R
+      }
+
+      struct MyStruct {
+        subscript<R>(index: Int) -> R {
+          statement
+          statement
+        }
+      }
+      """
+
+    var expected =
+    """
+      protocol MyProtocol {
+        subscript<R>(index: Int)
+          -> R
+      }
+
+      struct MyStruct {
+        subscript<R>(index: Int)
+          -> R
+        {
+          statement
+          statement
+        }
+      }
+
+      """
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 26)
+
+    expected =
+    """
+    protocol MyProtocol {
+      subscript<R>(index: Int)
+        -> R
+    }
+
+    struct MyStruct {
+      subscript<R>(index: Int)
+        -> R
+      {
+        statement
+        statement
+      }
+    }
+
+    """
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 27)
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 30)
+  }
+
+  public func testBreaksBeforeOrInsideOutput_prioritizingKeepingOutputTogether() {
+    let input =
+    """
+      protocol MyProtocol {
+        subscript<R>(index: Int) -> R
+      }
+
+      struct MyStruct {
+        subscript<R>(index: Int) -> R {
+          statement
+          statement
+        }
+      }
+      """
+
+    var expected =
+    """
+      protocol MyProtocol {
+        subscript<R>(
+          index: Int
+        ) -> R
+      }
+
+      struct MyStruct {
+        subscript<R>(
+          index: Int
+        ) -> R {
+          statement
+          statement
+        }
+      }
+
+      """
+    let config = Configuration()
+    config.prioritizeKeepingFunctionOutputTogether = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 26, configuration: config)
+
+    expected =
+    """
+    protocol MyProtocol {
+      subscript<R>(
+        index: Int
+      ) -> R
+    }
+
+    struct MyStruct {
+      subscript<R>(
+        index: Int
+      ) -> R {
+        statement
+        statement
+      }
+    }
+
+    """
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 27, configuration: config)
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 30, configuration: config)
+  }
+
   public func testSubscriptFullWrap() {
     let input =
     """

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -244,8 +244,11 @@ extension FunctionDeclTests {
         ("testBasicFunctionDeclarations_packArguments", testBasicFunctionDeclarations_packArguments),
         ("testBodilessFunctionDecl", testBodilessFunctionDecl),
         ("testBreaksBeforeOrInsideOutput", testBreaksBeforeOrInsideOutput),
+        ("testBreaksBeforeOrInsideOutput_prioritizingKeepingOutputTogether", testBreaksBeforeOrInsideOutput_prioritizingKeepingOutputTogether),
         ("testBreaksBeforeOrInsideOutputWithAttributes", testBreaksBeforeOrInsideOutputWithAttributes),
+        ("testBreaksBeforeOrInsideOutputWithAttributes_prioritizingKeepingOutputTogether", testBreaksBeforeOrInsideOutputWithAttributes_prioritizingKeepingOutputTogether),
         ("testBreaksBeforeOrInsideOutputWithWhereClause", testBreaksBeforeOrInsideOutputWithWhereClause),
+        ("testBreaksBeforeOrInsideOutputWithWhereClause_prioritizingKeepingOutputTogether", testBreaksBeforeOrInsideOutputWithWhereClause_prioritizingKeepingOutputTogether),
         ("testDoesNotCollapseFunctionParameterAttributes", testDoesNotCollapseFunctionParameterAttributes),
         ("testDoesNotCollapseStackedFunctionParameterAttributes", testDoesNotCollapseStackedFunctionParameterAttributes),
         ("testEmptyFunction", testEmptyFunction),
@@ -507,6 +510,8 @@ extension SubscriptDeclTests {
     // to regenerate.
     static let __allTests__SubscriptDeclTests = [
         ("testBasicSubscriptDeclarations", testBasicSubscriptDeclarations),
+        ("testBreaksBeforeOrInsideOutput", testBreaksBeforeOrInsideOutput),
+        ("testBreaksBeforeOrInsideOutput_prioritizingKeepingOutputTogether", testBreaksBeforeOrInsideOutput_prioritizingKeepingOutputTogether),
         ("testEmptySubscript", testEmptySubscript),
         ("testSubscriptAttributes", testSubscriptAttributes),
         ("testSubscriptFullWrap", testSubscriptFullWrap),


### PR DESCRIPTION
## Motivation

When a function's signature doesn't fit a single line because of the output (e.g. `throws -> ResultType`), the default behavior is to break right before the output and indent it one extra level.

However, this might not be the desired visual outcome, and by prioritizing keeping the output together (i.e. `) throws -> ReturnType`), the pretty printer will first break on any generic parameters and parameters before breaking the output into its own line.

## Changes

- Add new `prioritizeKeepingFunctionOutputTogether` configuration that is applied on `TokenStreamCreator`'s `visit(_ node: FunctionDeclSyntax)` and `visit(_ node: SubscriptDeclSyntax)`.

- Add new unit tests to validate desired behavior.