### PR TITLE
Update BlankLineBetweenMembers rule to remove false positives.

### DIFF
--- a/Sources/SwiftFormatConfiguration/Configuration.swift
+++ b/Sources/SwiftFormatConfiguration/Configuration.swift
@@ -159,7 +159,11 @@ public class Configuration: Codable {
 /// Configuration for the BlankLineBetweenMembers rule.
 public struct BlankLineBetweenMembersConfiguration: Codable {
   /// If true, blank lines are not required between single-line properties.
-  public let ignoreSingleLineProperties = true
+  public let ignoreSingleLineProperties: Bool
+
+  public init(ignoreSingleLineProperties: Bool = true) {
+    self.ignoreSingleLineProperties = ignoreSingleLineProperties
+  }
 }
 
 /// Configuration for the NoPlaygroundLiterals rule.

--- a/Tests/SwiftFormatRulesTests/BlankLineBetweenMembersTests.swift
+++ b/Tests/SwiftFormatRulesTests/BlankLineBetweenMembersTests.swift
@@ -1,6 +1,7 @@
 import Foundation
-import XCTest
+import SwiftFormatConfiguration
 import SwiftSyntax
+import XCTest
 
 @testable import SwiftFormatRules
 
@@ -192,17 +193,23 @@ public class BlankLineBetweenMembersTests: DiagnosingTestCase {
                  let baz = 2
                }
                enum Foo {
-
                  // MARK: - This is an important region of the code.
 
                  let bar = 1
                  let baz = 2
                }
                enum Foo {
+                 var quxxe = 0
+                 // MARK: - This is an important region of the code.
 
-                 // This comment is describing bar.
                  let bar = 1
                  let baz = 2
+               }
+               enum Foo {
+                 let bar = 1
+                 let baz = 2
+
+                 // MARK: - This is an important region of the code.
                }
                """,
         expected: """
@@ -211,6 +218,13 @@ public class BlankLineBetweenMembersTests: DiagnosingTestCase {
                     let baz = 2
                   }
                   enum Foo {
+                    // MARK: - This is an important region of the code.
+
+                    let bar = 1
+                    let baz = 2
+                  }
+                  enum Foo {
+                    var quxxe = 0
 
                     // MARK: - This is an important region of the code.
 
@@ -218,12 +232,107 @@ public class BlankLineBetweenMembersTests: DiagnosingTestCase {
                     let baz = 2
                   }
                   enum Foo {
+                    let bar = 1
+                    let baz = 2
+
+                    // MARK: - This is an important region of the code.
+                  }
+                  """)
+  }
+
+  public func testBlankLinesAroundDocumentedMembers() {
+    XCTAssertFormatting(
+           BlankLineBetweenMembers.self,
+           input: """
+                  enum Foo {
 
                     // This comment is describing bar.
                     let bar = 1
-
                     let baz = 2
+                    let quxxe = 3
                   }
-                  """)
+                  enum Foo {
+                    var quxxe = 0
+
+                    /// bar: A property that has a Bar.
+                    let bar = 1
+                    let baz = 2
+                    var car = 3
+                  }
+                  """,
+           expected: """
+                     enum Foo {
+
+                       // This comment is describing bar.
+                       let bar = 1
+
+                       let baz = 2
+                       let quxxe = 3
+                     }
+                     enum Foo {
+                       var quxxe = 0
+
+                       /// bar: A property that has a Bar.
+                       let bar = 1
+
+                       let baz = 2
+                       var car = 3
+                     }
+                     """)
+  }
+
+  public func testBlankLineBetweenMembersIgnoreSingleLineDisabled() {
+    let config = Configuration()
+    config.blankLineBetweenMembers =
+      BlankLineBetweenMembersConfiguration(ignoreSingleLineProperties: false)
+
+    let input = """
+      enum Foo {
+        let bar = 1
+        let baz = 2
+      }
+      enum Foo {
+        // MARK: - This is an important region of the code.
+
+        let bar = 1
+        let baz = 2
+      }
+      enum Foo {
+        var quxxe = 0
+        // MARK: - This is an important region of the code.
+
+        let bar = 1
+        let baz = 2
+      }
+      """
+    let expected = """
+      enum Foo {
+        let bar = 1
+
+        let baz = 2
+      }
+      enum Foo {
+        // MARK: - This is an important region of the code.
+
+        let bar = 1
+
+        let baz = 2
+      }
+      enum Foo {
+        var quxxe = 0
+
+        // MARK: - This is an important region of the code.
+
+        let bar = 1
+
+        let baz = 2
+      }
+      """
+
+    XCTAssertFormatting(
+      BlankLineBetweenMembers.self,
+      input: input,
+      expected: expected,
+      configuration: config)
   }
 }

