### PR TITLE
Fix scrunching of range operators.

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/BinaryOperatorExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/BinaryOperatorExprTests.swift
@@ -1,16 +1,161 @@
 public class BinaryOperatorExprTests: PrettyPrintTestCase {
-  public func testOperatorSpacing() {
+
+  public func testNonRangeFormationOperatorsAreSurroundedByBreaks() {
     let input =
       """
-      x=1+8-9  ..<  5*4/10
+      x=1+8-9  ^*^  5*4/10
+      """
+
+    let expected80 =
+      """
+      x = 1 + 8 - 9 ^*^ 5 * 4 / 10
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected80, linelength: 80)
+
+    let expected10 =
+      """
+      x = 1 + 8
+        - 9
+        ^*^ 5
+        * 4 / 10
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected10, linelength: 10)
+  }
+
+  public func testRangeFormationOperatorsAreCompactedWhenPossible() {
+    let input =
+      """
+      x = 1...100
+      x = 1..<100
+      x = (1++)...(-100)
+      x = 1 ... 100
+      x = 1 ..< 100
+      x = (1++) ... (-100)
       """
 
     let expected =
       """
-      x = 1 + 8 - 9..<5 * 4 / 10
+      x = 1...100
+      x = 1..<100
+      x = (1++)...(-100)
+      x = 1...100
+      x = 1..<100
+      x = (1++)...(-100)
 
       """
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 80)
+  }
+
+  public func testRangeFormationOperatorsAreNotCompactedWhenFollowingAPostfixOperator() {
+    let input =
+      """
+      x = 1++ ... 100
+      x = 1-- ..< 100
+      x = 1++   ...   100
+      x = 1--   ..<   100
+      """
+
+    let expected80 =
+      """
+      x = 1++ ... 100
+      x = 1-- ..< 100
+      x = 1++ ... 100
+      x = 1-- ..< 100
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected80, linelength: 80)
+
+    let expected10 =
+      """
+      x = 1++
+        ... 100
+      x = 1--
+        ..< 100
+      x = 1++
+        ... 100
+      x = 1--
+        ..< 100
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected10, linelength: 10)
+  }
+
+  public func testRangeFormationOperatorsAreNotCompactedWhenPrecedingAPrefixOperator() {
+    let input =
+      """
+      x = 1 ... -100
+      x = 1 ..< -100
+      x = 1   ...   √100
+      x = 1   ..<   √100
+      """
+
+    let expected80 =
+      """
+      x = 1 ... -100
+      x = 1 ..< -100
+      x = 1 ... √100
+      x = 1 ..< √100
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected80, linelength: 80)
+
+    let expected10 =
+      """
+      x = 1
+        ... -100
+      x = 1
+        ..< -100
+      x = 1
+        ... √100
+      x = 1
+        ..< √100
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected10, linelength: 10)
+  }
+
+  public func testRangeFormationOperatorsAreNotCompactedWhenUnaryOperatorsAreOnEachSide() {
+    let input =
+      """
+      x = 1++ ... -100
+      x = 1-- ..< -100
+      x = 1++   ...   √100
+      x = 1--   ..<   √100
+      """
+
+    let expected80 =
+      """
+      x = 1++ ... -100
+      x = 1-- ..< -100
+      x = 1++ ... √100
+      x = 1-- ..< √100
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected80, linelength: 80)
+
+    let expected10 =
+      """
+      x = 1++
+        ... -100
+      x = 1--
+        ..< -100
+      x = 1++
+        ... √100
+      x = 1--
+        ..< √100
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected10, linelength: 10)
   }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -89,7 +89,11 @@ extension BinaryOperatorExprTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__BinaryOperatorExprTests = [
-        ("testOperatorSpacing", testOperatorSpacing),
+        ("testNonRangeFormationOperatorsAreSurroundedByBreaks", testNonRangeFormationOperatorsAreSurroundedByBreaks),
+        ("testRangeFormationOperatorsAreCompactedWhenPossible", testRangeFormationOperatorsAreCompactedWhenPossible),
+        ("testRangeFormationOperatorsAreNotCompactedWhenFollowingAPostfixOperator", testRangeFormationOperatorsAreNotCompactedWhenFollowingAPostfixOperator),
+        ("testRangeFormationOperatorsAreNotCompactedWhenPrecedingAPrefixOperator", testRangeFormationOperatorsAreNotCompactedWhenPrecedingAPrefixOperator),
+        ("testRangeFormationOperatorsAreNotCompactedWhenUnaryOperatorsAreOnEachSide", testRangeFormationOperatorsAreNotCompactedWhenUnaryOperatorsAreOnEachSide),
     ]
 }
 


### PR DESCRIPTION
We can't unconditionally remove all whitespace around range operators
when they are preceded by a postfix operator or followed by a
postfix operator; the parser greedily treats the combined string
as a single operator.

We still remove whitespace around range operators when possible, but
rather than try to strictly enforce the lack of whitespace in all cases
through more clever and potentially disruptive transformations (like
surrounding the operands by parentheses), we just keep the whitespace
when we can't remove it.

Fixes SR-11798.