### PR TITLE
Use continuation opens instead of block opens around conditions in if…

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -412,13 +412,12 @@ private final class TokenStreamCreator: SyntaxVisitor {
   func visit(_ node: IfStmtSyntax) -> SyntaxVisitorContinueKind {
     after(node.ifKeyword, tokens: .space)
 
-    // Add break groups around any conditions after the first so that those conditions have at least
-    // 1 non-continuation based indent from an indentation stack. Without that indent, all
-    // continuation lines in the condition are indented by the same amount as the condition's first
-    // line because continuation breaks don't stack. There are no breaks around the first condition
-    // because if-statements look better without a break between the "if" and the first condition.
+    // Add break groups, using open continuation breaks, around any conditions after the first so
+    // that continuations inside of the conditions can stack in addition to continuations between
+    // the conditions. There are no breaks around the first condition because if-statements look
+    // better without a break between the "if" and the first condition.
     for condition in node.conditions.dropFirst() {
-      before(condition.firstToken, tokens: .break(.open, size: 0))
+      before(condition.firstToken, tokens: .break(.open(kind: .continuation), size: 0))
       after(condition.lastToken, tokens: .break(.close(mustBreak: false), size: 0))
     }
 
@@ -438,11 +437,10 @@ private final class TokenStreamCreator: SyntaxVisitor {
   func visit(_ node: GuardStmtSyntax) -> SyntaxVisitorContinueKind {
     after(node.guardKeyword, tokens: .space)
 
-    // Add break groups around all conditions, similar to the break groups used around if-statement
-    // conditions. For guard-statements, breaking after the "guard" is visually acceptable hence the
-    // first condition is included.
+    // Add break groups, using open continuation breaks, around all conditions so that continuations
+    // inside of the conditions can stack in addition to continuations between the conditions.
     for condition in node.conditions {
-      before(condition.firstToken, tokens: .break(.open, size: 0))
+      before(condition.firstToken, tokens: .break(.open(kind: .continuation), size: 0))
       after(condition.lastToken, tokens: .break(.close(mustBreak: false), size: 0))
     }
 

--- a/Tests/SwiftFormatPrettyPrintTests/GuardStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/GuardStmtTests.swift
@@ -123,6 +123,9 @@ public class GuardStmtTests: PrettyPrintTestCase {
         let anotherCastedObject = object as? SomeOtherSlightlyLongerType else {
         return nil
       }
+      guard let object1 = fetchingFunc(foo), let object2 = fetchingFunc(bar), let object3 = fetchingFunc(baz) else {
+        return nil
+      }
       """
 
     let expected =
@@ -146,6 +149,12 @@ public class GuardStmtTests: PrettyPrintTestCase {
           foo, bar, baz, quxxe, far, fab, faz),
         let anotherCastedObject = object
           as? SomeOtherSlightlyLongerType
+      else {
+        return nil
+      }
+      guard let object1 = fetchingFunc(foo),
+        let object2 = fetchingFunc(bar),
+        let object3 = fetchingFunc(baz)
       else {
         return nil
       }

--- a/Tests/SwiftFormatPrettyPrintTests/IfStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/IfStmtTests.swift
@@ -232,6 +232,9 @@ public class IfStmtTests: PrettyPrintTestCase {
         let anotherCastedObject = object as? SomeOtherSlightlyLongerType {
         return nil
       }
+      if let object1 = fetchingFunc(foo), let object2 = fetchingFunc(bar), let object3 = fetchingFunc(baz) {
+        return nil
+      }
       """
 
     let expected =
@@ -254,6 +257,12 @@ public class IfStmtTests: PrettyPrintTestCase {
         foo, bar, baz, quxxe, far, fab, faz),
         let anotherCastedObject = object
           as? SomeOtherSlightlyLongerType
+      {
+        return nil
+      }
+      if let object1 = fetchingFunc(foo),
+        let object2 = fetchingFunc(bar),
+        let object3 = fetchingFunc(baz)
       {
         return nil
       }


### PR DESCRIPTION
… and guard stmts.

The block type of open creates 2x indents when the open break occurs on a line that is a continuation, because the relevant active-open-break can contribute a block indent and a continuation indent. The conditions in if and guard stmts aren't code blocks. These open breaks were added to support stacking a single continuation inside of each condition. The continuation type of open was added later and better models the behavior desired in this case.