### PR TITLE
Fix sequences involving casts that don't fold correctly.

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -448,6 +448,7 @@ extension SequenceExprFoldingTests {
         ("testCustomOperator", testCustomOperator),
         ("testDifferentOperatorsSamePrecedence", testDifferentOperatorsSamePrecedence),
         ("testMixedAssociativity", testMixedAssociativity),
+        ("testMixedCastsTriesAndTernaries", testMixedCastsTriesAndTernaries),
         ("testNestedTernary", testNestedTernary),
         ("testSimpleBinaryExprIsUnchanged", testSimpleBinaryExprIsUnchanged),
         ("testSimpleBinaryExprLeftAssociativity", testSimpleBinaryExprLeftAssociativity),


### PR DESCRIPTION
There were two problems here; casts not getting duplicated
correctly when they were nested inside a ternary, and the
`mayChangeByFolding` check incorrectly flagging some
sequences as not changing when they should have.