### PR TITLE
Wrap after assignment operators, not before.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1228,6 +1228,8 @@ private final class TokenStreamCreator: SyntaxVisitor {
       let rhs = iterator.next()!
       maybeGroupAroundSubexpression(rhs, combiningOperator: binOp)
 
+      let wrapsBeforeOperator = !isAssigningOperator(binOp)
+
       if shouldRequireWhitespace(around: binOp) {
         if shouldStackIndentation(after: binOp) {
           // For certain operators like `&&` and `||`, we don't want to treat all continue breaks
@@ -1237,15 +1239,28 @@ private final class TokenStreamCreator: SyntaxVisitor {
           // operators and their right-hand sides so that the continuation breaks inside those
           // scopes "stack", instead of receiving the usual single-level "continuation line or not"
           // behavior.
-          before(binOp.firstToken, tokens: .break(.open(kind: .continuation)), .open)
+          let openBreakTokens: [Token] = [.break(.open(kind: .continuation)), .open]
+          if wrapsBeforeOperator {
+            before(binOp.firstToken, tokens: openBreakTokens)
+          } else {
+            after(binOp.lastToken, tokens: openBreakTokens)
+          }
           after(
             rhs.lastToken,
             tokens: [.break(.reset, size: 0), .break(.close(mustBreak: false), size: 0), .close])
         } else {
-          before(binOp.firstToken, tokens: .break(.continue))
+          if wrapsBeforeOperator {
+            before(binOp.firstToken, tokens: .break(.continue))
+          } else {
+            after(binOp.lastToken, tokens: .break(.continue))
+          }
         }
 
-        after(binOp.lastToken, tokens: .space)
+        if wrapsBeforeOperator {
+          after(binOp.lastToken, tokens: .space)
+        } else {
+          before(binOp.firstToken, tokens: .space)
+        }
       }
     }
 
@@ -1318,7 +1333,19 @@ private final class TokenStreamCreator: SyntaxVisitor {
 
   func visit(_ node: PatternBindingSyntax) -> SyntaxVisitorContinueKind {
     if let accessorOrCodeBlock = node.accessor {
+      if let typeAnnotation = node.typeAnnotation {
+        after(typeAnnotation.colon, tokens: .break)
+      }
       arrangeAccessorOrCodeBlock(accessorOrCodeBlock)
+    } else {
+      if let typeAnnotation = node.typeAnnotation {
+        after(typeAnnotation.colon, tokens: .break(.open(kind: .continuation)))
+        after(node.lastToken, tokens: .break(.close, size: 0))
+      }
+      if let initializer = node.initializer {
+        after(initializer.equal, tokens: .break(.open(kind: .continuation)))
+        after(node.lastToken, tokens: .break(.close, size: 0))
+      }
     }
     return .visitChildren
   }
@@ -1362,8 +1389,8 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   func visit(_ node: TypeInitializerClauseSyntax) -> SyntaxVisitorContinueKind {
-    before(node.equal, tokens: .break)
-    after(node.equal, tokens: .space)
+    before(node.equal, tokens: .space)
+    after(node.equal, tokens: .break)
     return .visitChildren
   }
 
@@ -1394,8 +1421,8 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   func visit(_ node: TypeAnnotationSyntax) -> SyntaxVisitorContinueKind {
-    after(node.colon, tokens: .break(.open), .open)
-    after(node.lastToken, tokens: .break(.close, size: 0), .close)
+    before(node.type.firstToken, tokens: .open)
+    after(node.type.lastToken, tokens: .close)
     return .visitChildren
   }
 
@@ -1491,8 +1518,13 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   func visit(_ node: InitializerClauseSyntax) -> SyntaxVisitorContinueKind {
-    before(node.equal, tokens: .break)
-    after(node.equal, tokens: .space)
+    before(node.equal, tokens: .space)
+
+    // InitializerClauses that are children of a PatternBindingSyntax are already handled in the
+    // latter node, to ensure that continuations stack appropriately.
+    if !(node.parent is PatternBindingSyntax) {
+      after(node.equal, tokens: .break)
+    }
     return .visitChildren
   }
 

--- a/Tests/SwiftFormatPrettyPrintTests/AssignmentExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/AssignmentExprTests.swift
@@ -9,10 +9,10 @@ public class AssignmentExprTests: PrettyPrintTestCase {
     let expected =
       """
       foo = bar
-      someVeryLongVariableName
-        = anotherPrettyLongVariableName
-      shortName
-        = superLongNameForAVariable
+      someVeryLongVariableName =
+        anotherPrettyLongVariableName
+      shortName =
+        superLongNameForAVariable
 
       """
 
@@ -28,8 +28,8 @@ public class AssignmentExprTests: PrettyPrintTestCase {
       """
     let expected =
       """
-      someVeryLongVariableName
-        = anotherPrettyLongVariableName
+      someVeryLongVariableName =
+        anotherPrettyLongVariableName
         && someOtherOperand
       shortName = wxyz + aaaaaa
         + bbbbbb + cccccc

--- a/Tests/SwiftFormatPrettyPrintTests/CommentTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/CommentTests.swift
@@ -370,8 +370,8 @@ public class CommentTests: PrettyPrintTestCase {
       /* Comment 3
          Comment 4 */
 
-      let reallyLongVariableName
-        = 123 /* This comment should wrap */
+      let reallyLongVariableName =
+        123 /* This comment should wrap */
 
       let a = myfun(
         123 /* Cmt 5 */
@@ -437,9 +437,9 @@ public class CommentTests: PrettyPrintTestCase {
       }
 
       struct Foo {
-        typealias Bar
+        typealias Bar =
           // comment
-          = SomeOtherType
+          SomeOtherType
       }
       """
 

--- a/Tests/SwiftFormatPrettyPrintTests/ForInStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ForInStmtTests.swift
@@ -226,6 +226,11 @@ public class ForInStmtTests: PrettyPrintTestCase {
       }
       """
 
+    // FIXME: Based on the way that continuations are now handled, it's not clear that we can
+    // get `// comment #2` indented correctly based on what comes *after* it. I think the right
+    // approach here is to change the handling of full-line comments (and probably doc-comments as
+    // well) so that they are deferred until either just before the next text token is printed or
+    // the next close-break. But this is a larger change that I'll revisit in a separate PR.
     let expected =
       """
       for x in someCollection
@@ -250,7 +255,7 @@ public class ForInStmtTests: PrettyPrintTestCase {
           })
         // comment #1
         && someOtherCondition
-          // comment #2
+        // comment #2
           + thatUses + operators
         && binPackable && exprs
       {

--- a/Tests/SwiftFormatPrettyPrintTests/IfStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/IfStmtTests.swift
@@ -171,8 +171,8 @@ public class IfStmtTests: PrettyPrintTestCase {
         let a = 123
         var b = "abc"
       }
-      if case .reallyLongCaseName
-        = reallyLongVariableName
+      if case .reallyLongCaseName =
+        reallyLongVariableName
       {
         let a = 123
         var b = "abc"

--- a/Tests/SwiftFormatPrettyPrintTests/RespectsExistingLineBreaksTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/RespectsExistingLineBreaksTests.swift
@@ -49,8 +49,8 @@ class RespectsExistingLineBreaksTests: PrettyPrintTestCase {
       }
 
       struct Foo {
-        var storedProperty: Int
-          = 100
+        var storedProperty: Int =
+          100
         var readOnlyProperty: Int {
           return
             200
@@ -61,8 +61,8 @@ class RespectsExistingLineBreaksTests: PrettyPrintTestCase {
               somethingElse
           }
           set {
-            somethingElse
-              = newValue
+            somethingElse =
+              newValue
           }
         }
 

--- a/Tests/SwiftFormatPrettyPrintTests/StringTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/StringTests.swift
@@ -12,10 +12,10 @@ public class StringTests: PrettyPrintTestCase {
       """
       let a = "abc"
       myFun("Some string \\(a + b)")
-      let b
-        = "A really long string that should not wrap"
-      let c
-        = "A really long string with \\(a + b) some expressions \\(c + d)"
+      let b =
+        "A really long string that should not wrap"
+      let c =
+        "A really long string with \\(a + b) some expressions \\(c + d)"
 
       """
 
@@ -100,8 +100,8 @@ public class StringTests: PrettyPrintTestCase {
 
     let expected =
       #"""
-      let aLongVariableName
-        = """
+      let aLongVariableName =
+        """
         some
         multi-
         line

--- a/Tests/SwiftFormatPrettyPrintTests/SubscriptExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/SubscriptExprTests.swift
@@ -32,8 +32,8 @@ public class SubscriptExprTests: PrettyPrintTestCase {
       myCollection[index] = someValue
       myCollection[label: index] = someValue
       myCollection[
-        index, default: someDefaultValue]
-        = someValue
+        index, default: someDefaultValue] =
+        someValue
 
       """
 

--- a/Tests/SwiftFormatPrettyPrintTests/TernaryExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/TernaryExprTests.swift
@@ -41,11 +41,12 @@ public class TernaryExprTests: PrettyPrintTestCase {
       """
     let expected =
       """
-      let someLocalizedText = shouldUseTheFirstOption
-        ? stringFunc(name: "Name1", comment: "short comment")
-        : stringFunc(
-          name: "Name2", comment: "Some very, extremely long comment",
-          details: "Another comment")
+      let someLocalizedText =
+        shouldUseTheFirstOption
+          ? stringFunc(name: "Name1", comment: "short comment")
+          : stringFunc(
+            name: "Name2", comment: "Some very, extremely long comment",
+            details: "Another comment")
 
       """
 

--- a/Tests/SwiftFormatPrettyPrintTests/VariableDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/VariableDeclTests.swift
@@ -16,8 +16,8 @@ public class VariableDeclarationTests: PrettyPrintTestCase {
       let y: Int = anotherVar
         + moreVar
       let (w, z, s):
-        (Int, Double, Bool)
-        = firstTuple + secondTuple
+        (Int, Double, Bool) =
+          firstTuple + secondTuple
 
       """
 
@@ -37,8 +37,8 @@ public class VariableDeclarationTests: PrettyPrintTestCase {
       """
       @NSCopying let a: Int = 123
       @NSCopying @NSManaged let a: Int = 123
-      @NSCopying let areallylongvarname: Int
-        = 123
+      @NSCopying let areallylongvarname: Int =
+        123
       @NSCopying @NSManaged
       let areallylongvarname: Int = 123
 
@@ -60,8 +60,8 @@ public class VariableDeclarationTests: PrettyPrintTestCase {
       let a = 100, b = 200, c = 300, d = 400,
         e = 500, f = 600
       let a = 5,
-        anotherReallyLongVariableName
-          = something,
+        anotherReallyLongVariableName =
+          something,
         longVariableName = longFunctionCall()
       let
         a = letsForceTheFirstOneToWrapAsWell,
@@ -82,8 +82,8 @@ public class VariableDeclarationTests: PrettyPrintTestCase {
       """
       let a: Int = 100,
         b: ReallyLongTypeName = 200,
-        c: (AnotherLongTypeName, AnotherOne)
-          = 300
+        c: (AnotherLongTypeName, AnotherOne) =
+          300
 
       """
 

--- a/Tests/SwiftFormatPrettyPrintTests/YieldStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/YieldStmtTests.swift
@@ -21,8 +21,8 @@ public class YieldStmtTests: PrettyPrintTestCase {
             1234567890
         }
         _modify {
-          var someLongVariable
-            = 0
+          var someLongVariable =
+            0
           yield
             &someLongVariable
         }


### PR DESCRIPTION
This required some changes to the pretty-printer around newlines
that are adjacent to breaks that I'd like to revisit at some point
in the future; there are a lot of subtleties in situations involving
breaks immediately before a newline vs. immediately after a newline
that I think could be simplified and cleaned up.