### PR TITLE
Put freestanding `init` decls in a test into a type.

### DIFF
--- a/Tests/SwiftFormatRulesTests/ValidateDocumentationCommentsTests.swift
+++ b/Tests/SwiftFormatRulesTests/ValidateDocumentationCommentsTests.swift
@@ -187,28 +187,30 @@ public class ValidateDocumentationCommentsTests: DiagnosingTestCase {
   public func testInitializer() {
     let input =
     """
-    /// Brief summary.
-    ///
-    /// - Parameter command: The command to execute in the shell environment.
-    /// - Returns: Shouldn't be here.
-    init(label commando: String) {
-    // ...
-    }
+    struct SomeType {
+      /// Brief summary.
+      ///
+      /// - Parameter command: The command to execute in the shell environment.
+      /// - Returns: Shouldn't be here.
+      init(label commando: String) {
+      // ...
+      }
 
-    /// Brief summary.
-    ///
-    /// - Parameter command: The command to execute in the shell environment.
-    init(label command: String) {
-    // ...
-    }
+      /// Brief summary.
+      ///
+      /// - Parameter command: The command to execute in the shell environment.
+      init(label command: String) {
+      // ...
+      }
 
-    /// Brief summary.
-    ///
-    /// - Parameters:
-    ///   - command: The command to execute in the shell environment.
-    ///   - stdin: The string to use as standard input.
-    init(label command: String, label2 stdin: String) {
-    // ...
+      /// Brief summary.
+      ///
+      /// - Parameters:
+      ///   - command: The command to execute in the shell environment.
+      ///   - stdin: The string to use as standard input.
+      init(label command: String, label2 stdin: String) {
+      // ...
+      }
     }
     """
     performLint(ValidateDocumentationComments.self, input: input)


### PR DESCRIPTION
Even though these aren't semantically valid Swift, these parse correctly
with the 9/26 snapshot we're currently on. At a more recent commit we
noticed that these `init`s seem to be hitting a code path that causes an
assertion in the parser:

    assertion failed in swift::Type swift::ValueDecl::getInterfaceType() const:
    ctx.getLegacyGlobalTypeChecker() && "The type checker must be installed to
    make semantic queries!"

We should try to pinpoint this crash, but for now I'm patching this so
that the test is more "correct" and it unblocks some of our internal work.