### PR TITLE
Migrate to swift-tools-support-core.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,30 +2,21 @@
   "object": {
     "pins": [
       {
-        "package": "llbuild",
-        "repositoryURL": "https://github.com/apple/swift-llbuild.git",
-        "state": {
-          "branch": null,
-          "revision": "f1c9ad9a253cdf1aa89a7f5c99c30b4513b06ddb",
-          "version": "0.1.1"
-        }
-      },
-      {
-        "package": "SwiftPM",
-        "repositoryURL": "https://github.com/apple/swift-package-manager.git",
-        "state": {
-          "branch": null,
-          "revision": "8656a25cb906c1896339f950ac960ee1b4fe8034",
-          "version": "0.4.0"
-        }
-      },
-      {
         "package": "SwiftSyntax",
         "repositoryURL": "https://github.com/apple/swift-syntax",
         "state": {
           "branch": "swift-DEVELOPMENT-SNAPSHOT-2019-09-26-m",
           "revision": "c915603ef6815e0ec09cec33fe120be735798131",
           "version": null
+        }
+      },
+      {
+        "package": "swift-tools-support-core",
+        "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
+        "state": {
+          "branch": null,
+          "revision": "693aba4c4c9dcc4767cc853a0dd38bf90ad8c258",
+          "version": "0.0.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.1
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
@@ -21,11 +21,11 @@ let package = Package(
     .library(name: "SwiftFormatConfiguration", targets: ["SwiftFormatConfiguration"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.4.0"),
     .package(
       url: "https://github.com/apple/swift-syntax",
       .revision("swift-DEVELOPMENT-SNAPSHOT-2019-09-26-m")
     ),
+    .package(url: "https://github.com/apple/swift-tools-support-core.git", from: "0.0.1"),
   ],
   targets: [
     .target(
@@ -60,11 +60,11 @@ let package = Package(
     .target(
       name: "swift-format",
       dependencies: [
-        "SPMUtility",
         "SwiftFormat",
         "SwiftFormatConfiguration",
         "SwiftFormatCore",
         "SwiftSyntax",
+        "SwiftToolsSupport-auto",
       ]
     ),
     .testTarget(

--- a/Sources/swift-format/CommandLineOptions.swift
+++ b/Sources/swift-format/CommandLineOptions.swift
@@ -10,10 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Basic
 import Foundation
-import SPMUtility
 import SwiftFormat
+import TSCBasic
+import TSCUtility
 
 /// Collects the command line options that were passed to `swift-format`.
 struct CommandLineOptions {

--- a/Sources/swift-format/Run.swift
+++ b/Sources/swift-format/Run.swift
@@ -10,12 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Basic
 import Foundation
 import SwiftFormat
 import SwiftFormatConfiguration
 import SwiftFormatCore
 import SwiftSyntax
+import TSCBasic
 
 /// Runs the linting pipeline over the provided source file.
 ///

--- a/Sources/swift-format/ToolMode.swift
+++ b/Sources/swift-format/ToolMode.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SPMUtility
+import TSCUtility
 
 /// The mode in which the `swift-format` tool should run.
 enum ToolMode: String, Codable, ArgumentKind {

--- a/Sources/swift-format/main.swift
+++ b/Sources/swift-format/main.swift
@@ -10,12 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Basic
 import Foundation
-import SPMUtility
 import SwiftFormat
 import SwiftFormatConfiguration
 import SwiftFormatCore
+import TSCBasic
+import TSCUtility
 
 fileprivate func main(_ arguments: [String]) -> Int32 {
   let url = URL(fileURLWithPath: arguments.first!)


### PR DESCRIPTION
This removes the dependency on the private libraries inside SwiftPM
that we've been using for argument parsing, file streams, and other
things, and uses the recently factored out swift-tools-support-core
repository instead which is intended to be publicly consumed.