### PR TITLE
Handle end-of-line comments correctly in BlankLineBetweenMembers.

### DIFF
--- a/Tests/SwiftFormatRulesTests/BlankLineBetweenMembersTests.swift
+++ b/Tests/SwiftFormatRulesTests/BlankLineBetweenMembersTests.swift
@@ -335,4 +335,31 @@ public class BlankLineBetweenMembersTests: DiagnosingTestCase {
       expected: expected,
       configuration: config)
   }
+
+  func testTrailingCommentsAreKeptTrailing() {
+    XCTAssertFormatting(
+      BlankLineBetweenMembers.self,
+      input:
+        """
+        enum Foo {
+          static let foo = "foo"  // foo
+          static let bar = "bar"  // bar
+          // this should move down
+          static let baz = "baz"  // baz
+          static let andSo = "should"  // this
+        }
+        """,
+      expected:
+        """
+        enum Foo {
+          static let foo = "foo"  // foo
+          static let bar = "bar"  // bar
+
+          // this should move down
+          static let baz = "baz"  // baz
+
+          static let andSo = "should"  // this
+        }
+        """)
+  }
 }

--- a/Tests/SwiftFormatRulesTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatRulesTests/XCTestManifests.swift
@@ -50,6 +50,7 @@ extension BlankLineBetweenMembersTests {
         ("testInvalidBlankLineBetweenMembers", testInvalidBlankLineBetweenMembers),
         ("testNestedMembers", testNestedMembers),
         ("testNoBlankLineBetweenSingleLineMembers", testNoBlankLineBetweenSingleLineMembers),
+        ("testTrailingCommentsAreKeptTrailing", testTrailingCommentsAreKeptTrailing),
         ("testTwoMembers", testTwoMembers),
     ]
 }


### PR DESCRIPTION
When we were doing the is-single-line check, we weren't considering that
the first comment in the trivia might precede any newlines in that trivia,
meaning it's an end-of-line comment for a previous line, not a line
comment that we should consider part of the current decl. Likewise, when
we insert a newline, we need to insert it after that initial EOL comment,
if it exists.

Complex logic like this should probably be factored into a more general
trivia transform utility at some point, so it can be localized.