### PR TITLE
Allow the closing paren for function decls in protocols on the same l…

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/ProtocolDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ProtocolDeclTests.swift
@@ -144,6 +144,10 @@ public class ProtocolDeclTests: PrettyPrintTestCase {
       protocol MyProtocol {
         func foo(bar: Int) -> Int
         func reallyLongName(reallyLongLabel: Int, anotherLongLabel: Bool) -> Float
+        func doAProtoThing(first: Foo, second s: Bar)
+        func doAThing(first: Foo) -> ResultType
+        func doSomethingElse(firstArg: Foo, second secondArg: Bar, third thirdArg: Baz)
+        func doStuff(firstArg: Foo, second second: Bar, third third: Baz) -> Output
       }
       """
     
@@ -155,6 +159,19 @@ public class ProtocolDeclTests: PrettyPrintTestCase {
           reallyLongLabel: Int,
           anotherLongLabel: Bool
         ) -> Float
+        func doAProtoThing(
+          first: Foo, second s: Bar)
+        func doAThing(first: Foo)
+          -> ResultType
+        func doSomethingElse(
+          firstArg: Foo,
+          second secondArg: Bar,
+          third thirdArg: Baz)
+        func doStuff(
+          firstArg: Foo,
+          second second: Bar,
+          third third: Baz
+        ) -> Output
       }
 
       """
@@ -177,8 +194,7 @@ public class ProtocolDeclTests: PrettyPrintTestCase {
         init(bar: Int)
         init(
           reallyLongLabel: Int,
-          anotherLongLabel: Bool
-        )
+          anotherLongLabel: Bool)
       }
 
       """


### PR DESCRIPTION
…ine as the last parameter.

Breaking before this paren doesn't aid in the readability in the same way it does when the decl isn't part of a protocol, because there's no function body nor curly braces after the paren in this case. This break existed to aid readability by creating a boundary between the function's signature and its body. When the decl is part of a protocol, there is no body and the boundary isn't necessary.

In order to make this change, I had to hoist the grouping and breaking around parens in a function signature from the ParameterClauseSyntax visitor into parent visitor methods. The ParameterClauseSyntax is nested below the node which can determine if the decl has a body. Instead of traversing parent pointers, I hoisted the implementation into the parent visitors.