### PR TITLE
Vastly improve formatting of ternary expressions.

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/TernaryExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/TernaryExprTests.swift
@@ -16,14 +16,17 @@ public class TernaryExprTests: PrettyPrintTestCase {
       let x = a ? b : c
       let y = a ? b : c
       let z = a ? b : c
-      let reallyLongName = a
-        ? longTruePart : longFalsePart
-      let reallyLongName = reallyLongCondition
+      let reallyLongName =
+        a ? longTruePart : longFalsePart
+      let reallyLongName =
+        reallyLongCondition
         ? reallyLongTruePart : reallyLongFalsePart
-      let reallyLongName = reallyLongCondition
+      let reallyLongName =
+        reallyLongCondition
         ? reallyReallyReallyLongTruePart
         : reallyLongFalsePart
-      let reallyLongName = someCondition
+      let reallyLongName =
+        someCondition
         ? firstFunc(foo: arg)
         : secondFunc(bar: arg)
 
@@ -51,5 +54,157 @@ public class TernaryExprTests: PrettyPrintTestCase {
       """
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 80)
+  }
+
+  public func testTernaryWithWrappingExpressions() {
+    let input =
+      """
+      foo = firstTerm + secondTerm + thirdTerm ? firstTerm + secondTerm + thirdTerm : firstTerm + secondTerm + thirdTerm
+      let foo = firstTerm + secondTerm + thirdTerm ? firstTerm + secondTerm + thirdTerm : firstTerm + secondTerm + thirdTerm
+      foo = firstTerm || secondTerm && thirdTerm ? firstTerm + secondTerm + thirdTerm : firstTerm + secondTerm + thirdTerm
+      let foo = firstTerm || secondTerm && thirdTerm ? firstTerm + secondTerm + thirdTerm : firstTerm + secondTerm + thirdTerm
+      """
+
+    let expected =
+      """
+      foo =
+        firstTerm
+          + secondTerm
+          + thirdTerm
+        ? firstTerm
+          + secondTerm
+          + thirdTerm
+        : firstTerm
+          + secondTerm
+          + thirdTerm
+      let foo =
+        firstTerm
+          + secondTerm
+          + thirdTerm
+        ? firstTerm
+          + secondTerm
+          + thirdTerm
+        : firstTerm
+          + secondTerm
+          + thirdTerm
+      foo =
+        firstTerm
+          || secondTerm
+            && thirdTerm
+        ? firstTerm
+          + secondTerm
+          + thirdTerm
+        : firstTerm
+          + secondTerm
+          + thirdTerm
+      let foo =
+        firstTerm
+          || secondTerm
+            && thirdTerm
+        ? firstTerm
+          + secondTerm
+          + thirdTerm
+        : firstTerm
+          + secondTerm
+          + thirdTerm
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 15)
+  }
+
+  public func testNestedTernaries() {
+    let input =
+      """
+      a = b ? c : d ? e : f
+      let a = b ? c : d ? e : f
+      a = b ? c0 + c1 : d ? e : f
+      let a = b ? c0 + c1 : d ? e : f
+      a = b ? c0 + c1 + c2 + c3 : d ? e : f
+      let a = b ? c0 + c1 + c2 + c3 : d ? e : f
+      foo = testA ? testB ? testC : testD : testE ? testF : testG
+      let foo = testA ? testB ? testC : testD : testE ? testF : testG
+      """
+
+    let expected =
+      """
+      a =
+        b
+        ? c
+        : d ? e : f
+      let a =
+        b
+        ? c
+        : d ? e : f
+      a =
+        b
+        ? c0 + c1
+        : d ? e : f
+      let a =
+        b
+        ? c0 + c1
+        : d ? e : f
+      a =
+        b
+        ? c0 + c1
+          + c2 + c3
+        : d ? e : f
+      let a =
+        b
+        ? c0 + c1
+          + c2 + c3
+        : d ? e : f
+      foo =
+        testA
+        ? testB
+          ? testC
+          : testD
+        : testE
+          ? testF
+          : testG
+      let foo =
+        testA
+        ? testB
+          ? testC
+          : testD
+        : testE
+          ? testF
+          : testG
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 15)
+  }
+
+  public func testExpressionStartsWithTernary() {
+    // When the ternary itself doesn't already start on a continuation line, we don't have a way
+    // to indent the continuation of the condition differently from the first and second choices,
+    // because we don't want to double-indent the condition's continuation lines, and we don't want
+    // to keep put the choices at the same indentation level as the condition (because that would
+    // be the start of the statement). Neither of these choices is really ideal, unfortunately.
+    let input =
+      """
+      condition ? callSomething() : callSomethingElse()
+      condition && otherCondition ? callSomething() : callSomethingElse()
+      (condition && otherCondition) ? callSomething() : callSomethingElse()
+      """
+
+    let expected =
+      """
+      condition
+        ? callSomething()
+        : callSomethingElse()
+      condition
+        && otherCondition
+        ? callSomething()
+        : callSomethingElse()
+      (condition
+        && otherCondition)
+        ? callSomething()
+        : callSomethingElse()
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 25)
   }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -632,8 +632,11 @@ extension TernaryExprTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__TernaryExprTests = [
+        ("testExpressionStartsWithTernary", testExpressionStartsWithTernary),
+        ("testNestedTernaries", testNestedTernaries),
         ("testTernaryExprs", testTernaryExprs),
         ("testTernaryExprsWithMultiplePartChoices", testTernaryExprsWithMultiplePartChoices),
+        ("testTernaryWithWrappingExpressions", testTernaryWithWrappingExpressions),
     ]
 }
 


### PR DESCRIPTION
This change now ensures that continuation indentation is stacked within
the condition/first choice/second choice of a ternary expression, which
ensures that those parts as well as nested ternary expressions cascade
in a readable fashion (instead of all having the same continuation indent,
as they do today).