### PR TITLE
Use a closure instead of a keypath in a call to `map`.

### DIFF
--- a/Sources/SwiftFormatRules/NoCasesWithOnlyFallthrough.swift
+++ b/Sources/SwiftFormatRules/NoCasesWithOnlyFallthrough.swift
@@ -65,12 +65,12 @@ public final class NoCasesWithOnlyFallthrough: SyntaxFormatRule {
         if let label = switchCase.label as? SwitchCaseLabelSyntax {
           if retrieveNumericCaseValue(caseLabel: label) != nil {
             collapsedCase = collapseIntegerCases(
-              violations: fallthroughOnlyCasesAndLabels.lazy.map(\.label),
+              violations: fallthroughOnlyCasesAndLabels.lazy.map { $0.label },
               validCaseLabel: label,
               validCase: switchCase)
           } else {
             collapsedCase = collapseNonIntegerCases(
-              violations: fallthroughOnlyCasesAndLabels.lazy.map(\.label),
+              violations: fallthroughOnlyCasesAndLabels.lazy.map { $0.label },
               validCaseLabel: label,
               validCase: switchCase)
           }


### PR DESCRIPTION
I accidentally snuck in a usage of the keypath-to-function-literal
conversion (SE-0249) since master is developed against a trunk
development snapshot, but this feature isn't part of any released
Swift. It's not so critical that we need it, so it's better to just
use a closure for now so that this change can be cherry-picked back
into the 5.1 branch.