### PR TITLE
Various fixes for `NoCasesWithOnlyFallthrough`.

### DIFF
--- a/Sources/SwiftFormatCore/Trivia+Convenience.swift
+++ b/Sources/SwiftFormatCore/Trivia+Convenience.swift
@@ -134,6 +134,23 @@ extension Trivia {
       })
   }
 
+  /// Returns this trivia, excluding the last newline and anything following it.
+  ///
+  /// If there is no newline in the trivia, it is returned unmodified.
+  public func withoutLastLine() -> Trivia {
+    var maybeLastNewlineOffset: Int? = nil
+    for (offset, piece) in self.enumerated() {
+      switch piece {
+      case .newlines, .carriageReturns, .carriageReturnLineFeeds:
+        maybeLastNewlineOffset = offset
+      default:
+        break
+      }
+    }
+    guard let lastNewlineOffset = maybeLastNewlineOffset else { return self }
+    return Trivia(pieces: self.dropLast(self.count - lastNewlineOffset))
+  }
+
   /// Returns this set of trivia, with all spaces removed except for one at the
   /// end.
   public func withOneTrailingSpace() -> Trivia {

--- a/Tests/SwiftFormatRulesTests/NoCasesWithOnlyFallthroughTests.swift
+++ b/Tests/SwiftFormatRulesTests/NoCasesWithOnlyFallthroughTests.swift
@@ -4,122 +4,202 @@ import XCTest
 
 @testable import SwiftFormatRules
 
-public class NoCasesWithOnlyFallthroughTests: DiagnosingTestCase {
+final class NoCasesWithOnlyFallthroughTests: DiagnosingTestCase {
+
   func testFallthroughCases() {
-    XCTAssertFormatting(NoCasesWithOnlyFallthrough.self,
-                        input: """
-                               switch numbers {
-                               case 1: print("one")
-                               case 2: fallthrough
-                               case 3: fallthrough
-                               case 4: print("two to four")
-                               case 5: fallthrough
-                               case 7: print("five or seven")
-                               default: break
-                               }
-                               switch letters {
-                               case "a": fallthrough
-                               case "b", "c": fallthrough
-                               case "d": print("abcd")
-                               case "e": print("e")
-                               case "f": fallthrough
-                               case "z": print("fz")
-                               default: break
-                               }
-                               switch tokens {
-                               case .comma: print(",")
-                               case .rightBrace: fallthrough
-                               case .leftBrace: fallthrough
-                               case .braces: print("{}")
-                               case .period: print(".")
-                               case .empty: fallthrough
-                               default: break
-                               }
-                               """,
-                        expected: """
-                                  switch numbers {
-                                  case 1: print("one")
-                                  case 2...4: print("two to four")
-                                  case 5, 7: print("five or seven")
-                                  default: break
-                                  }
-                                  switch letters {
-                                  case "a", "b", "c", "d": print("abcd")
-                                  case "e": print("e")
-                                  case "f", "z": print("fz")
-                                  default: break
-                                  }
-                                  switch tokens {
-                                  case .comma: print(",")
-                                  case .rightBrace, .leftBrace, .braces: print("{}")
-                                  case .period: print(".")
-                                  default: break
-                                  }
-                                  """)
+    XCTAssertFormatting(
+      NoCasesWithOnlyFallthrough.self,
+      input: """
+        switch numbers {
+        case 1: print("one")
+        case 2: fallthrough
+        case 3: fallthrough
+        case 4: print("two to four")
+        case 5: fallthrough
+        case 7: print("five or seven")
+        default: break
+        }
+        switch letters {
+        case "a": fallthrough
+        case "b", "c": fallthrough
+        case "d": print("abcd")
+        case "e": print("e")
+        case "f": fallthrough
+        case "z": print("fz")
+        default: break
+        }
+        switch tokens {
+        case .comma: print(",")
+        case .rightBrace: fallthrough
+        case .leftBrace: fallthrough
+        case .braces: print("{}")
+        case .period: print(".")
+        case .empty: fallthrough
+        default: break
+        }
+        """,
+      expected: """
+        switch numbers {
+        case 1: print("one")
+        case 2...4: print("two to four")
+        case 5, 7: print("five or seven")
+        default: break
+        }
+        switch letters {
+        case "a", "b", "c", "d": print("abcd")
+        case "e": print("e")
+        case "f", "z": print("fz")
+        default: break
+        }
+        switch tokens {
+        case .comma: print(",")
+        case .rightBrace, .leftBrace, .braces: print("{}")
+        case .period: print(".")
+        default: break
+        }
+        """)
   }
 
   func testFallthroughCasesWithCommentsAreNotCombined() {
-    XCTAssertFormatting(NoCasesWithOnlyFallthrough.self,
-                         input: """
-                                switch numbers {
-                                case 1:
-                                  return 0 // This return has an inline comment.
-                                case 2: fallthrough
-                                // This case is commented so it should stay.
-                                case 3:
-                                  fallthrough
-                                case 4:
-                                  // This fallthrough is commented so it should stay.
-                                  fallthrough
-                                case 5: fallthrough  // This fallthrough is relevant.
-                                case 6:
-                                  fallthrough
-                                // This case has a descriptive comment.
-                                case 7: print("got here")
-                                }
-                                """,
-                         expected: """
-                                   switch numbers {
-                                   case 1:
-                                     return 0 // This return has an inline comment.
-                                   // This case is commented so it should stay.
-                                   case 2...3:
-                                     fallthrough
-                                   case 4:
-                                     // This fallthrough is commented so it should stay.
-                                     fallthrough
-                                   case 5: fallthrough  // This fallthrough is relevant.
-                                   // This case has a descriptive comment.
-                                   case 6...7: print("got here")
-                                   }
-                                   """)
+    XCTAssertFormatting(
+      NoCasesWithOnlyFallthrough.self,
+      input: """
+        switch numbers {
+        case 1:
+          return 0 // This return has an inline comment.
+        case 2: fallthrough
+        // This case is commented so it should stay.
+        case 3:
+          fallthrough
+        case 4:
+          // This fallthrough is commented so it should stay.
+          fallthrough
+        case 5: fallthrough  // This fallthrough is relevant.
+        case 6:
+          fallthrough
+        // This case has a descriptive comment.
+        case 7: print("got here")
+        }
+        """,
+      expected: """
+        switch numbers {
+        case 1:
+          return 0 // This return has an inline comment.
+        // This case is commented so it should stay.
+        case 2...3:
+          fallthrough
+        case 4:
+          // This fallthrough is commented so it should stay.
+          fallthrough
+        case 5: fallthrough  // This fallthrough is relevant.
+        // This case has a descriptive comment.
+        case 6...7: print("got here")
+        }
+        """)
   }
 
   func testCommentsAroundCombinedCasesStayInPlace() {
-    XCTAssertFormatting(NoCasesWithOnlyFallthrough.self,
-                         input: """
-                                switch numbers {
-                                case 5:
-                                  return 42 // This return is important.
-                                case 6: fallthrough
-                                // This case has an important comment.
-                                case 7: print("6 to 7")
-                                case 8: fallthrough
+    XCTAssertFormatting(
+      NoCasesWithOnlyFallthrough.self,
+      input: """
+        switch numbers {
+        case 5:
+          return 42 // This return is important.
+        case 6: fallthrough
+        // This case has an important comment.
+        case 7: print("6 to 7")
+        case 8: fallthrough
 
-                                // This case has an extra leading newline for emphasis.
-                                case 9: print("8 to 9")
-                                }
-                                """,
-                         expected: """
-                                   switch numbers {
-                                   case 5:
-                                     return 42 // This return is important.
-                                   // This case has an important comment.
-                                   case 6...7: print("6 to 7")
+        // This case has an extra leading newline for emphasis.
+        case 9: print("8 to 9")
+        }
+        """,
+      expected: """
+        switch numbers {
+        case 5:
+          return 42 // This return is important.
+        // This case has an important comment.
+        case 6...7: print("6 to 7")
 
-                                   // This case has an extra leading newline for emphasis.
-                                   case 8...9: print("8 to 9")
-                                   }
-                                   """)
+        // This case has an extra leading newline for emphasis.
+        case 8...9: print("8 to 9")
+        }
+        """)
+  }
+
+  func testNestedSwitches() {
+    XCTAssertFormatting(
+      NoCasesWithOnlyFallthrough.self,
+      input: """
+        switch x {
+        case 1: fallthrough
+        case 2: fallthrough
+        case 3:
+          switch y {
+          case 1: fallthrough
+          case 2: print(2)
+          }
+        case 4:
+          switch y {
+          case 1: fallthrough
+          case 2: print(2)
+          }
+        }
+        """,
+      expected: """
+        switch x {
+        case 1...3:
+          switch y {
+          case 1...2: print(2)
+          }
+        case 4:
+          switch y {
+          case 1...2: print(2)
+          }
+        }
+        """)
+  }
+
+  func testCasesInsideConditionalCompilationBlock() {
+    XCTAssertFormatting(
+      NoCasesWithOnlyFallthrough.self,
+      input: """
+        switch x {
+        case 1: fallthrough
+        #if FOO
+        case 2: fallthrough
+        case 3: print(3)
+        case 4: print(4)
+        #endif
+        case 5: fallthrough
+        case 6: print(6)
+        #if BAR
+        #if BAZ
+        case 7: print(7)
+        case 8: fallthrough
+        #endif
+        case 9: fallthrough
+        #endif
+        case 10: print(10)
+        }
+        """,
+      expected: """
+        switch x {
+        case 1: fallthrough
+        #if FOO
+        case 2...3: print(3)
+        case 4: print(4)
+        #endif
+        case 5...6: print(6)
+        #if BAR
+        #if BAZ
+        case 7: print(7)
+        case 8: fallthrough
+        #endif
+        case 9: fallthrough
+        #endif
+        case 10: print(10)
+        }
+        """)
   }
 }

--- a/Tests/SwiftFormatRulesTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatRulesTests/XCTestManifests.swift
@@ -185,9 +185,11 @@ extension NoCasesWithOnlyFallthroughTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__NoCasesWithOnlyFallthroughTests = [
+        ("testCasesInsideConditionalCompilationBlock", testCasesInsideConditionalCompilationBlock),
         ("testCommentsAroundCombinedCasesStayInPlace", testCommentsAroundCombinedCasesStayInPlace),
         ("testFallthroughCases", testFallthroughCases),
         ("testFallthroughCasesWithCommentsAreNotCombined", testFallthroughCasesWithCommentsAreNotCombined),
+        ("testNestedSwitches", testNestedSwitches),
     ]
 }
 


### PR DESCRIPTION
This resolves some situations where the rule was dropping cases,
most notably when they were surrounded by an `#if/#endif` block.
The only time cases should be dropped completely (instead of
folded into subsequent cases) is when they are fallthroughs that
are followed by a `default` clause.