### PR TITLE
Replace enable/disable directives with ignore for formatter rules.

### DIFF
--- a/Sources/SwiftFormatCore/Context.swift
+++ b/Sources/SwiftFormatCore/Context.swift
@@ -75,14 +75,11 @@ public class Context {
   /// location or not.
   public func isRuleEnabled(_ ruleName: String, node: Syntax) -> Bool {
     let loc = node.startLocation(converter: self.sourceLocationConverter)
-    guard let line = loc.line else { return false }
-    switch ruleMask.ruleState(ruleName, atLine: line) {
+    switch ruleMask.ruleState(ruleName, at: loc) {
     case .default:
       return configuration.rules[ruleName] ?? false
     case .disabled:
       return false
-    case .enabled:
-      return true
     }
   }
 }

--- a/Sources/SwiftFormatCore/RuleState.swift
+++ b/Sources/SwiftFormatCore/RuleState.swift
@@ -18,9 +18,6 @@ public enum RuleState {
   /// or disabled at the requested location, so the configuration default should be used.
   case `default`
 
-  /// The rule is explicitly enabled at the requested location.
-  case enabled
-
   /// The rule is explicitly disabled at the requested location.
   case disabled
 }

--- a/Tests/SwiftFormatCoreTests/RuleMaskTests.swift
+++ b/Tests/SwiftFormatCoreTests/RuleMaskTests.swift
@@ -5,161 +5,172 @@ import XCTest
 
 public class RuleMaskTests: XCTestCase {
 
+  /// The source converter for the text in the current test. This is implicitly unwrapped because
+  /// each test case must prepare some source text before performing any assertions, otherwise
+  /// there's a developer error.
+  var converter: SourceLocationConverter!
+
   private func createMask(sourceText: String) -> RuleMask {
     let fileURL = URL(fileURLWithPath: "/tmp/test.swift")
-    let converter = SourceLocationConverter(file: fileURL.path, source: sourceText)
+    converter = SourceLocationConverter(file: fileURL.path, source: sourceText)
     let syntax = try! SyntaxParser.parse(source: sourceText)
     return RuleMask(syntaxNode: syntax, sourceLocationConverter: converter)
+  }
+
+  /// Returns the source location that corresponds to the given line and column numbers.
+  private func location(ofLine line: Int, column: Int = 0) -> SourceLocation {
+    return converter.location(for: converter.position(ofLine: line, column: column))
   }
 
   public func testSingleRule() {
     let text =
       """
       let a = 123
-      // swift-format-disable: rule1
+      // swift-format-ignore: rule1
       let b = 456
-      // swift-format-enable: rule1
       let c = 789
       """
 
     let mask = createMask(sourceText: text)
 
-    XCTAssertEqual(mask.ruleState("rule1", atLine: 1), .default)
-    XCTAssertEqual(mask.ruleState("rule1", atLine: 3), .disabled)
-    XCTAssertEqual(mask.ruleState("rule1", atLine: 5), .enabled)
+    XCTAssertEqual(mask.ruleState("rule1", at: location(ofLine: 1)), .default)
+    XCTAssertEqual(mask.ruleState("rule1", at: location(ofLine: 3)), .disabled)
+    XCTAssertEqual(mask.ruleState("rule1", at: location(ofLine: 4)), .default)
   }
 
-  public func testTwoRules() {
+  public func testIgnoreTwoRules() {
     let text =
       """
       let a = 123
-      // swift-format-disable: rule1
+      // swift-format-ignore: rule1
       let b = 456
-      // swift-format-disable: rule2
+      // swift-format-ignore: rule2
       let c = 789
-      // swift-format-enable: rule1
+      // swift-format-ignore: rule1, rule2
       let d = "abc"
-      // swift-format-enable: rule2
       let e = "def"
       """
 
     let mask = createMask(sourceText: text)
 
-    XCTAssertEqual(mask.ruleState("rule1", atLine: 1), .default)
-    XCTAssertEqual(mask.ruleState("rule1", atLine: 3), .disabled)
-    XCTAssertEqual(mask.ruleState("rule1", atLine: 5), .disabled)
-    XCTAssertEqual(mask.ruleState("rule1", atLine: 7), .enabled)
-    XCTAssertEqual(mask.ruleState("rule1", atLine: 9), .enabled)
+    XCTAssertEqual(mask.ruleState("rule1", at: location(ofLine: 1)), .default)
+    XCTAssertEqual(mask.ruleState("rule1", at: location(ofLine: 3)), .disabled)
+    XCTAssertEqual(mask.ruleState("rule1", at: location(ofLine: 5)), .default)
+    XCTAssertEqual(mask.ruleState("rule1", at: location(ofLine: 7)), .disabled)
+    XCTAssertEqual(mask.ruleState("rule1", at: location(ofLine: 8)), .default)
 
-    XCTAssertEqual(mask.ruleState("rule2", atLine: 1), .default)
-    XCTAssertEqual(mask.ruleState("rule2", atLine: 3), .default)
-    XCTAssertEqual(mask.ruleState("rule2", atLine: 5), .disabled)
-    XCTAssertEqual(mask.ruleState("rule2", atLine: 7), .disabled)
-    XCTAssertEqual(mask.ruleState("rule2", atLine: 9), .enabled)
-  }
-
-  public func testEnableBeforeDisable() {
-    let text =
-      """
-      let a = 123
-      // swift-format-enable: rule1
-      let b = 456
-      // swift-format-disable: rule1
-      let c = 789
-      """
-
-    let mask = createMask(sourceText: text)
-
-    XCTAssertEqual(mask.ruleState("rule1", atLine: 1), .default)
-    XCTAssertEqual(mask.ruleState("rule1", atLine: 3), .enabled)
-    XCTAssertEqual(mask.ruleState("rule1", atLine: 5), .disabled)
+    XCTAssertEqual(mask.ruleState("rule2", at: location(ofLine: 1)), .default)
+    XCTAssertEqual(mask.ruleState("rule2", at: location(ofLine: 3)), .default)
+    XCTAssertEqual(mask.ruleState("rule2", at: location(ofLine: 5)), .disabled)
+    XCTAssertEqual(mask.ruleState("rule2", at: location(ofLine: 7)), .disabled)
+    XCTAssertEqual(mask.ruleState("rule2", at: location(ofLine: 8)), .default)
   }
 
   public func testDuplicateNested() {
     let text =
       """
-      let a = 123
-      // swift-format-disable: rule1
-      let b = 456
-      // swift-format-disable: rule1
-      let c = 789
-      // swift-format-enable: rule1
-      let d = "abc"
-      // swift-format-enable: rule1
-      let e = "def"
+      // swift-format-ignore: rule1
+      struct Foo {
+        var bar = 0
+
+        // swift-format-ignore: rule1
+        var baz = 0
+
+        // swift-format-ignore: rule4
+        var bazzle = 0
+
+        var barzle = 0
+      }
       """
 
     let mask = createMask(sourceText: text)
 
-    XCTAssertEqual(mask.ruleState("rule1", atLine: 1), .default)
-    XCTAssertEqual(mask.ruleState("rule1", atLine: 3), .disabled)
-    XCTAssertEqual(mask.ruleState("rule1", atLine: 5), .disabled)
-    XCTAssertEqual(mask.ruleState("rule1", atLine: 7), .enabled)
-    XCTAssertEqual(mask.ruleState("rule1", atLine: 9), .enabled)
-  }
+    XCTAssertEqual(mask.ruleState("rule1", at: location(ofLine: 3, column: 3)), .disabled)
+    XCTAssertEqual(mask.ruleState("rule4", at: location(ofLine: 3, column: 3)), .default)
 
-  public func testSingleFlags() {
-    let text1 =
-      """
-      let a = 123
-      let b = 456
-      // swift-format-disable: rule1
-      let c = 789
-      let d = "abc"
-      """
+    XCTAssertEqual(mask.ruleState("rule1", at: location(ofLine: 6, column: 3)), .disabled)
+    XCTAssertEqual(mask.ruleState("rule4", at: location(ofLine: 6, column: 3)), .default)
 
-    let mask1 = createMask(sourceText: text1)
+    XCTAssertEqual(mask.ruleState("rule1", at: location(ofLine: 9, column: 3)), .disabled)
+    XCTAssertEqual(mask.ruleState("rule4", at: location(ofLine: 9, column: 3)), .disabled)
 
-    XCTAssertEqual(mask1.ruleState("rule1", atLine: 1), .default)
-    XCTAssertEqual(mask1.ruleState("rule1", atLine: 5), .disabled)
+    XCTAssertEqual(mask.ruleState("rule4", at: location(ofLine: 11, column: 3)), .default)
 
-    let text2 =
-      """
-      let a = 123
-      let b = 456
-      // swift-format-enable: rule1
-      let c = 789
-      let d = "abc"
-      """
-
-    let mask2 = createMask(sourceText: text2)
-
-    XCTAssertEqual(mask2.ruleState("rule1", atLine: 1), .default)
-    XCTAssertEqual(mask2.ruleState("rule1", atLine: 5), .enabled)
   }
 
   public func testSpuriousFlags() {
     let text1 =
       """
       let a = 123
-      let b = 456 // swift-format-disable: rule1
+      let b = 456 // swift-format-ignore: rule1
       let c = 789
-      // swift-format-enable: rule1
-      let d = "abc"
+      /* swift-format-ignore: rule2 */
+      let d = 111
+      // swift-format-ignore:
+      let b = 456
       """
 
     let mask1 = createMask(sourceText: text1)
 
-    XCTAssertEqual(mask1.ruleState("rule1", atLine: 1), .default)
-    XCTAssertEqual(mask1.ruleState("rule1", atLine: 3), .default)
-    XCTAssertEqual(mask1.ruleState("rule1", atLine: 5), .enabled)
+    XCTAssertEqual(mask1.ruleState("rule1", at: location(ofLine: 1)), .default)
+    XCTAssertEqual(mask1.ruleState("rule1", at: location(ofLine: 2)), .default)
+    XCTAssertEqual(mask1.ruleState("rule1", at: location(ofLine: 3)), .default)
+    XCTAssertEqual(mask1.ruleState("rule1", at: location(ofLine: 5)), .default)
+    XCTAssertEqual(mask1.ruleState("rule1", at: location(ofLine: 7)), .default)
 
     let text2 =
       #"""
       let a = 123
       let b =
         """
-        // swift-format-disable: rule1
+        // swift-format-ignore: rule1
         """
       let c = 789
-      // swift-format-enable: rule1
+      // swift-format-ignore: rule1
       let d = "abc"
       """#
 
     let mask2 = createMask(sourceText: text2)
 
-    XCTAssertEqual(mask2.ruleState("rule1", atLine: 1), .default)
-    XCTAssertEqual(mask2.ruleState("rule1", atLine: 6), .default)
-    XCTAssertEqual(mask2.ruleState("rule1", atLine: 8), .enabled)
+    XCTAssertEqual(mask2.ruleState("rule1", at: location(ofLine: 1)), .default)
+    XCTAssertEqual(mask2.ruleState("rule1", at: location(ofLine: 6)), .default)
+    XCTAssertEqual(mask2.ruleState("rule1", at: location(ofLine: 8)), .disabled)
+  }
+
+  public func testNamelessDirectiveAffectsAllRules() {
+    let text =
+      """
+      let a = 123
+      // swift-format-ignore
+      let b = 456
+      let c = 789
+      """
+
+    let mask = createMask(sourceText: text)
+
+    XCTAssertEqual(mask.ruleState("rule1", at: location(ofLine: 1)), .default)
+    XCTAssertEqual(mask.ruleState("rule1", at: location(ofLine: 3)), .disabled)
+    XCTAssertEqual(mask.ruleState("TotallyMadeUpRule", at: location(ofLine: 3)), .disabled)
+    XCTAssertEqual(mask.ruleState("rule1", at: location(ofLine: 4)), .default)
+  }
+
+  public func testDirectiveWithRulesList() {
+    let text =
+      """
+      let a = 123
+      // swift-format-ignore: rule1, rule2   , AnotherRule  , TheBestRule,, ,   , ,
+      let b = 456
+      let c = 789
+      """
+
+    let mask = createMask(sourceText: text)
+
+    XCTAssertEqual(mask.ruleState("rule1", at: location(ofLine: 1)), .default)
+    XCTAssertEqual(mask.ruleState("rule1", at: location(ofLine: 3)), .disabled)
+    XCTAssertEqual(mask.ruleState("rule2", at: location(ofLine: 3)), .disabled)
+    XCTAssertEqual(mask.ruleState("AnotherRule", at: location(ofLine: 3)), .disabled)
+    XCTAssertEqual(mask.ruleState("TheBestRule", at: location(ofLine: 3)), .disabled)
+    XCTAssertEqual(mask.ruleState("TotallyMadeUpRule", at: location(ofLine: 3)), .default)
+    XCTAssertEqual(mask.ruleState("rule1", at: location(ofLine: 4)), .default)
   }
 }

--- a/Tests/SwiftFormatCoreTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatCoreTests/XCTestManifests.swift
@@ -6,12 +6,12 @@ extension RuleMaskTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__RuleMaskTests = [
+        ("testDirectiveWithRulesList", testDirectiveWithRulesList),
         ("testDuplicateNested", testDuplicateNested),
-        ("testEnableBeforeDisable", testEnableBeforeDisable),
-        ("testSingleFlags", testSingleFlags),
+        ("testIgnoreTwoRules", testIgnoreTwoRules),
+        ("testNamelessDirectiveAffectsAllRules", testNamelessDirectiveAffectsAllRules),
         ("testSingleRule", testSingleRule),
         ("testSpuriousFlags", testSpuriousFlags),
-        ("testTwoRules", testTwoRules),
     ]
 }
 

--- a/Tests/SwiftFormatRulesTests/OrderedImportsTests.swift
+++ b/Tests/SwiftFormatRulesTests/OrderedImportsTests.swift
@@ -255,9 +255,8 @@ public class OrderedImportsTests: DiagnosingTestCase {
       """
       import C
       import B
-      // swift-format-disable: OrderedImports
+      // swift-format-ignore: OrderedImports
       import A
-      // swift-format-enable: OrderedImports
       let a = 123
       import func Darwin.C.isatty
       """
@@ -269,9 +268,8 @@ public class OrderedImportsTests: DiagnosingTestCase {
 
       import func Darwin.C.isatty
 
-      // swift-format-disable: OrderedImports
+      // swift-format-ignore: OrderedImports
       import A
-      // swift-format-enable: OrderedImports
       let a = 123
       """
 
@@ -291,9 +289,8 @@ public class OrderedImportsTests: DiagnosingTestCase {
       """
       import B
       import C
-      // swift-format-disable: OrderedImports
+      // swift-format-ignore: OrderedImports
       import A
-      // swift-format-enable: OrderedImports
       import D
       """
 
@@ -301,10 +298,9 @@ public class OrderedImportsTests: DiagnosingTestCase {
       """
       import B
       import C
-      // swift-format-enable: OrderedImports
       import D
 
-      // swift-format-disable: OrderedImports
+      // swift-format-ignore: OrderedImports
       import A
       """
 


### PR DESCRIPTION
Previously, the rules used an "active" enable/disable model where rules were explicitly enabled or disabled for a number of lines by using paired enable & disable comments. This model makes sense for rules, but it proved to be challenging to implement for the pretty printing portion of the formatter. Instead of having diverging patterns, I've reimplented the rules logic to use ignore next node style comments like were previously implemented in the pretty printer.

In addition, I've added support for comma delimited lists of rules since I was rewriting most of code anyway.

Authors may no longer use `// swift-format-[enable|disable]: [rule-name]`. Instead, rules can only be "ignored" by adding `// swift-format-ignore[: rule-name, rule-name, rule-name]`.

## Considerations
I opted to use "activate" to replace the behavior offered starting with "swift-format-enable". This functionality allows authors to create off-by-default rules that are selectively enabled on sections of code. The baseline swift-format package doesn't have any off-by-default rules, but I didn't want to break the ability to add those rules.

I'm not thrilled with the name; I tried to find a more passive verb (like ignore) because "activate" implies there could later be a corresponding "deactivate". I explicitly didn't use "enable" to avoid any perceived conflict with existing enable/disable comments.

I'm open to renaming "activate" to something else if there are suggestions.