### PR TITLE
Configuration-related let-to-var cleanup after merging #86 and #74.

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/ClassDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ClassDeclTests.swift
@@ -247,7 +247,7 @@ public class ClassDeclTests: PrettyPrintTestCase {
 
       """
 
-    let config = Configuration()
+    var config = Configuration()
     config.lineBreakBeforeEachGenericRequirement = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 60, configuration: config)
   }
@@ -323,7 +323,7 @@ public class ClassDeclTests: PrettyPrintTestCase {
 
       """
 
-    let config = Configuration()
+    var config = Configuration()
     config.lineBreakBeforeEachGenericRequirement = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 60, configuration: config)
   }
@@ -404,7 +404,7 @@ public class ClassDeclTests: PrettyPrintTestCase {
 
       """
 
-    let config = Configuration()
+    var config = Configuration()
     config.lineBreakBeforeEachArgument = false
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 50, configuration: config)
   }

--- a/Tests/SwiftFormatPrettyPrintTests/EnumDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/EnumDeclTests.swift
@@ -326,7 +326,7 @@ public class EnumDeclTests: PrettyPrintTestCase {
 
       """
 
-    let config = Configuration()
+    var config = Configuration()
     config.lineBreakBeforeEachGenericRequirement = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 60, configuration: config)
   }
@@ -415,7 +415,7 @@ public class EnumDeclTests: PrettyPrintTestCase {
 
       """
 
-    let config = Configuration()
+    var config = Configuration()
     config.lineBreakBeforeEachGenericRequirement = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 60, configuration: config)
   }
@@ -496,7 +496,7 @@ public class EnumDeclTests: PrettyPrintTestCase {
 
       """
 
-    let config = Configuration()
+    var config = Configuration()
     config.lineBreakBeforeEachArgument = false
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 50, configuration: config)
   }

--- a/Tests/SwiftFormatPrettyPrintTests/ExtensionDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ExtensionDeclTests.swift
@@ -161,7 +161,7 @@ public class ExtensionDeclTests: PrettyPrintTestCase {
 
       """
 
-    let config = Configuration()
+    var config = Configuration()
     config.lineBreakBeforeEachGenericRequirement = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 70, configuration: config)
   }
@@ -249,7 +249,7 @@ public class ExtensionDeclTests: PrettyPrintTestCase {
 
       """
 
-    let config = Configuration()
+    var config = Configuration()
     config.lineBreakBeforeEachGenericRequirement = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 70, configuration: config)
   }
@@ -362,7 +362,7 @@ public class ExtensionDeclTests: PrettyPrintTestCase {
 
       """
 
-    let config = Configuration()
+    var config = Configuration()
     config.lineBreakBeforeEachGenericRequirement = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 50, configuration: config)
   }

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
@@ -334,7 +334,7 @@ public class FunctionDeclTests: PrettyPrintTestCase {
 
       """
 
-    let config = Configuration()
+    var config = Configuration()
     config.lineBreakBeforeEachArgument = false
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 50, configuration: config)
   }
@@ -600,7 +600,7 @@ public class FunctionDeclTests: PrettyPrintTestCase {
 
     """
 
-    let config = Configuration()
+    var config = Configuration()
     config.lineBreakBeforeEachGenericRequirement = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 30, configuration: config)
   }

--- a/Tests/SwiftFormatPrettyPrintTests/InitializerDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/InitializerDeclTests.swift
@@ -290,7 +290,7 @@ public class InitializerDeclTests: PrettyPrintTestCase {
 
     """
 
-    let config = Configuration()
+    var config = Configuration()
     config.lineBreakBeforeEachArgument = false
     config.lineBreakBeforeEachGenericRequirement = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 50, configuration: config)
@@ -369,7 +369,7 @@ public class InitializerDeclTests: PrettyPrintTestCase {
 
       """
 
-    let config = Configuration()
+    var config = Configuration()
     config.lineBreakBeforeEachArgument = false
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: config)
   }

--- a/Tests/SwiftFormatPrettyPrintTests/StructDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/StructDeclTests.swift
@@ -247,7 +247,7 @@ public class StructDeclTests: PrettyPrintTestCase {
 
       """
 
-    let config = Configuration()
+    var config = Configuration()
     config.lineBreakBeforeEachGenericRequirement = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 60, configuration: config)
   }
@@ -335,7 +335,7 @@ public class StructDeclTests: PrettyPrintTestCase {
 
       """
 
-    let config = Configuration()
+    var config = Configuration()
     config.lineBreakBeforeEachGenericRequirement = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 60, configuration: config)
   }
@@ -416,7 +416,7 @@ public class StructDeclTests: PrettyPrintTestCase {
 
       """
 
-    let config = Configuration()
+    var config = Configuration()
     config.lineBreakBeforeEachArgument = false
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 50, configuration: config)
   }

--- a/Tests/SwiftFormatPrettyPrintTests/SubscriptDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/SubscriptDeclTests.swift
@@ -200,7 +200,7 @@ public class SubscriptDeclTests: PrettyPrintTestCase {
 
       """
 
-    let config = Configuration()
+    var config = Configuration()
     config.lineBreakBeforeEachArgument = false
     config.lineBreakBeforeEachGenericRequirement = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 50, configuration: config)
@@ -473,7 +473,7 @@ public class SubscriptDeclTests: PrettyPrintTestCase {
 
     """
 
-    let config = Configuration()
+    var config = Configuration()
     config.lineBreakBeforeEachGenericRequirement = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 34, configuration: config)
   }


### PR DESCRIPTION
@p4checo, I accidentally broke the tests you added when I changed `Configuration` to a value type (#86) and merged that in along with your PR (#74). This fixes those.

Tested via:

```shell
$ TOOLCHAINS=org.swift.50201909261a swift test --parallel
[19/19] Linking swift-format
[397/397] Testing SwiftFormatPrettyPrintTests.YieldStmtTests/testBasic
```