### PR TITLE
Various fixes for switch/case statements.

### DIFF
--- a/Sources/SwiftFormatRules/NoCasesWithOnlyFallthrough.swift
+++ b/Sources/SwiftFormatRules/NoCasesWithOnlyFallthrough.swift
@@ -26,14 +26,14 @@ public final class NoCasesWithOnlyFallthrough: SyntaxFormatRule {
 
   public override func visit(_ node: SwitchCaseListSyntax) -> Syntax {
     var newChildren: [Syntax] = []
-    var fallthroughOnlyCasesAndLabels: [(case: SwitchCaseSyntax, label: SwitchCaseLabelSyntax)] = []
+    var fallthroughOnlyCases: [SwitchCaseSyntax] = []
 
     /// Flushes any un-collapsed violations to the new cases list.
     func flushViolations() {
-      fallthroughOnlyCasesAndLabels.forEach {
-        newChildren.append(super.visit($0.case))
+      fallthroughOnlyCases.forEach {
+        newChildren.append(super.visit($0))
       }
-      fallthroughOnlyCasesAndLabels.removeAll()
+      fallthroughOnlyCases.removeAll()
     }
 
     for element in node {
@@ -49,47 +49,43 @@ public final class NoCasesWithOnlyFallthrough: SyntaxFormatRule {
       if isFallthroughOnly(switchCase), let label = switchCase.label as? SwitchCaseLabelSyntax {
         // If the case is fallthrough-only, store it as a violation that we will merge later.
         diagnose(.collapseCase(name: "\(label)"), on: switchCase)
-        fallthroughOnlyCasesAndLabels.append((case: switchCase, label: label))
+        fallthroughOnlyCases.append(switchCase)
       } else {
-        guard fallthroughOnlyCasesAndLabels.count > 0 else {
+        guard !fallthroughOnlyCases.isEmpty else {
           // If there are no violations recorded, just append the case. There's nothing we can try
           // to merge into it.
           newChildren.append(visit(switchCase))
           continue
         }
 
+        // If the case is not a `case ...`, then it must be a `default`. Under *most* circumstances,
+        // we could simply remove the immediately preceding `fallthrough`-only cases because they
+        // would end up falling through to the `default`, which would match them anyway. However,
+        // if any of the patterns in those cases have side effects, removing those cases would
+        // change the program's behavior. Nobody should ever write code like this, but we don't want
+        // to risk changing behavior just by reformatting.
+        guard switchCase.label is SwitchCaseLabelSyntax else {
+          flushViolations()
+          newChildren.append(visit(switchCase))
+          continue
+        }
+
         // We have a case that's not fallthrough-only, and a list of fallthrough-only cases before
         // it. Merge them and add the result to the new list.
-        var collapsedCase: SwitchCaseSyntax
-
-        if let label = switchCase.label as? SwitchCaseLabelSyntax {
-          if retrieveNumericCaseValue(caseLabel: label) != nil {
-            collapsedCase = collapseIntegerCases(
-              violations: fallthroughOnlyCasesAndLabels.lazy.map { $0.label },
-              validCaseLabel: label,
-              validCase: switchCase)
-          } else {
-            collapsedCase = collapseNonIntegerCases(
-              violations: fallthroughOnlyCasesAndLabels.lazy.map { $0.label },
-              validCaseLabel: label,
-              validCase: switchCase)
-          }
-        } else {
-          collapsedCase = switchCase
-        }
+        var newCase = mergedCase(violations: fallthroughOnlyCases, validCase: switchCase)
 
         // Only the first violation case can have displaced trivia, because any non-whitespace
         // trivia in the other violation cases would've prevented collapsing.
         if let displacedLeadingTrivia =
-          fallthroughOnlyCasesAndLabels.first?.1.leadingTrivia?.withoutLastLine()
+          fallthroughOnlyCases.first?.leadingTrivia?.withoutLastLine()
         {
-          let existingLeadingTrivia = collapsedCase.leadingTrivia ?? []
+          let existingLeadingTrivia = newCase.leadingTrivia ?? []
           let mergedLeadingTrivia = displacedLeadingTrivia + existingLeadingTrivia
-          collapsedCase = collapsedCase.withLeadingTrivia(mergedLeadingTrivia)
+          newCase = newCase.withLeadingTrivia(mergedLeadingTrivia)
         }
 
-        newChildren.append(visit(collapsedCase))
-        fallthroughOnlyCasesAndLabels.removeAll()
+        newChildren.append(visit(newCase))
+        fallthroughOnlyCases.removeAll()
       }
     }
 
@@ -101,6 +97,7 @@ public final class NoCasesWithOnlyFallthrough: SyntaxFormatRule {
   }
 
   /// Returns whether the given `SwitchCaseSyntax` contains only a fallthrough statement.
+  ///
   /// - Parameter switchCase: A syntax node describing a case in a switch statement.
   private func isFallthroughOnly(_ switchCase: SwitchCaseSyntax) -> Bool {
     // When there are any additional or non-fallthrough statements, it isn't only a fallthrough.
@@ -132,96 +129,31 @@ public final class NoCasesWithOnlyFallthrough: SyntaxFormatRule {
     return true
   }
 
-  // Puts all given cases on one line with range operator or commas
-  private func collapseIntegerCases<Labels: Sequence>(
-    violations: Labels,
-    validCaseLabel: SwitchCaseLabelSyntax, validCase: SwitchCaseSyntax
-  ) -> SwitchCaseSyntax where Labels.Element == SwitchCaseLabelSyntax {
-    var isConsecutive = true
-    var index = 0
-    var caseNums: [Int] = []
-
-    for item in violations {
-      guard let caseNum = retrieveNumericCaseValue(caseLabel: item) else { continue }
-      caseNums.append(caseNum)
-    }
-
-    guard let validCaseNum = retrieveNumericCaseValue(caseLabel: validCaseLabel) else {
-      return validCase
-    }
-    caseNums.append(validCaseNum)
-
-    while index <= caseNums.count - 2, isConsecutive {
-      isConsecutive = caseNums[index] + 1 == caseNums[index + 1]
-      index += 1
-    }
-
+  /// Returns a copy of the given valid case (and its statements) but with the case items from the
+  /// violations merged with its own case items.
+  private func mergedCase(violations: [SwitchCaseSyntax], validCase: SwitchCaseSyntax)
+    -> SwitchCaseSyntax
+  {
     var newCaseItems: [CaseItemSyntax] = []
-    let first = caseNums[0]
-    let last = caseNums[caseNums.count - 1]
-    if isConsecutive {
-      // Create a case with a sequence expression based on the new range
-      let start = SyntaxFactory.makeIntegerLiteralExpr(
-        digits: SyntaxFactory.makeIntegerLiteral("\(first)"))
-      let end = SyntaxFactory.makeIntegerLiteralExpr(
-        digits: SyntaxFactory.makeIntegerLiteral("\(last)"))
-      let newExpList = SyntaxFactory.makeExprList(
-        [
-          start,
-          SyntaxFactory.makeBinaryOperatorExpr(
-            operatorToken:
-              SyntaxFactory.makeUnspacedBinaryOperator("...")),
-          end,
-        ])
-      let newExpPat = SyntaxFactory.makeExpressionPattern(
-        expression: SyntaxFactory.makeSequenceExpr(elements: newExpList))
+
+    for label in violations.lazy.compactMap({ $0.label as? SwitchCaseLabelSyntax }) {
+      let caseItems = Array(label.caseItems)
+
+      // We can blindly append all but the last case item because they must already have a trailing
+      // comma. Then, we need to add a trailing comma to the last one, since it will be followed by
+      // more items.
+      newCaseItems.append(contentsOf: caseItems.dropLast())
       newCaseItems.append(
-        SyntaxFactory.makeCaseItem(pattern: newExpPat, whereClause: nil, trailingComma: nil))
-    } else {
-      // Add each case item separated by a comma
-      for num in caseNums {
-        let newExpPat = SyntaxFactory.makeExpressionPattern(
-          expression: SyntaxFactory.makeIntegerLiteralExpr(
-            digits: SyntaxFactory.makeIntegerLiteral("\(num)")))
-        let trailingComma = SyntaxFactory.makeCommaToken(trailingTrivia: .spaces(1))
-        let newCaseItem = SyntaxFactory.makeCaseItem(
-          pattern: newExpPat,
-          whereClause: nil,
-          trailingComma: num == last ? nil : trailingComma
-        )
-        newCaseItems.append(newCaseItem)
-      }
+        caseItems.last!.withTrailingComma(
+          SyntaxFactory.makeCommaToken(trailingTrivia: .spaces(1))))
     }
-    let caseItemList = SyntaxFactory.makeCaseItemList(newCaseItems)
-    return validCase.withLabel(validCaseLabel.withCaseItems(caseItemList))
-  }
 
-  // Gets integer value from case label, if possible
-  private func retrieveNumericCaseValue(caseLabel: SwitchCaseLabelSyntax) -> Int? {
-    if let firstTok = caseLabel.caseItems.firstToken, let num = Int(firstTok.text) {
-      return num
-    }
-    return nil
-  }
+    let validCaseLabel = validCase.label as! SwitchCaseLabelSyntax
+    newCaseItems.append(contentsOf: validCaseLabel.caseItems)
 
-  // Puts all given cases on one line separated by commas
-  private func collapseNonIntegerCases<Labels: Sequence>(
-    violations: Labels,
-    validCaseLabel: SwitchCaseLabelSyntax, validCase: SwitchCaseSyntax
-  ) -> SwitchCaseSyntax where Labels.Element == SwitchCaseLabelSyntax {
-    var newCaseItems: [CaseItemSyntax] = []
-    for violation in violations {
-      for item in violation.caseItems {
-        let newCaseItem = item.withTrailingComma(
-          SyntaxFactory.makeCommaToken(trailingTrivia: .spaces(1)))
-        newCaseItems.append(newCaseItem)
-      }
-    }
-    for item in validCaseLabel.caseItems {
-      newCaseItems.append(item)
-    }
-    let caseItemList = SyntaxFactory.makeCaseItemList(newCaseItems)
-    return validCase.withLabel(validCaseLabel.withCaseItems(caseItemList))
+    return validCase.withLabel(
+      validCaseLabel.withCaseItems(
+        SyntaxFactory.makeCaseItemList(newCaseItems)))
   }
 }
 

--- a/Tests/SwiftFormatPrettyPrintTests/SwitchStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/SwitchStmtTests.swift
@@ -216,4 +216,44 @@ public class SwitchStmtTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20)
   }
+
+  public func testNewlinesDisambiguatingWhereClauses() {
+    let input =
+      """
+      switch foo {
+      case 1, 2, 3:
+        break
+      case 4 where bar(), 5, 6:
+        break
+      case 7, 8, 9 where bar():
+        break
+      case 10 where bar(), 11 where bar(), 12 where bar():
+        break
+      case 13, 14 where bar(), 15, 16 where bar():
+        break
+      }
+      """
+
+    let expected =
+      """
+      switch foo {
+      case 1, 2, 3:
+        break
+      case 4 where bar(), 5, 6:
+        break
+      case 7, 8,
+        9 where bar():
+        break
+      case 10 where bar(), 11 where bar(), 12 where bar():
+        break
+      case 13,
+        14 where bar(), 15,
+        16 where bar():
+        break
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 80)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -575,6 +575,7 @@ extension SwitchStmtTests {
     static let __allTests__SwitchStmtTests = [
         ("testBasicSwitch", testBasicSwitch),
         ("testNestedSwitch", testNestedSwitch),
+        ("testNewlinesDisambiguatingWhereClauses", testNewlinesDisambiguatingWhereClauses),
         ("testSwitchCases", testSwitchCases),
         ("testSwitchCompoundCases", testSwitchCompoundCases),
         ("testSwitchValueBinding", testSwitchValueBinding),

--- a/Tests/SwiftFormatRulesTests/NoCasesWithOnlyFallthroughTests.swift
+++ b/Tests/SwiftFormatRulesTests/NoCasesWithOnlyFallthroughTests.swift
@@ -41,7 +41,7 @@ final class NoCasesWithOnlyFallthroughTests: DiagnosingTestCase {
       expected: """
         switch numbers {
         case 1: print("one")
-        case 2...4: print("two to four")
+        case 2, 3, 4: print("two to four")
         case 5, 7: print("five or seven")
         default: break
         }
@@ -55,6 +55,7 @@ final class NoCasesWithOnlyFallthroughTests: DiagnosingTestCase {
         case .comma: print(",")
         case .rightBrace, .leftBrace, .braces: print("{}")
         case .period: print(".")
+        case .empty: fallthrough
         default: break
         }
         """)
@@ -86,14 +87,14 @@ final class NoCasesWithOnlyFallthroughTests: DiagnosingTestCase {
         case 1:
           return 0 // This return has an inline comment.
         // This case is commented so it should stay.
-        case 2...3:
+        case 2, 3:
           fallthrough
         case 4:
           // This fallthrough is commented so it should stay.
           fallthrough
         case 5: fallthrough  // This fallthrough is relevant.
         // This case has a descriptive comment.
-        case 6...7: print("got here")
+        case 6, 7: print("got here")
         }
         """)
   }
@@ -119,10 +120,10 @@ final class NoCasesWithOnlyFallthroughTests: DiagnosingTestCase {
         case 5:
           return 42 // This return is important.
         // This case has an important comment.
-        case 6...7: print("6 to 7")
+        case 6, 7: print("6 to 7")
 
         // This case has an extra leading newline for emphasis.
-        case 8...9: print("8 to 9")
+        case 8, 9: print("8 to 9")
         }
         """)
   }
@@ -148,13 +149,13 @@ final class NoCasesWithOnlyFallthroughTests: DiagnosingTestCase {
         """,
       expected: """
         switch x {
-        case 1...3:
+        case 1, 2, 3:
           switch y {
-          case 1...2: print(2)
+          case 1, 2: print(2)
           }
         case 4:
           switch y {
-          case 1...2: print(2)
+          case 1, 2: print(2)
           }
         }
         """)
@@ -187,10 +188,10 @@ final class NoCasesWithOnlyFallthroughTests: DiagnosingTestCase {
         switch x {
         case 1: fallthrough
         #if FOO
-        case 2...3: print(3)
+        case 2, 3: print(3)
         case 4: print(4)
         #endif
-        case 5...6: print(6)
+        case 5, 6: print(6)
         #if BAR
         #if BAZ
         case 7: print(7)
@@ -199,6 +200,36 @@ final class NoCasesWithOnlyFallthroughTests: DiagnosingTestCase {
         case 9: fallthrough
         #endif
         case 10: print(10)
+        }
+        """)
+  }
+
+  func testCasesWithWhereClauses() {
+    // As noted in the rule implementation, the formatted result should include a newline before any
+    // case items that have `where` clauses if they follow any case items that do not, to avoid
+    // compiler warnings. This is handled by the pretty printer, not this rule.
+    XCTAssertFormatting(
+      NoCasesWithOnlyFallthrough.self,
+      input: """
+        switch x {
+        case 1 where y < 0: fallthrough
+        case 2 where y == 0: fallthrough
+        case 3 where y < 0: fallthrough
+        case 4 where y != 0: print(4)
+        case 5: fallthrough
+        case 6: fallthrough
+        case 7: fallthrough
+        case 8: fallthrough
+        case 9: fallthrough
+        case 10 where y == 0: print(10)
+        default: print("?")
+        }
+        """,
+      expected: """
+        switch x {
+        case 1 where y < 0, 2 where y == 0, 3 where y < 0, 4 where y != 0: print(4)
+        case 5, 6, 7, 8, 9, 10 where y == 0: print(10)
+        default: print("?")
         }
         """)
   }

--- a/Tests/SwiftFormatRulesTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatRulesTests/XCTestManifests.swift
@@ -176,6 +176,7 @@ extension NoCasesWithOnlyFallthroughTests {
     // to regenerate.
     static let __allTests__NoCasesWithOnlyFallthroughTests = [
         ("testCasesInsideConditionalCompilationBlock", testCasesInsideConditionalCompilationBlock),
+        ("testCasesWithWhereClauses", testCasesWithWhereClauses),
         ("testCommentsAroundCombinedCasesStayInPlace", testCommentsAroundCombinedCasesStayInPlace),
         ("testFallthroughCases", testFallthroughCases),
         ("testFallthroughCasesWithCommentsAreNotCombined", testFallthroughCasesWithCommentsAreNotCombined),


### PR DESCRIPTION
- When combining integer fallthrough-only cases into ranges, we
  were dropping their where-clauses.
- It's not entirely safe to collapse integer cases into ranges,
  because it's possible to write a type that implements `~=` such
  that it only pattern matches against integers but not ranges.
  These are now collapsed into comma-delimited lists.
- It's not entirely safe to remove fallthrough-only cases before
  a default clause. Even though the default would match those, the
  patterns could have side effects. This is awful, but possible,
  and would break at runtime (not detected at compile-time).

The pretty-printer now also inserts newlines before case items
that have where clauses if they immediately follow a case item
that does not have a where clause, to avoid compiler warnings.