### PR TITLE
Fix collapsing of func param attribute

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -854,6 +854,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
 
   func visit(_ node: FunctionParameterSyntax) -> SyntaxVisitorContinueKind {
     before(node.firstToken, tokens: .open)
+    arrangeAttributeList(node.attributes)
     after(node.colon, tokens: .break)
     before(node.secondName, tokens: .break)
 

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
@@ -700,4 +700,28 @@ public class FunctionDeclTests: PrettyPrintTestCase {
       """
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 21)
   }
+
+  func testDoesNotCollapseFunctionParameterAttributes() {
+    let input =
+    """
+    func foo<Content: View>(@ViewBuilder bar: () -> View) {
+      bar()
+    }
+
+    """
+
+    assertPrettyPrintEqual(input: input, expected: input, linelength: 60)
+  }
+
+  func testDoesNotCollapseStackedFunctionParameterAttributes() {
+    let input =
+    """
+    func foo<Content: View>(@FakeAttr @ViewBuilder bar: () -> View) {
+      bar()
+    }
+
+    """
+
+    assertPrettyPrintEqual(input: input, expected: input, linelength: 80)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -243,6 +243,8 @@ extension FunctionDeclTests {
         ("testBreaksBeforeOrInsideOutput", testBreaksBeforeOrInsideOutput),
         ("testBreaksBeforeOrInsideOutputWithAttributes", testBreaksBeforeOrInsideOutputWithAttributes),
         ("testBreaksBeforeOrInsideOutputWithWhereClause", testBreaksBeforeOrInsideOutputWithWhereClause),
+        ("testDoesNotCollapseFunctionParameterAttributes", testDoesNotCollapseFunctionParameterAttributes),
+        ("testDoesNotCollapseStackedFunctionParameterAttributes", testDoesNotCollapseStackedFunctionParameterAttributes),
         ("testEmptyFunction", testEmptyFunction),
         ("testFunctionAttributes", testFunctionAttributes),
         ("testFunctionDeclReturns", testFunctionDeclReturns),


### PR DESCRIPTION
Currently the pretty printer does not add a break after a function parameter attribute, which will now be more common in SwiftUI due to the `@ViewBuilder` attribute. This results in the following behavior: 

**Before formatting:**
```
func foo<Content: View>(@ViewBuilder bar: () -> View) {
      bar()
}
```
**After formatting:**
```
func foo<Content: View>(@ViewBuilderbar: () -> View) {
      bar()
}
```

This PR adds a break in between and after the attribute tokens to ensure a space (or break) is maintained in these cases.

~_Note: I've been unable to get the tests to run locally due to a SwiftSyntax parser incompatibility error, so I haven't been able to confirm this works as expected._~ (Was able to test these against the `5.1` branch)