### PR TITLE
Don't remove spaces around a range operator followed by a prefix dot.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -2510,12 +2510,16 @@ private final class TokenStreamCreator: SyntaxVisitor {
         precedence === operatorContext.precedenceGroup(named: .rangeFormation)
       {
         // We want to omit whitespace around range formation operators if possible. We can't do this
-        // if the token is either preceded by a postfix operator or followed by a prefix operator---
-        // removing the spaces in those situations would cause the parser to greedily treat the
-        // combined sequence of operator characters as a single operator.
+        // if the token is either preceded by a postfix operator, followed by a prefix operator, or
+        // followed by a dot (for example, in an implicit member reference)---removing the spaces in
+        // those situations would cause the parser to greedily treat the combined sequence of
+        // operator characters as a single operator.
         if case .postfixOperator? = token.previousToken?.tokenKind { return true }
-        if case .prefixOperator? = token.nextToken?.tokenKind { return true }
-        return false
+
+        switch token.nextToken?.tokenKind {
+        case .prefixOperator?, .prefixPeriod?: return true
+        default: return false
+        }
       }
     }
 

--- a/Tests/SwiftFormatPrettyPrintTests/BinaryOperatorExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/BinaryOperatorExprTests.swift
@@ -171,4 +171,44 @@ public class BinaryOperatorExprTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected10, linelength: 10)
   }
+
+  public func testRangeFormationOperatorsAreNotCompactedWhenPrecedingPrefixDot() {
+    let input =
+      """
+      x = .first   ...   .last
+      x = .first   ..<   .last
+      x = .first   ...   .last
+      x = .first   ..<   .last
+      """
+
+    let expected80 =
+      """
+      x = .first ... .last
+      x = .first ..< .last
+      x = .first ... .last
+      x = .first ..< .last
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected80, linelength: 80)
+
+    let expected10 =
+      """
+      x =
+        .first
+          ... .last
+      x =
+        .first
+          ..< .last
+      x =
+        .first
+          ... .last
+      x =
+        .first
+          ..< .last
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected10, linelength: 10)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -94,6 +94,7 @@ extension BinaryOperatorExprTests {
         ("testRangeFormationOperatorsAreCompactedWhenPossible", testRangeFormationOperatorsAreCompactedWhenPossible),
         ("testRangeFormationOperatorsAreNotCompactedWhenFollowingAPostfixOperator", testRangeFormationOperatorsAreNotCompactedWhenFollowingAPostfixOperator),
         ("testRangeFormationOperatorsAreNotCompactedWhenPrecedingAPrefixOperator", testRangeFormationOperatorsAreNotCompactedWhenPrecedingAPrefixOperator),
+        ("testRangeFormationOperatorsAreNotCompactedWhenPrecedingPrefixDot", testRangeFormationOperatorsAreNotCompactedWhenPrecedingPrefixDot),
         ("testRangeFormationOperatorsAreNotCompactedWhenUnaryOperatorsAreOnEachSide", testRangeFormationOperatorsAreNotCompactedWhenUnaryOperatorsAreOnEachSide),
     ]
 }


### PR DESCRIPTION
I *believe* this is the last remaining place where an "operator character"
would occur in an expression following a binary range operator where that
character would not already be identified itself as an operator token.

Fixes SR-11798.