--- a/Tests/SwiftFormatRulesTests/DiagnosingTestCase.swift
+++ b/Tests/SwiftFormatRulesTests/DiagnosingTestCase.swift
@@ -38,9 +38,11 @@ public class DiagnosingTestCase: XCTestCase {
   }
 
   /// Creates and returns a new `Context` from the given syntax tree.
-  private func makeContext(sourceFileSyntax: SourceFileSyntax) -> Context {
+  private func makeContext(sourceFileSyntax: SourceFileSyntax, configuration: Configuration? = nil)
+    -> Context
+  {
     let context = Context(
-      configuration: Configuration(),
+      configuration: configuration ?? Configuration(),
       diagnosticEngine: DiagnosticEngine(),
       fileURL: URL(fileURLWithPath: "/tmp/test.swift"),
       sourceFileSyntax: sourceFileSyntax)
@@ -101,7 +103,8 @@ public class DiagnosingTestCase: XCTestCase {
     expected: String,
     file: StaticString = #file,
     line: UInt = #line,
-    checkForUnassertedDiagnostics: Bool = false
+    checkForUnassertedDiagnostics: Bool = false,
+    configuration: Configuration? = nil
   ) {
     let sourceFileSyntax: SourceFileSyntax
     do {
@@ -111,7 +114,7 @@ public class DiagnosingTestCase: XCTestCase {
       return
     }
 
-    context = makeContext(sourceFileSyntax: sourceFileSyntax)
+    context = makeContext(sourceFileSyntax: sourceFileSyntax, configuration: configuration)
 
     // Force the rule to be enabled while we test it.
     context!.configuration.rules[formatType.ruleName] = true

--- a/Tests/SwiftFormatRulesTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatRulesTests/XCTestManifests.swift
@@ -45,6 +45,8 @@ extension BlankLineBetweenMembersTests {
     // to regenerate.
     static let __allTests__BlankLineBetweenMembersTests = [
         ("testBlankLineBeforeFirstChildOrNot", testBlankLineBeforeFirstChildOrNot),
+        ("testBlankLineBetweenMembersIgnoreSingleLineDisabled", testBlankLineBetweenMembersIgnoreSingleLineDisabled),
+        ("testBlankLinesAroundDocumentedMembers", testBlankLinesAroundDocumentedMembers),
         ("testInvalidBlankLineBetweenMembers", testInvalidBlankLineBetweenMembers),
         ("testNestedMembers", testNestedMembers),
         ("testNoBlankLineBetweenSingleLineMembers", testNoBlankLineBetweenSingleLineMembers),


### PR DESCRIPTION
The rule was overly eager in adding blank lines around members that have comments in their leading trivia, because it didn't always correctly determine whether a given comment should trigger blank lines around the member.

I have refactored the rule using the following criteria for adding blank lines:
1. Any member whose leading trivia contains a non-blank-line-terminated comment must have a leading blank line (before the comment) and a trailing blank line (after the member).
2. Any comment that contains at least 1 blank line between the comment and the relevant syntax token is ignored entirely by the rule.

~This also includes formatting of the files that I touched; the changes were small enough that I think it's reasonable to include in a single PR. I'm fine with doing a separate pre-format PR though if the diff here is at all confusing.~ Reverted formatting changes.