### PR TITLE
Grouping and continuation consistency improvements.

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/AccessorTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/AccessorTests.swift
@@ -62,8 +62,8 @@ public class AccessorTests: PrettyPrintTestCase {
           }
           set(newValue) {
             memberValue = newValue && otherValue
-            memberValue2 = newValue / 2
-              && andableValue
+            memberValue2 =
+              newValue / 2 && andableValue
           }
         }
       }

--- a/Tests/SwiftFormatPrettyPrintTests/AsExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/AsExprTests.swift
@@ -4,7 +4,9 @@ public class AsExprTests: PrettyPrintTestCase {
       """
       func foo() {
         let a = b as Int
+        a = b as Int
         let reallyLongVariableName = x as ReallyLongTypeName
+        reallyLongVariableName = x as ReallyLongTypeName
       }
       """
 
@@ -12,8 +14,11 @@ public class AsExprTests: PrettyPrintTestCase {
       """
       func foo() {
         let a = b as Int
-        let reallyLongVariableName = x
-          as ReallyLongTypeName
+        a = b as Int
+        let reallyLongVariableName =
+          x as ReallyLongTypeName
+        reallyLongVariableName =
+          x as ReallyLongTypeName
       }
 
       """
@@ -26,8 +31,11 @@ public class AsExprTests: PrettyPrintTestCase {
       """
       func foo() {
         let a = b as? Int
+        a = b as? Int
         let c = d as! Int
+        c = d as! Int
         let reallyLongVariableName = x as? ReallyLongTypeName
+        reallyLongVariableName = x as? ReallyLongTypeName
       }
       """
 
@@ -35,9 +43,13 @@ public class AsExprTests: PrettyPrintTestCase {
       """
       func foo() {
         let a = b as? Int
+        a = b as? Int
         let c = d as! Int
-        let reallyLongVariableName = x
-          as? ReallyLongTypeName
+        c = d as! Int
+        let reallyLongVariableName =
+          x as? ReallyLongTypeName
+        reallyLongVariableName =
+          x as? ReallyLongTypeName
       }
 
       """

--- a/Tests/SwiftFormatPrettyPrintTests/AssignmentExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/AssignmentExprTests.swift
@@ -1,3 +1,5 @@
+import SwiftFormatConfiguration
+
 public class AssignmentExprTests: PrettyPrintTestCase {
   public func testBasicAssignmentExprs() {
     let input =
@@ -30,53 +32,177 @@ public class AssignmentExprTests: PrettyPrintTestCase {
       """
       someVeryLongVariableName =
         anotherPrettyLongVariableName
-        && someOtherOperand
-      shortName = wxyz + aaaaaa
-        + bbbbbb + cccccc
-      longerName = wxyz + aaaaaa
-        + bbbbbb + cccccc || zzzzzzz
+          && someOtherOperand
+      shortName =
+        wxyz + aaaaaa + bbbbbb
+          + cccccc
+      longerName =
+        wxyz + aaaaaa + bbbbbb
+          + cccccc || zzzzzzz
 
       """
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 30)
   }
 
-  public func testAssignmentFromFunctionCalls() {
+  public func testAssignmentOperatorFromSequenceWithFunctionCalls() {
+    let input =
+        """
+        result = firstOp + secondOp + someOpFetchingFunc(foo, bar: bar, baz: baz)
+        result = someOpFetchingFunc(foo, bar: bar, baz: baz)
+        result += someOpFetchingFunc(foo, bar: bar, baz: baz)
+        result = someOpFetchingFunc(foo, bar: bar, baz: baz) + someOtherOperand + andAThirdOneForReasons
+        result = firstOp + secondOp + thirdOp + someOpFetchingFunc(foo, bar, baz) + nextOp + lastOp
+        result += firstOp + secondOp + thirdOp + someOpFetchingFunc(foo, bar, baz) + nextOp + lastOp
+        """
+
+      let expectedWithArgBinPacking =
+        """
+        result =
+          firstOp + secondOp
+            + someOpFetchingFunc(
+              foo, bar: bar, baz: baz)
+        result = someOpFetchingFunc(
+          foo, bar: bar, baz: baz)
+        result += someOpFetchingFunc(
+          foo, bar: bar, baz: baz)
+        result =
+          someOpFetchingFunc(
+            foo, bar: bar, baz: baz)
+            + someOtherOperand
+            + andAThirdOneForReasons
+        result =
+          firstOp + secondOp + thirdOp
+            + someOpFetchingFunc(
+              foo, bar, baz) + nextOp
+            + lastOp
+        result +=
+          firstOp + secondOp + thirdOp
+            + someOpFetchingFunc(
+              foo, bar, baz) + nextOp
+            + lastOp
+
+        """
+
+      var config = Configuration()
+      config.lineBreakBeforeEachArgument = false
+      assertPrettyPrintEqual(
+        input: input, expected: expectedWithArgBinPacking, linelength: 35, configuration: config)
+
+      let expectedWithBreakBeforeEachArg =
+        """
+        result =
+          firstOp + secondOp
+            + someOpFetchingFunc(
+              foo,
+              bar: bar,
+              baz: baz
+            )
+        result = someOpFetchingFunc(
+          foo,
+          bar: bar,
+          baz: baz
+        )
+        result += someOpFetchingFunc(
+          foo,
+          bar: bar,
+          baz: baz
+        )
+        result =
+          someOpFetchingFunc(
+            foo,
+            bar: bar,
+            baz: baz
+          ) + someOtherOperand
+            + andAThirdOneForReasons
+        result =
+          firstOp + secondOp + thirdOp
+            + someOpFetchingFunc(
+              foo,
+              bar,
+              baz
+            ) + nextOp + lastOp
+        result +=
+          firstOp + secondOp + thirdOp
+            + someOpFetchingFunc(
+              foo,
+              bar,
+              baz
+            ) + nextOp + lastOp
+
+        """
+      config.lineBreakBeforeEachArgument = true
+      assertPrettyPrintEqual(
+        input: input, expected: expectedWithBreakBeforeEachArg, linelength: 35, configuration: config)
+  }
+
+  public func testAssignmentPatternBindingFromSequenceWithFunctionCalls() {
     let input =
       """
-      result = firstOp + secondOp + someOpFetchingFunc(foo, bar: bar, baz: baz)
-      result = someOpFetchingFunc(foo, bar: bar, baz: baz)
-      result += someOpFetchingFunc(foo, bar: bar, baz: baz)
-      result = someOpFetchingFunc(foo, bar: bar, baz: baz) + someOtherOperand + andAThirdOneForReasons
       let result = firstOp + secondOp + someOpFetchingFunc(foo, bar: bar, baz: baz)
       let result = someOpFetchingFunc(foo, bar: bar, baz: baz)
       let result = someOpFetchingFunc(foo, bar: bar, baz: baz) + someOtherOperand + andAThirdOneForReasons
+      let result = firstOp + secondOp + thirdOp + someOpFetchingFunc(foo, bar, baz) + nextOp + lastOp
       """
-    let expected =
+
+    let expectedWithArgBinPacking =
       """
-      result = firstOp + secondOp
-        + someOpFetchingFunc(
-          foo, bar: bar, baz: baz)
-      result = someOpFetchingFunc(
-        foo, bar: bar, baz: baz)
-      result += someOpFetchingFunc(
-        foo, bar: bar, baz: baz)
-      result = someOpFetchingFunc(
-        foo, bar: bar, baz: baz)
-        + someOtherOperand
-        + andAThirdOneForReasons
-      let result = firstOp + secondOp
-        + someOpFetchingFunc(
-          foo, bar: bar, baz: baz)
+      let result =
+        firstOp + secondOp
+          + someOpFetchingFunc(
+            foo, bar: bar, baz: baz)
       let result = someOpFetchingFunc(
         foo, bar: bar, baz: baz)
-      let result = someOpFetchingFunc(
-        foo, bar: bar, baz: baz)
-        + someOtherOperand
-        + andAThirdOneForReasons
+      let result =
+        someOpFetchingFunc(
+          foo, bar: bar, baz: baz)
+          + someOtherOperand
+          + andAThirdOneForReasons
+      let result =
+        firstOp + secondOp + thirdOp
+          + someOpFetchingFunc(
+            foo, bar, baz) + nextOp
+          + lastOp
 
       """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 35)
+    var config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(
+      input: input, expected: expectedWithArgBinPacking, linelength: 35, configuration: config)
+
+    let expectedWithBreakBeforeEachArg =
+      """
+      let result =
+        firstOp + secondOp
+          + someOpFetchingFunc(
+            foo,
+            bar: bar,
+            baz: baz
+          )
+      let result = someOpFetchingFunc(
+        foo,
+        bar: bar,
+        baz: baz
+      )
+      let result =
+        someOpFetchingFunc(
+          foo,
+          bar: bar,
+          baz: baz
+        ) + someOtherOperand
+          + andAThirdOneForReasons
+      let result =
+        firstOp + secondOp + thirdOp
+          + someOpFetchingFunc(
+            foo,
+            bar,
+            baz
+          ) + nextOp + lastOp
+
+      """
+    config.lineBreakBeforeEachArgument = true
+    assertPrettyPrintEqual(
+      input: input, expected: expectedWithBreakBeforeEachArg, linelength: 35, configuration: config)
   }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/BinaryOperatorExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/BinaryOperatorExprTests.swift
@@ -16,8 +16,9 @@ public class BinaryOperatorExprTests: PrettyPrintTestCase {
 
     let expected10 =
       """
-      x = 1 + 8
-        - 9
+      x =
+        1 + 8
+          - 9
         ^*^ 5
         * 4 / 10
 
@@ -73,14 +74,18 @@ public class BinaryOperatorExprTests: PrettyPrintTestCase {
 
     let expected10 =
       """
-      x = 1++
-        ... 100
-      x = 1--
-        ..< 100
-      x = 1++
-        ... 100
-      x = 1--
-        ..< 100
+      x =
+        1++
+          ... 100
+      x =
+        1--
+          ..< 100
+      x =
+        1++
+          ... 100
+      x =
+        1--
+          ..< 100
 
       """
 
@@ -109,14 +114,18 @@ public class BinaryOperatorExprTests: PrettyPrintTestCase {
 
     let expected10 =
       """
-      x = 1
-        ... -100
-      x = 1
-        ..< -100
-      x = 1
-        ... √100
-      x = 1
-        ..< √100
+      x =
+        1
+          ... -100
+      x =
+        1
+          ..< -100
+      x =
+        1
+          ... √100
+      x =
+        1
+          ..< √100
 
       """
 
@@ -145,14 +154,18 @@ public class BinaryOperatorExprTests: PrettyPrintTestCase {
 
     let expected10 =
       """
-      x = 1++
-        ... -100
-      x = 1--
-        ..< -100
-      x = 1++
-        ... √100
-      x = 1--
-        ..< √100
+      x =
+        1++
+          ... -100
+      x =
+        1--
+          ..< -100
+      x =
+        1++
+          ... √100
+      x =
+        1--
+          ..< √100
 
       """
 

--- a/Tests/SwiftFormatPrettyPrintTests/CommentTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/CommentTests.swift
@@ -179,8 +179,9 @@ public class CommentTests: PrettyPrintTestCase {
       default: ()
       }
 
-      let a = 123 +  // comment
-        b + c
+      let a =
+        123 +  // comment
+          b + c
 
       let d = 123
       // Trailing Comment

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
@@ -217,8 +217,9 @@ public class FunctionCallTests: PrettyPrintTestCase {
 
     let expected =
       """
-      let result = firstObj.someOptionalReturningFunc(foo: arg)
-        ?? (someOtherObj as SomeUsefulType).someGetterFunc()
+      let result =
+        firstObj.someOptionalReturningFunc(foo: arg)
+          ?? (someOtherObj as SomeUsefulType).someGetterFunc()
 
       """
 

--- a/Tests/SwiftFormatPrettyPrintTests/MemberAccessExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/MemberAccessExprTests.swift
@@ -115,8 +115,9 @@ public class MemberAccessExprTests: PrettyPrintTestCase {
 
     let expected =
       """
-      let totalHeight = Constants.textFieldHeight
-        + Constants.borderHeight + Constants.importantLabelHeight
+      let totalHeight =
+        Constants.textFieldHeight + Constants.borderHeight
+          + Constants.importantLabelHeight
 
       """
 

--- a/Tests/SwiftFormatPrettyPrintTests/RespectsExistingLineBreaksTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/RespectsExistingLineBreaksTests.swift
@@ -14,11 +14,12 @@ class RespectsExistingLineBreaksTests: PrettyPrintTestCase {
 
     let expectedRespecting =
       """
-      a = b + c
-        + d
-        + e + f
-        + g
-        + h + i
+      a =
+        b + c
+          + d
+          + e + f
+          + g
+          + h + i
 
       """
 
@@ -28,8 +29,9 @@ class RespectsExistingLineBreaksTests: PrettyPrintTestCase {
 
     let expectedNotRespecting =
       """
-      a = b + c + d + e + f + g
-        + h + i
+      a =
+        b + c + d + e + f + g
+          + h + i
 
       """
 

--- a/Tests/SwiftFormatPrettyPrintTests/VariableDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/VariableDeclTests.swift
@@ -9,12 +9,13 @@ public class VariableDeclarationTests: PrettyPrintTestCase {
 
     let expected =
       """
-      let x = firstVariable
-        + secondVariable
-        / thirdVariable
-        + fourthVariable
-      let y: Int = anotherVar
-        + moreVar
+      let x =
+        firstVariable
+          + secondVariable
+          / thirdVariable
+          + fourthVariable
+      let y: Int =
+        anotherVar + moreVar
       let (w, z, s):
         (Int, Double, Bool) =
           firstTuple + secondTuple

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -43,7 +43,8 @@ extension AssignmentExprTests {
     // to regenerate.
     static let __allTests__AssignmentExprTests = [
         ("testAssignmentExprsWithGroupedOperators", testAssignmentExprsWithGroupedOperators),
-        ("testAssignmentFromFunctionCalls", testAssignmentFromFunctionCalls),
+        ("testAssignmentOperatorFromSequenceWithFunctionCalls", testAssignmentOperatorFromSequenceWithFunctionCalls),
+        ("testAssignmentPatternBindingFromSequenceWithFunctionCalls", testAssignmentPatternBindingFromSequenceWithFunctionCalls),
         ("testBasicAssignmentExprs", testBasicAssignmentExprs),
     ]
 }


### PR DESCRIPTION
Changes:
1. Add a group around the RHS of assignments (including pattern binding, e.g. let and var initializers) when the RHS expression is "compound".
2. Add a continuation open break before the RHS of assignments in a sequence expression to be consistent with pattern binding, which already has a continuation open break before the initializer expression.

Compound means an expression that consists of multiple subexpressions, including wrapper expressions, like try, by investigating the contents of the wrapped expression.

The additional groups around RHS of assignments better encapsulate the subexpression so that the RHS is visually separated from the LHS and assignment token.