### PR TITLE
Fix a number of bugs in UseShorthandTypeNames.

### DIFF
--- a/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
+++ b/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
@@ -17,7 +17,7 @@ import SwiftSyntax
 /// Shorthand type forms must be used wherever possible.
 ///
 /// Lint: Using a non-shorthand form (e.g. `Array<Element>`) yields a lint error unless the long
-///       form is necessary (e.g. `Array<Element>.Index` cannot be shortened.)
+///       form is necessary (e.g. `Array<Element>.Index` cannot be shortened today.)
 ///
 /// Format: Where possible, shorthand types replace long form types; e.g. `Array<Element>` is
 ///         converted to `[Element]`.
@@ -25,275 +25,458 @@ import SwiftSyntax
 /// - SeeAlso: https://google.github.io/swift#types-with-shorthand-names
 public final class UseShorthandTypeNames: SyntaxFormatRule {
 
-  // Visits all potential long forms interpreted as types
   public override func visit(_ node: SimpleTypeIdentifierSyntax) -> TypeSyntax {
-    // If nested in a member type identifier, type must be left in long form for the compiler
-    guard let parent = node.parent, !(parent is MemberTypeIdentifierSyntax) else { return node }
-    // Type is in long form if it has a non-nil generic argument clause
-    guard let genArg = node.genericArgumentClause else { return node }
+    // Ignore types that don't have generic arguments.
+    guard let genericArgumentClause = node.genericArgumentClause else {
+      return super.visit(node)
+    }
 
-    // Ensure that all arguments in the clause are shortened and in expected-format by visiting
-    // the argument list, first
-    let argList = visit(genArg.arguments) as! GenericArgumentListSyntax
-    // Store trivia of the long form type to pass to the new shorthand type later
-    let trivia = retrieveTrivia(from: node)
+    // If the node is a direct child of a member type identifier (e.g., `Array<Int>.Index`), the
+    // type must be left in long form for the compiler. Fall back to the default visitation logic,
+    // so that we don't skip children that may need to be rewritten. For example,
+    // `Foo<Array<Int>>.Bar` can still be transformed to `Foo<[Int]>.Bar` because the member
+    // reference is not directly attached to the type that will be transformed, but we need to visit
+    // the children so that we don't skip this).
+    guard let parent = node.parent, !(parent is MemberTypeIdentifierSyntax) else {
+      return super.visit(node)
+    }
 
-    let newNode: TypeSyntax
+    // Ensure that all arguments in the clause are shortened and in the expected format by visiting
+    // the argument list, first.
+    let genericArgumentList = visit(genericArgumentClause.arguments) as! GenericArgumentListSyntax
+
+    let (leadingTrivia, trailingTrivia) = boundaryTrivia(around: node)
+    let newNode: TypeSyntax?
+
     switch node.name.text {
     case "Array":
-      guard let arg = argList.firstAndOnly else { return node }
-      newNode = shortenArrayType(argument: arg, trivia: trivia)
+      guard let typeArgument = genericArgumentList.firstAndOnly else {
+        newNode = nil
+        break
+      }
+      newNode = shorthandArrayType(
+        element: typeArgument.argumentType,
+        leadingTrivia: leadingTrivia,
+        trailingTrivia: trailingTrivia)
+
     case "Dictionary":
-      guard let args = exactlyTwoChildren(of: argList) else { return node }
-      newNode = shortenDictionaryType(arguments: args, trivia: trivia)
+      guard let typeArguments = exactlyTwoChildren(of: genericArgumentList) else {
+        newNode = nil
+        break
+      }
+      newNode = shorthandDictionaryType(
+        key: typeArguments.0.argumentType,
+        value: typeArguments.1.argumentType,
+        leadingTrivia: leadingTrivia,
+        trailingTrivia: trailingTrivia)
+
     case "Optional":
-      guard let arg = argList.firstAndOnly else { return node }
-      newNode = shortenOptionalType(argument: arg, trivia: trivia)
+      guard let typeArgument = genericArgumentList.firstAndOnly else {
+        newNode = nil
+        break
+      }
+      newNode = shorthandOptionalType(
+        wrapping: typeArgument.argumentType,
+        leadingTrivia: leadingTrivia,
+        trailingTrivia: trailingTrivia)
+
     default:
-      return node
+      newNode = nil
     }
 
-    diagnose(.useTypeShorthand(type: node.name.text), on: node)
-    return newNode
+    if let newNode = newNode {
+      diagnose(.useTypeShorthand(type: node.name.text), on: node)
+      return newNode
+    }
+
+    // Even if we don't shorten this specific type that we're visiting, we may have rewritten
+    // something in the generic argument list that we recursively visited, so return the original
+    // node with that swapped out.
+    return node.withGenericArgumentClause(
+      genericArgumentClause.withArguments(genericArgumentList))
   }
 
-  // Visits all potential long forms interpreted as expressions
   public override func visit(_ node: SpecializeExprSyntax) -> ExprSyntax {
-    let argList = visit(node.genericArgumentClause.arguments) as! GenericArgumentListSyntax
-    guard let exp = node.expression as? IdentifierExprSyntax else { return node }
-    let trivia = retrieveTrivia(from: node)
-    switch exp.identifier.text {
-    case "Array":
-      guard let arg = argList.firstAndOnly else { return node }
-      let newArray = shortenArrayExp(argument: arg, trivia: trivia)
-      return newArray ?? node
-    case "Dictionary":
-      guard let args = exactlyTwoChildren(of: argList) else { return node }
-      let newDictionary = shortenDictExp(arguments: args, trivia: trivia)
-      return newDictionary ?? node
-    default:
-      break
+    // `SpecializeExpr`s are found in the syntax tree when a generic type is encountered in an
+    // expression context, such as `Array<Int>()`. In these situations, the corresponding array and
+    // dictionary shorthand nodes will be expression nodes, not type nodes, so we may need to
+    // translate the arguments inside the generic argument list---which are types---to the
+    // appropriate equivalent.
+
+    // Ignore nodes where the expression being specialized isn't a simple identifier.
+    guard let expression = node.expression as? IdentifierExprSyntax else {
+      return super.visit(node)
     }
-    return node
+
+    // Member access after a shorthand type in an expression context appears to be fine in Swift.
+    // For example, `let x: [Int].Index` is not permitted but `let x = [Int].Index()` is allowed.
+    // To avoid introducing inconsistencies in users' code, we choose not to apply a shorthand
+    // transform to these member accesses in expression contexts, even when they would be valid.
+    // However, we still fall back to the default visitation logic, so that we don't skip children
+    // that may need to be rewritten. For example, `Foo<Array<Int>>.Bar()` can still be transformed
+    // to `Foo<[Int]>.Bar()` because the member reference is not directly attached to the type that
+    // will be transformed, but we need to visit the children so that we don't skip this).
+    guard let parent = node.parent, !(parent is MemberAccessExprSyntax) else {
+      return super.visit(node)
+    }
+
+    // Ensure that all arguments in the clause are shortened and in the expected format by visiting
+    // the argument list, first.
+    let genericArgumentList =
+      visit(node.genericArgumentClause.arguments) as! GenericArgumentListSyntax
+
+    let (leadingTrivia, trailingTrivia) = boundaryTrivia(around: node)
+    let newNode: ExprSyntax?
+
+    switch expression.identifier.text {
+    case "Array":
+      guard let typeArgument = genericArgumentList.firstAndOnly else {
+        newNode = nil
+        break
+      }
+      newNode = makeArrayTypeExpression(
+        elementType: typeArgument.argumentType,
+        leftSquareBracket: SyntaxFactory.makeLeftSquareBracketToken(leadingTrivia: leadingTrivia),
+        rightSquareBracket:
+          SyntaxFactory.makeRightSquareBracketToken(trailingTrivia: trailingTrivia))
+
+    case "Dictionary":
+      guard let typeArguments = exactlyTwoChildren(of: genericArgumentList) else {
+        newNode = nil
+        break
+      }
+      newNode = makeDictionaryTypeExpression(
+        keyType: typeArguments.0.argumentType,
+        valueType: typeArguments.1.argumentType,
+        leftSquareBracket: SyntaxFactory.makeLeftSquareBracketToken(leadingTrivia: leadingTrivia),
+        colon: SyntaxFactory.makeColonToken(trailingTrivia: .spaces(1)),
+        rightSquareBracket:
+          SyntaxFactory.makeRightSquareBracketToken(trailingTrivia: trailingTrivia))
+
+    case "Optional":
+      guard let typeArgument = genericArgumentList.firstAndOnly else {
+        newNode = nil
+        break
+      }
+      newNode = makeOptionalTypeExpression(
+        wrapping: typeArgument.argumentType,
+        leadingTrivia: leadingTrivia,
+        questionMark: SyntaxFactory.makePostfixQuestionMarkToken(trailingTrivia: trailingTrivia))
+
+    default:
+      newNode = nil
+    }
+
+    if let newNode = newNode {
+      diagnose(.useTypeShorthand(type: expression.identifier.text), on: expression)
+      return newNode
+    }
+
+    // Even if we don't shorten this specific expression that we're visiting, we may have
+    // rewritten something in the generic argument list that we recursively visited, so return the
+    // original node with that swapped out.
+    return node.withGenericArgumentClause(
+      node.genericArgumentClause.withArguments(genericArgumentList))
   }
 
   /// Returns the two arguments in the given argument list, if there are exactly two elements;
   /// otherwise, it returns nil.
-  func exactlyTwoChildren(of argumentList: GenericArgumentListSyntax) -> [GenericArgumentSyntax]? {
+  private func exactlyTwoChildren(of argumentList: GenericArgumentListSyntax)
+    -> (GenericArgumentSyntax, GenericArgumentSyntax)?
+  {
     var iterator = argumentList.makeIterator()
     guard let first = iterator.next() else { return nil }
     guard let second = iterator.next() else { return nil }
     guard iterator.next() == nil else { return nil }
-    return [first, second]
+    return (first, second)
   }
 
-  // Get type identifier from generic argument, construct shorthand array form, as a type
-  func shortenArrayType(argument: GenericArgumentSyntax, trivia: (Trivia, Trivia)) -> TypeSyntax {
-    let (leading, trailing) = trivia
-    let leftBracket = SyntaxFactory.makeLeftSquareBracketToken(leadingTrivia: leading)
-    let rightBracket = SyntaxFactory.makeRightSquareBracketToken(trailingTrivia: trailing)
-    let newArray = SyntaxFactory.makeArrayType(
-      leftSquareBracket: leftBracket,
-      elementType: argument.argumentType,
-      rightSquareBracket: rightBracket)
-    return newArray
+  /// Retuns a `TypeSyntax` representing a shorthand array type (e.g., `[Foo]`) with the given
+  /// element type and trivia.
+  private func shorthandArrayType(
+    element: TypeSyntax,
+    leadingTrivia: Trivia,
+    trailingTrivia: Trivia
+  ) -> TypeSyntax {
+    return SyntaxFactory.makeArrayType(
+      leftSquareBracket: SyntaxFactory.makeLeftSquareBracketToken(leadingTrivia: leadingTrivia),
+      elementType: element,
+      rightSquareBracket: SyntaxFactory.makeRightSquareBracketToken(trailingTrivia: trailingTrivia))
   }
 
-  // Get type identifiers from generic arguments, construct shorthand dictionary form, as a type
-  func shortenDictionaryType(arguments: [GenericArgumentSyntax], trivia: (Trivia, Trivia))
-    -> TypeSyntax
-  {
-    let (leading, trailing) = trivia
-    let leftBracket = SyntaxFactory.makeLeftSquareBracketToken(leadingTrivia: leading)
-    let rightBracket = SyntaxFactory.makeRightSquareBracketToken(trailingTrivia: trailing)
-    let colon = SyntaxFactory.makeColonToken(trailingTrivia: .spaces(1))
-    let newDictionary = SyntaxFactory.makeDictionaryType(
-      leftSquareBracket: leftBracket,
-      keyType: arguments[0].argumentType,
-      colon: colon,
-      valueType: arguments[1].argumentType,
-      rightSquareBracket: rightBracket)
-    return newDictionary
+  /// Returns a `TypeSyntax` representing a shorthand dictionary type (e.g., `[Foo: Bar]`) with the
+  /// given key/value types and trivia.
+  private func shorthandDictionaryType(
+    key: TypeSyntax,
+    value: TypeSyntax,
+    leadingTrivia: Trivia,
+    trailingTrivia: Trivia
+  ) -> TypeSyntax {
+    return SyntaxFactory.makeDictionaryType(
+      leftSquareBracket: SyntaxFactory.makeLeftSquareBracketToken(leadingTrivia: leadingTrivia),
+      keyType: key,
+      colon: SyntaxFactory.makeColonToken(trailingTrivia: .spaces(1)),
+      valueType: value,
+      rightSquareBracket: SyntaxFactory.makeRightSquareBracketToken(trailingTrivia: trailingTrivia))
   }
 
-  // Get type identifier from generic argument, construct shorthand optional form, as a type
-  func shortenOptionalType(argument: GenericArgumentSyntax, trivia: (Trivia, Trivia))
-    -> TypeSyntax
-  {
-    let argumentType: TypeSyntax
-    if let functionType = argument.argumentType as? FunctionTypeSyntax {
+  /// Returns a `TypeSyntax` representing a shorthand optional type (e.g., `Foo?`) with the given
+  /// wrapped type and trivia, taking care to parenthesize the type when the wrapped type is a
+  /// function type.
+  private func shorthandOptionalType(
+    wrapping wrappedType: TypeSyntax,
+    leadingTrivia: Trivia,
+    trailingTrivia: Trivia
+  ) -> TypeSyntax {
+    var wrappedType = wrappedType
+
+    if let functionType = wrappedType as? FunctionTypeSyntax {
       // Function types must be wrapped as a tuple before using shorthand optional syntax,
-      // otherwise the "?" applies to the return type instead of the function type.
+      // otherwise the "?" applies to the return type instead of the function type. Attach the
+      // leading trivia to the left-paren that we're adding in this case.
       let tupleTypeElement =
         SyntaxFactory.makeTupleTypeElement(type: functionType, trailingComma: nil)
       let tupleElementList = SyntaxFactory.makeTupleTypeElementList([tupleTypeElement])
-      argumentType = SyntaxFactory.makeTupleType(
-        leftParen: SyntaxFactory.makeLeftParenToken(),
+      wrappedType = SyntaxFactory.makeTupleType(
+        leftParen: SyntaxFactory.makeLeftParenToken(leadingTrivia: leadingTrivia),
         elements: tupleElementList,
         rightParen: SyntaxFactory.makeRightParenToken())
     } else {
-      // Otherwise, the argument type can safely become an optional by simply appending a "?".
-      argumentType = argument.argumentType
+      // Otherwise, the argument type can safely become an optional by simply appending a "?", but
+      // we need to transfer the leading trivia from the original `Optional` token over to it.
+      // By doing so, something like `/* comment */ Optional<Foo>` will become `/* comment */ Foo?`
+      // instead of discarding the comment.
+      wrappedType =
+        replaceTrivia(
+          on: wrappedType, token: wrappedType.firstToken, leadingTrivia: leadingTrivia)
+        as! TypeSyntax
     }
-    let (_, trailing) = trivia
-    let questionMark = SyntaxFactory.makePostfixQuestionMarkToken(trailingTrivia: trailing)
-    let newOptional =
-      SyntaxFactory.makeOptionalType(wrappedType: argumentType, questionMark: questionMark)
-    return newOptional
+
+    return SyntaxFactory.makeOptionalType(
+      wrappedType: wrappedType,
+      questionMark: SyntaxFactory.makePostfixQuestionMarkToken(trailingTrivia: trailingTrivia))
   }
 
-  // Construct an array expression from type information in the generic argument
-  func shortenArrayExp(argument arg: GenericArgumentSyntax, trivia: (Trivia, Trivia))
-    -> ArrayExprSyntax?
-  {
-    var element = SyntaxFactory.makeBlankArrayElement()
+  /// Returns an `ArrayExprSyntax` whose single element is the expression representation of the
+  /// given type, or nil if the conversion is not possible because the element type does not
+  /// have a valid expression representation.
+  private func makeArrayTypeExpression(
+    elementType: TypeSyntax,
+    leftSquareBracket: TokenSyntax,
+    rightSquareBracket: TokenSyntax
+  ) -> ArrayExprSyntax? {
+    guard let elementTypeExpr = expressionRepresentation(of: elementType) else {
+      return nil
+    }
+    return SyntaxFactory.makeArrayExpr(
+      leftSquare: leftSquareBracket,
+      elements: SyntaxFactory.makeArrayElementList([
+        SyntaxFactory.makeArrayElement(expression: elementTypeExpr, trailingComma: nil),
+      ]),
+      rightSquare: rightSquareBracket)
+  }
 
-    // Type id can be in a simple type identifier (ex: Int)
-    if let simpleId = arg.argumentType as? SimpleTypeIdentifierSyntax {
-      let idExp = SyntaxFactory.makeIdentifierExpr(
-        identifier: simpleId.name,
+  /// Returns a `DictionaryExprSyntax` whose single key/value pair is the expression representations
+  /// of the given key and value types, or nil if the conversion is not possible because either the
+  /// key type or value type does not have a valid expression representation.
+  private func makeDictionaryTypeExpression(
+    keyType: TypeSyntax,
+    valueType: TypeSyntax,
+    leftSquareBracket: TokenSyntax,
+    colon: TokenSyntax,
+    rightSquareBracket: TokenSyntax
+  ) -> DictionaryExprSyntax? {
+    guard
+      let keyTypeExpr = expressionRepresentation(of: keyType),
+      let valueTypeExpr = expressionRepresentation(of: valueType)
+    else {
+      return nil
+    }
+    return SyntaxFactory.makeDictionaryExpr(
+      leftSquare: leftSquareBracket,
+      content: SyntaxFactory.makeDictionaryElementList([
+        SyntaxFactory.makeDictionaryElement(
+          keyExpression: keyTypeExpr,
+          colon: colon,
+          valueExpression: valueTypeExpr,
+          trailingComma: nil),
+      ]),
+      rightSquare: rightSquareBracket)
+  }
+
+  /// Returns an `OptionalChainingExprSyntax` whose wrapped expression is the expression
+  /// representation of the given type, or nil if the conversion is not possible because either the
+  /// key type or value type does not have a valid expression representation.
+  private func makeOptionalTypeExpression(
+    wrapping wrappedType: TypeSyntax,
+    leadingTrivia: Trivia? = nil,
+    questionMark: TokenSyntax
+  ) -> OptionalChainingExprSyntax? {
+    guard var wrappedTypeExpr = expressionRepresentation(of: wrappedType) else { return nil }
+
+    if wrappedType is FunctionTypeSyntax {
+      // Function types must be wrapped as a tuple before using shorthand optional syntax,
+      // otherwise the "?" applies to the return type instead of the function type. Attach the
+      // leading trivia to the left-paren that we're adding in this case.
+      let tupleElement =
+        SyntaxFactory.makeTupleElement(
+          label: nil, colon: nil, expression: wrappedTypeExpr, trailingComma: nil)
+      let tupleElementList = SyntaxFactory.makeTupleElementList([tupleElement])
+      wrappedTypeExpr = SyntaxFactory.makeTupleExpr(
+        leftParen: SyntaxFactory.makeLeftParenToken(leadingTrivia: leadingTrivia ?? []),
+        elementList: tupleElementList,
+        rightParen: SyntaxFactory.makeRightParenToken())
+    } else if let leadingTrivia = leadingTrivia {
+      // Otherwise, the argument type can safely become an optional by simply appending a "?". If
+      // we were given leading trivia from another node (for example, from `Optional` when
+      // converting a long-form to short-form), we need to transfer it over. By doing so, something
+      // like `/* comment */ Optional<Foo>` will become `/* comment */ Foo?` instead of discarding
+      // the comment.
+      wrappedTypeExpr =
+        replaceTrivia(
+          on: wrappedTypeExpr, token: wrappedTypeExpr.firstToken, leadingTrivia: leadingTrivia)
+        as! ExprSyntax
+    }
+
+    return SyntaxFactory.makeOptionalChainingExpr(
+      expression: wrappedTypeExpr,
+      questionMark: questionMark)
+  }
+
+  /// Returns an `ExprSyntax` that is syntactically equivalent to the given `TypeSyntax`, or nil if
+  /// it wouldn't be valid.
+  ///
+  /// An example of an invalid expression representation for a type would be `[Int].Index`, which
+  /// can be represented in the syntax tree but is not permitted by the compiler today; it must be
+  /// written `Array<Int>.Index` to compile correctly.
+  private func expressionRepresentation(of type: TypeSyntax) -> ExprSyntax? {
+    switch type {
+    case let simpleTypeIdentifier as SimpleTypeIdentifierSyntax:
+      let identifierExpr = SyntaxFactory.makeIdentifierExpr(
+        identifier: simpleTypeIdentifier.name,
         declNameArguments: nil)
-      element = SyntaxFactory.makeArrayElement(expression: idExp, trailingComma: nil)
-      // Type id can be in a long form array (ex: Array<Int>.Index)
-    } else if let memberTypeId = arg.argumentType as? MemberTypeIdentifierSyntax {
-      guard let memberAccessExp = restructureLongForm(member: memberTypeId) else { return nil }
-      element = SyntaxFactory.makeArrayElement(expression: memberAccessExp, trailingComma: nil)
-      // Type id can be in an array, dictionary, or optional type (ex: [Int], [String: Int], Int?)
-    } else if arg.argumentType is ArrayTypeSyntax || arg.argumentType is DictionaryTypeSyntax || arg
-      .argumentType is OptionalTypeSyntax
-    {
-      if let newExp = restructureTypeSyntax(type: arg.argumentType) {
-        element = SyntaxFactory.makeArrayElement(expression: newExp, trailingComma: nil)
+
+      // If the type has a generic argument clause, we need to construct a `SpecializeExpr` to wrap
+      // the identifier and the generic arguments. Otherwise, we can return just the
+      // `IdentifierExpr` itself.
+      if let genericArgumentClause = simpleTypeIdentifier.genericArgumentClause {
+        let newGenericArgumentClause = visit(genericArgumentClause) as! GenericArgumentClauseSyntax
+        return SyntaxFactory.makeSpecializeExpr(
+          expression: identifierExpr,
+          genericArgumentClause: newGenericArgumentClause)
+      } else {
+        return identifierExpr
       }
-    } else { return nil }
 
-    let elementList = SyntaxFactory.makeArrayElementList([element])
-    let (leading, trailing) = trivia
-    let leftBracket = SyntaxFactory.makeLeftSquareBracketToken(leadingTrivia: leading)
-    let rightBracket = SyntaxFactory.makeRightSquareBracketToken(trailingTrivia: trailing)
-    let arrayExp = SyntaxFactory.makeArrayExpr(
-      leftSquare: leftBracket,
-      elements: elementList,
-      rightSquare: rightBracket)
-    return arrayExp
-  }
-
-  // Construct a dictionary expression from type information in the generic arguments
-  func shortenDictExp(arguments: [GenericArgumentSyntax], trivia: (Trivia, Trivia))
-    -> DictionaryExprSyntax?
-  {
-    let blank = SyntaxFactory.makeBlankIdentifierExpr()
-    let colon = SyntaxFactory.makeColonToken(trailingTrivia: .spaces(1))
-    var element = SyntaxFactory.makeDictionaryElement(
-      keyExpression: blank,
-      colon: colon,
-      valueExpression: blank,
-      trailingComma: nil)
-    // Get type id, create an expression, add to the dictionary element
-    for (idx, arg) in arguments.enumerated() {
-      if let simpleId = arg.argumentType as? SimpleTypeIdentifierSyntax {
-        let idExp = SyntaxFactory.makeIdentifierExpr(
-          identifier: simpleId.name,
-          declNameArguments: nil)
-        element = idx == 0 ? element.withKeyExpression(idExp) : element.withValueExpression(idExp)
-      } else if let memberTypeId = arg.argumentType as? MemberTypeIdentifierSyntax {
-        guard let memberAccessExp = restructureLongForm(member: memberTypeId) else { return nil }
-        element = idx == 0
-          ? element.withKeyExpression(memberAccessExp) : element.withValueExpression(
-            memberAccessExp)
-      } else if arg.argumentType is ArrayTypeSyntax || arg.argumentType is DictionaryTypeSyntax
-        || arg.argumentType is OptionalTypeSyntax
-      {
-        let newExp = restructureTypeSyntax(type: arg.argumentType)
-        element = idx == 0 ? element.withKeyExpression(newExp) : element.withValueExpression(newExp)
-      } else { return nil }
-    }
-
-    let elementList = SyntaxFactory.makeDictionaryElementList([element])
-    let (leading, trailing) = trivia
-    let leftBracket = SyntaxFactory.makeLeftSquareBracketToken(leadingTrivia: leading)
-    let rightBracket = SyntaxFactory.makeRightSquareBracketToken(trailingTrivia: trailing)
-    let dictExp = SyntaxFactory.makeDictionaryExpr(
-      leftSquare: leftBracket,
-      content: elementList,
-      rightSquare: rightBracket)
-    return dictExp
-  }
-
-  // Convert member type identifier to an equivalent member access expression
-  // The node will appear the same, but the structure of the tree is different
-  func restructureLongForm(member: MemberTypeIdentifierSyntax) -> MemberAccessExprSyntax? {
-    guard let simpleTypeId = member.baseType as? SimpleTypeIdentifierSyntax else { return nil }
-    guard let genArgClause = simpleTypeId.genericArgumentClause else { return nil }
-    // Node will only change if an argument in the generic argument clause is shortened
-    let argClause = visit(genArgClause) as! GenericArgumentClauseSyntax
-    let idExp = SyntaxFactory.makeIdentifierExpr(
-      identifier: simpleTypeId.name,
-      declNameArguments: nil)
-    let specialExp = SyntaxFactory.makeSpecializeExpr(
-      expression: idExp,
-      genericArgumentClause: argClause)
-    let memberAccessExp = SyntaxFactory.makeMemberAccessExpr(
-      base: specialExp,
-      dot: member.period,
-      name: member.name,
-      declNameArguments: nil)
-    return memberAccessExp
-  }
-
-  // Convert array, dictionary, or optional type to an equivalent expression
-  // The node will appear the same, but the structure of the tree is different
-  func restructureTypeSyntax(type: TypeSyntax) -> ExprSyntax? {
-    if let arrayType = type as? ArrayTypeSyntax {
-      let type = arrayType.elementType.description.trimmingCharacters(in: .whitespacesAndNewlines)
-      let typeId = SyntaxFactory.makeIdentifier(type)
-      let id = SyntaxFactory.makeIdentifierExpr(
-        identifier: typeId,
+    case let memberTypeIdentifier as MemberTypeIdentifierSyntax:
+      guard let baseType = expressionRepresentation(of: memberTypeIdentifier.baseType) else {
+        return nil
+      }
+      return SyntaxFactory.makeMemberAccessExpr(
+        base: baseType,
+        dot: memberTypeIdentifier.period,
+        name: memberTypeIdentifier.name,
         declNameArguments: nil)
-      let element = SyntaxFactory.makeArrayElement(expression: id, trailingComma: nil)
-      let elementList = SyntaxFactory.makeArrayElementList([element])
-      let arrayExp = SyntaxFactory.makeArrayExpr(
-        leftSquare: arrayType.leftSquareBracket,
-        elements: elementList,
-        rightSquare: arrayType.rightSquareBracket)
-      return arrayExp
-    } else if let dictType = type as? DictionaryTypeSyntax {
-      let keyType = dictType.keyType.description.trimmingCharacters(in: .whitespacesAndNewlines)
-      let keyTypeId = SyntaxFactory.makeIdentifier(keyType)
-      let keyIdExp = SyntaxFactory.makeIdentifierExpr(identifier: keyTypeId, declNameArguments: nil)
-      let valueType = dictType.valueType.description.trimmingCharacters(in: .whitespacesAndNewlines)
-      let valueTypeId = SyntaxFactory.makeIdentifier(valueType)
-      let valueIdExp = SyntaxFactory.makeIdentifierExpr(
-        identifier: valueTypeId,
-        declNameArguments: nil)
-      let element = SyntaxFactory.makeDictionaryElement(
-        keyExpression: keyIdExp,
-        colon: dictType.colon,
-        valueExpression: valueIdExp,
-        trailingComma: nil)
-      let elementList = SyntaxFactory.makeDictionaryElementList([element])
-      let dictExp = SyntaxFactory.makeDictionaryExpr(
-        leftSquare: dictType.leftSquareBracket,
-        content: elementList,
-        rightSquare: dictType.rightSquareBracket)
-      return dictExp
-    } else if let optionalType = type as? OptionalTypeSyntax {
-      let type = optionalType.wrappedType.description.trimmingCharacters(
-        in: .whitespacesAndNewlines)
-      let typeId = SyntaxFactory.makeIdentifier(type)
-      let idExp = SyntaxFactory.makeIdentifierExpr(identifier: typeId, declNameArguments: nil)
-      let optionalExp = SyntaxFactory.makeOptionalChainingExpr(
-        expression: idExp,
+
+    case let arrayType as ArrayTypeSyntax:
+      return makeArrayTypeExpression(
+        elementType: arrayType.elementType,
+        leftSquareBracket: arrayType.leftSquareBracket,
+        rightSquareBracket: arrayType.rightSquareBracket)
+
+    case let dictionaryType as DictionaryTypeSyntax:
+      return makeDictionaryTypeExpression(
+        keyType: dictionaryType.keyType,
+        valueType: dictionaryType.valueType,
+        leftSquareBracket: dictionaryType.leftSquareBracket,
+        colon: dictionaryType.colon,
+        rightSquareBracket: dictionaryType.rightSquareBracket)
+
+    case let optionalType as OptionalTypeSyntax:
+      return makeOptionalTypeExpression(
+        wrapping: optionalType.wrappedType,
+        leadingTrivia: optionalType.firstToken?.leadingTrivia,
         questionMark: optionalType.questionMark)
-      return optionalExp
+
+    case let functionType as FunctionTypeSyntax:
+      return makeFunctionTypeExpression(
+        leftParen: functionType.leftParen,
+        argumentTypes: functionType.arguments,
+        rightParen: functionType.rightParen,
+        throwsOrRethrowsKeyword: functionType.throwsOrRethrowsKeyword,
+        arrow: functionType.arrow,
+        returnType: functionType.returnType
+      )
+
+    case let tupleType as TupleTypeSyntax:
+      guard let elementExprs = expressionRepresentation(of: tupleType.elements) else { return nil }
+      return SyntaxFactory.makeTupleExpr(
+        leftParen: tupleType.leftParen,
+        elementList: elementExprs,
+        rightParen: tupleType.rightParen)
+
+    default:
+      return nil
     }
-    return nil
   }
 
-  // Returns trivia from the front and end of the entire given node
-  func retrieveTrivia(from node: Syntax) -> (Trivia, Trivia) {
-    guard let firstTok = node.firstToken, let lastTok = node.lastToken else { return ([], []) }
-    return (firstTok.leadingTrivia, lastTok.trailingTrivia)
+  private func expressionRepresentation(of tupleTypeElements: TupleTypeElementListSyntax)
+    -> TupleElementListSyntax?
+  {
+    guard !tupleTypeElements.isEmpty else { return nil }
+
+    var elementExprs = [TupleElementSyntax]()
+    for typeElement in tupleTypeElements {
+      guard let elementExpr = expressionRepresentation(of: typeElement.type) else { return nil }
+      elementExprs.append(
+        SyntaxFactory.makeTupleElement(
+          label: typeElement.name,
+          colon: typeElement.colon,
+          expression: elementExpr,
+          trailingComma: typeElement.trailingComma))
+    }
+    return SyntaxFactory.makeTupleElementList(elementExprs)
+  }
+
+  private func makeFunctionTypeExpression(
+    leftParen: TokenSyntax,
+    argumentTypes: TupleTypeElementListSyntax,
+    rightParen: TokenSyntax,
+    throwsOrRethrowsKeyword: TokenSyntax?,
+    arrow: TokenSyntax,
+    returnType: TypeSyntax
+  ) -> SequenceExprSyntax? {
+    guard
+      let argumentTypeExprs = expressionRepresentation(of: argumentTypes),
+      let returnTypeExpr = expressionRepresentation(of: returnType)
+    else {
+      return nil
+    }
+
+    return SyntaxFactory.makeSequenceExpr(
+      elements: SyntaxFactory.makeExprList([
+        SyntaxFactory.makeTupleExpr(
+          leftParen: leftParen,
+          elementList: argumentTypeExprs,
+          rightParen: rightParen),
+        SyntaxFactory.makeArrowExpr(
+          throwsToken: throwsOrRethrowsKeyword,
+          arrowToken: arrow),
+        returnTypeExpr,
+      ]))
+  }
+
+  /// Returns the leading and trailing trivia from the front and end of the entire given node.
+  ///
+  /// In other words, this is the leading trivia from the first token of the node and the trailing
+  /// trivia from the last token.
+  private func boundaryTrivia(around node: Syntax)
+    -> (leadingTrivia: Trivia, trailingTrivia: Trivia)
+  {
+    return (
+      leadingTrivia: node.firstToken?.leadingTrivia ?? [],
+      trailingTrivia: node.lastToken?.trailingTrivia ?? []
+    )
   }
 }
 

--- a/Tests/SwiftFormatRulesTests/UseShorthandTypeNamesTests.swift
+++ b/Tests/SwiftFormatRulesTests/UseShorthandTypeNamesTests.swift
@@ -1,63 +1,329 @@
-import Foundation
 import SwiftSyntax
 import XCTest
 
 @testable import SwiftFormatRules
 
-public class UseShorthandTypeNamesTests: DiagnosingTestCase {
-  public func testLongFormNames() {
+final class UseShorthandTypeNamesTests: DiagnosingTestCase {
+  func testNamesInTypeContextsAreShortened() {
     XCTAssertFormatting(
       UseShorthandTypeNames.self,
-      input: """
-             func enumeratedDictionary<Element>(
-               from values: Array<Element>,
-               start: Optional<Array<Element>.Index> = nil,
-               callback: Optional<(_ someArg: Optional<Bool>) -> Void> = nil
-             ) -> Dictionary<Int, Array<Element>> {
-               // Specializer syntax
-               Array<Array<Optional<Int>>.Index>.init()
-               // More specializer syntax
-               Array<[Int]>.init()
-               let foo: Optional<() -> Void>? = nil
-               let bar: Array<() -> Void> = []
-               let baz: Dictionary<Int, Optional<(Any) -> Void>>? = nil
-             }
-             func nestedLongForms(
-               x: Array<Dictionary<String, Int>>,
-               y: Dictionary<Array<Optional<String>>, Optional<Int>>) {
-               Dictionary<Array<Int>.Index, String>.init()
-               Dictionary<String, Optional<Float>>.init()
-               UnsafePointer<UInt8>.init()
-               UnsafeMutablePointer<UInt8>.init()
-             }
-             """,
-      expected: """
-                func enumeratedDictionary<Element>(
-                  from values: [Element],
-                  start: Array<Element>.Index? = nil,
-                  callback: ((_ someArg: Bool?) -> Void)? = nil
-                ) -> [Int: [Element]] {
-                  // Specializer syntax
-                  [Array<Int?>.Index].init()
-                  // More specializer syntax
-                  [[Int]].init()
-                  let foo: (() -> Void)?? = nil
-                  let bar: [() -> Void] = []
-                  let baz: [Int: ((Any) -> Void)?]? = nil
-                }
-                func nestedLongForms(
-                  x: [[String: Int]],
-                  y: [[String?]: Int?]) {
-                  [Array<Int>.Index: String].init()
-                  [String: Float?].init()
-                  UnsafePointer<UInt8>.init()
-                  UnsafeMutablePointer<UInt8>.init()
-                }
-                """)
+      input:
+        """
+        var a: Array<Int>
+        var b: Dictionary<String, Int>
+        var c: Optional<Foo>
+        """,
+      expected:
+        """
+        var a: [Int]
+        var b: [String: Int]
+        var c: Foo?
+        """)
+
     XCTAssertDiagnosed(.useTypeShorthand(type: "Array"))
     XCTAssertDiagnosed(.useTypeShorthand(type: "Dictionary"))
     XCTAssertDiagnosed(.useTypeShorthand(type: "Optional"))
-    XCTAssertNotDiagnosed(.useTypeShorthand(type: "UnsafePointer"))
-    XCTAssertNotDiagnosed(.useTypeShorthand(type: "UnsafeMutablePointer"))
+  }
+
+  func testNestedNamesInTypeContextsAreShortened() {
+    XCTAssertFormatting(
+      UseShorthandTypeNames.self,
+      input:
+        """
+        var a: Array<Array<Int>>
+        var b: Array<[Int]>
+        var c: [Array<Int>]
+
+        var a: Dictionary<Dictionary<String, Int>, Int>
+        var b: Dictionary<String, Dictionary<String, Int>>
+        var c: Dictionary<Dictionary<String, Int>, Dictionary<String, Int>>
+        var d: Dictionary<[String: Int], Int>
+        var e: Dictionary<String, [String: Int]>
+        var f: Dictionary<[String: Int], [String: Int]>
+        var g: [Dictionary<String, Int>: Int]
+        var h: [String: Dictionary<String, Int>]
+        var i: [Dictionary<String, Int>: Dictionary<String, Int>]
+
+        var a: Optional<Array<Int>>
+        var b: Optional<Dictionary<String, Int>>
+        var c: Optional<Optional<Int>>
+        var d: Array<Int>?
+        var e: Dictionary<String, Int>?
+        var f: Optional<Int>?
+        var g: Optional<Int?>
+
+        var a: Array<Optional<Int>>
+        var b: Dictionary<Optional<String>, Optional<Int>>
+        var c: Array<Int?>
+        var d: Dictionary<String?, Int?>
+        """,
+      expected:
+        """
+        var a: [[Int]]
+        var b: [[Int]]
+        var c: [[Int]]
+
+        var a: [[String: Int]: Int]
+        var b: [String: [String: Int]]
+        var c: [[String: Int]: [String: Int]]
+        var d: [[String: Int]: Int]
+        var e: [String: [String: Int]]
+        var f: [[String: Int]: [String: Int]]
+        var g: [[String: Int]: Int]
+        var h: [String: [String: Int]]
+        var i: [[String: Int]: [String: Int]]
+
+        var a: [Int]?
+        var b: [String: Int]?
+        var c: Int??
+        var d: [Int]?
+        var e: [String: Int]?
+        var f: Int??
+        var g: Int??
+
+        var a: [Int?]
+        var b: [String?: Int?]
+        var c: [Int?]
+        var d: [String?: Int?]
+        """)
+  }
+
+  func testNamesInNonMemberAccessExpressionContextsAreShortened() {
+    XCTAssertFormatting(
+      UseShorthandTypeNames.self,
+      input:
+        """
+        var a = Array<Int>()
+        var b = Dictionary<String, Int>()
+        var c = Optional<String>(from: decoder)
+        """,
+      expected:
+        """
+        var a = [Int]()
+        var b = [String: Int]()
+        var c = String?(from: decoder)
+        """)
+
+    XCTAssertDiagnosed(.useTypeShorthand(type: "Array"))
+    XCTAssertDiagnosed(.useTypeShorthand(type: "Dictionary"))
+    XCTAssertDiagnosed(.useTypeShorthand(type: "Optional"))
+  }
+
+  func testNestedNamesInNonMemberAccessExpressionContextsAreShortened() {
+    XCTAssertFormatting(
+      UseShorthandTypeNames.self,
+      input:
+        """
+        var a = Array<Array<Int>>()
+        var b = Array<[Int]>()
+        var c = [Array<Int>]()
+
+        var a = Dictionary<Dictionary<String, Int>, Int>()
+        var b = Dictionary<String, Dictionary<String, Int>>()
+        var c = Dictionary<Dictionary<String, Int>, Dictionary<String, Int>>()
+        var d = Dictionary<[String: Int], Int>()
+        var e = Dictionary<String, [String: Int]>()
+        var f = Dictionary<[String: Int], [String: Int]>()
+        var g = [Dictionary<String, Int>: Int]()
+        var h = [String: Dictionary<String, Int>]()
+        var i = [Dictionary<String, Int>: Dictionary<String, Int>]()
+
+        var a = Optional<Array<Int>>(from: decoder)
+        var b = Optional<Dictionary<String, Int>>(from: decoder)
+        var c = Optional<Optional<Int>>(from: decoder)
+        var d = Array<Int>?(from: decoder)
+        var e = Dictionary<String, Int>?(from: decoder)
+        var f = Optional<Int>?(from: decoder)
+        var g = Optional<Int?>(from: decoder)
+
+        var a = Array<Optional<Int>>()
+        var b = Dictionary<Optional<String>, Optional<Int>>()
+        var c = Array<Int?>()
+        var d = Dictionary<String?, Int?>()
+        """,
+      expected:
+        """
+        var a = [[Int]]()
+        var b = [[Int]]()
+        var c = [[Int]]()
+
+        var a = [[String: Int]: Int]()
+        var b = [String: [String: Int]]()
+        var c = [[String: Int]: [String: Int]]()
+        var d = [[String: Int]: Int]()
+        var e = [String: [String: Int]]()
+        var f = [[String: Int]: [String: Int]]()
+        var g = [[String: Int]: Int]()
+        var h = [String: [String: Int]]()
+        var i = [[String: Int]: [String: Int]]()
+
+        var a = [Int]?(from: decoder)
+        var b = [String: Int]?(from: decoder)
+        var c = Int??(from: decoder)
+        var d = [Int]?(from: decoder)
+        var e = [String: Int]?(from: decoder)
+        var f = Int??(from: decoder)
+        var g = Int??(from: decoder)
+
+        var a = [Int?]()
+        var b = [String?: Int?]()
+        var c = [Int?]()
+        var d = [String?: Int?]()
+        """)
+  }
+
+  func testTypesWithMemberAccessesAreNotShortened() {
+    XCTAssertFormatting(
+      UseShorthandTypeNames.self,
+      input:
+        """
+        var a: Array<Int>.Index = Array<Int>.Index()
+        var b: Dictionary<String, Int>.Index = Dictionary<String, Int>.Index()
+        var c: Array<Optional<Int>>.Index = Array<Optional<Int>>.Index()
+        var d: Dictionary<Optional<String>, Array<Int>>.Index = Dictionary<Optional<String>, Array<Int>>.Index()
+        var e: Array<Array<Int>.Index> = Array<Array<Int>.Index>()
+
+        var f: Foo<Array<Int>>.Bar = Foo<Array<Int>>.Bar()
+        var g: Foo<Array<Int>.Index>.Bar = Foo<Array<Int>.Index>.Bar()
+        var h: Foo.Bar<Array<Int>> = Foo.Bar<Array<Int>>()
+        var i: Foo.Bar<Array<Int>.Index> = Foo.Bar<Array<Int>.Index>()
+
+        var j: Optional<Array<Int>>.Publisher = Optional<Array<Int>>.Publisher()
+        var k: Optional<Dictionary<String, Int>>.Publisher = Optional<Dictionary<String, Int>>.Publisher()
+        var l: Optional<Optional<Int>>.Publisher = Optional<Optional<Int>>.Publisher()
+        """,
+      expected:
+        """
+        var a: Array<Int>.Index = Array<Int>.Index()
+        var b: Dictionary<String, Int>.Index = Dictionary<String, Int>.Index()
+        var c: Array<Int?>.Index = Array<Int?>.Index()
+        var d: Dictionary<String?, [Int]>.Index = Dictionary<String?, [Int]>.Index()
+        var e: [Array<Int>.Index] = [Array<Int>.Index]()
+
+        var f: Foo<[Int]>.Bar = Foo<[Int]>.Bar()
+        var g: Foo<Array<Int>.Index>.Bar = Foo<Array<Int>.Index>.Bar()
+        var h: Foo.Bar<[Int]> = Foo.Bar<[Int]>()
+        var i: Foo.Bar<Array<Int>.Index> = Foo.Bar<Array<Int>.Index>()
+
+        var j: Optional<[Int]>.Publisher = Optional<[Int]>.Publisher()
+        var k: Optional<[String: Int]>.Publisher = Optional<[String: Int]>.Publisher()
+        var l: Optional<Int?>.Publisher = Optional<Int?>.Publisher()
+        """)
+  }
+
+  func testFunctionTypesAreOnlyWrappedWhenShortenedAsOptionals() {
+    // Some of these examples are questionable since function types aren't hashable and thus not
+    // valid dictionary keys, nor are they codable, but syntactically they're fine.
+    XCTAssertFormatting(
+      UseShorthandTypeNames.self,
+      input:
+        """
+        var a: Array<(Foo) -> Bar> = Array<(Foo) -> Bar>()
+        var b: Dictionary<(Foo) -> Bar, (Foo) -> Bar> = Dictionary<(Foo) -> Bar, (Foo) -> Bar>()
+        var c: Optional<(Foo) -> Bar> = Optional<(Foo) -> Bar>(from: decoder)
+        var d: Optional<((Foo) -> Bar)> = Optional<((Foo) -> Bar)>(from: decoder)
+        """,
+      expected:
+        """
+        var a: [(Foo) -> Bar] = [(Foo) -> Bar]()
+        var b: [(Foo) -> Bar: (Foo) -> Bar] = [(Foo) -> Bar: (Foo) -> Bar]()
+        var c: ((Foo) -> Bar)? = ((Foo) -> Bar)?(from: decoder)
+        var d: ((Foo) -> Bar)? = ((Foo) -> Bar)?(from: decoder)
+        """)
+  }
+
+  func testTypesWithEmptyTupleAsGenericArgumentAreNotShortenedInExpressionContexts() {
+    // The Swift parser will treat `()` encountered in an expression context as the void *value*,
+    // not the type. This extends outwards to shorthand syntax, where `()?` would be treated as an
+    // attempt to optional-unwrap the tuple (which is not valid), `[()]` would be an array literal
+    // containing the empty tuple, and `[(): ()]` would be a dictionary literal mapping the empty
+    // tuple to the empty tuple. Because of this, we cannot permit the empty tuple type to appear
+    // directly inside an expression context. In type contexts, however, it's fine.
+    XCTAssertFormatting(
+      UseShorthandTypeNames.self,
+      input:
+        """
+        var a: Optional<()> = Optional<()>(from: decoder)
+        var b: Array<()> = Array<()>()
+        var c: Dictionary<(), ()> = Dictionary<(), ()>()
+        var d: Array<(Optional<()>) -> Optional<()>> = Array<(Optional<()>) -> Optional<()>>()
+        """,
+      expected:
+        """
+        var a: ()? = Optional<()>(from: decoder)
+        var b: [()] = Array<()>()
+        var c: [(): ()] = Dictionary<(), ()>()
+        var d: [(()?) -> ()?] = Array<(()?) -> ()?>()
+        """)
+  }
+
+  func testPreservesNestedGenericsForUnshortenedTypes() {
+    // Regression test for a bug that discarded the generic argument list of a nested type when
+    // shortening something like `Array<Range<Foo>>` to `[Range]` (instead of `[Range<Foo>]`.
+    XCTAssertFormatting(
+      UseShorthandTypeNames.self,
+      input:
+        """
+        var a: Array<Range<Foo>> = Array<Range<Foo>>()
+        var b: Dictionary<Range<Foo>, Range<Foo>> = Dictionary<Range<Foo>, Range<Foo>>()
+        var c: Optional<Range<Foo>> = Optional<Range<Foo>>(from: decoder)
+        """,
+      expected:
+        """
+        var a: [Range<Foo>] = [Range<Foo>]()
+        var b: [Range<Foo>: Range<Foo>] = [Range<Foo>: Range<Foo>]()
+        var c: Range<Foo>? = Range<Foo>?(from: decoder)
+        """)
+  }
+
+  func testTypesWithIncorrectNumbersOfGenericArgumentsAreNotChanged() {
+    XCTAssertFormatting(
+      UseShorthandTypeNames.self,
+      input:
+        """
+        var a: Array<Array<Foo>, Bar> = Array<Array<Foo>, Bar>()
+        var b: Dictionary<Dictionary<Foo, Bar>> = Dictionary<Dictionary<Foo, Bar>>()
+        var c: Optional<Optional<Foo>, Bar> = Optional<Optional<Foo>, Bar>(from: decoder)
+        """,
+      expected:
+        """
+        var a: Array<[Foo], Bar> = Array<[Foo], Bar>()
+        var b: Dictionary<[Foo: Bar]> = Dictionary<[Foo: Bar]>()
+        var c: Optional<Foo?, Bar> = Optional<Foo?, Bar>(from: decoder)
+        """)
+  }
+
+  func testModuleQualifiedNamesAreNotShortened() {
+    XCTAssertFormatting(
+      UseShorthandTypeNames.self,
+      input:
+        """
+        var a: Swift.Array<Array<Foo>> = Swift.Array<Array<Foo>>()
+        var b: Swift.Dictionary<Dictionary<Foo, Bar>, Dictionary<Foo, Bar>> = Swift.Dictionary<Dictionary<Foo, Bar>, Dictionary<Foo, Bar>>()
+        var c: Swift.Optional<Optional<Foo>> = Swift.Optional<Optional<Foo>>(from: decoder)
+        """,
+      expected:
+        """
+        var a: Swift.Array<[Foo]> = Swift.Array<[Foo]>()
+        var b: Swift.Dictionary<[Foo: Bar], [Foo: Bar]> = Swift.Dictionary<[Foo: Bar], [Foo: Bar]>()
+        var c: Swift.Optional<Foo?> = Swift.Optional<Foo?>(from: decoder)
+        """)
+  }
+
+  func testTypesWeDoNotCareAboutAreUnchanged() {
+    XCTAssertFormatting(
+      UseShorthandTypeNames.self,
+      input:
+        """
+        var a: Larry<Int> = Larry<Int>()
+        var b: Pictionary<String, Int> = Pictionary<String, Int>()
+        var c: Sectional<Couch> = Sectional<Couch>(from: warehouse)
+        """,
+      expected:
+        """
+        var a: Larry<Int> = Larry<Int>()
+        var b: Pictionary<String, Int> = Pictionary<String, Int>()
+        var c: Sectional<Couch> = Sectional<Couch>(from: warehouse)
+        """)
   }
 }

--- a/Tests/SwiftFormatRulesTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatRulesTests/XCTestManifests.swift
@@ -331,7 +331,17 @@ extension UseShorthandTypeNamesTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__UseShorthandTypeNamesTests = [
-        ("testLongFormNames", testLongFormNames),
+        ("testFunctionTypesAreOnlyWrappedWhenShortenedAsOptionals", testFunctionTypesAreOnlyWrappedWhenShortenedAsOptionals),
+        ("testModuleQualifiedNamesAreNotShortened", testModuleQualifiedNamesAreNotShortened),
+        ("testNamesInNonMemberAccessExpressionContextsAreShortened", testNamesInNonMemberAccessExpressionContextsAreShortened),
+        ("testNamesInTypeContextsAreShortened", testNamesInTypeContextsAreShortened),
+        ("testNestedNamesInNonMemberAccessExpressionContextsAreShortened", testNestedNamesInNonMemberAccessExpressionContextsAreShortened),
+        ("testNestedNamesInTypeContextsAreShortened", testNestedNamesInTypeContextsAreShortened),
+        ("testPreservesNestedGenericsForUnshortenedTypes", testPreservesNestedGenericsForUnshortenedTypes),
+        ("testTypesWeDoNotCareAboutAreUnchanged", testTypesWeDoNotCareAboutAreUnchanged),
+        ("testTypesWithEmptyTupleAsGenericArgumentAreNotShortenedInExpressionContexts", testTypesWithEmptyTupleAsGenericArgumentAreNotShortenedInExpressionContexts),
+        ("testTypesWithIncorrectNumbersOfGenericArgumentsAreNotChanged", testTypesWithIncorrectNumbersOfGenericArgumentsAreNotChanged),
+        ("testTypesWithMemberAccessesAreNotShortened", testTypesWithMemberAccessesAreNotShortened),
     ]
 }
 


### PR DESCRIPTION
This started as a fix for a bug where nested generic argument
clauses were being dropped, but I kept peeling back layers of
the onion and uncovering other cases that were missed or
places where we were doing the wrong thing. I took the
opportunity to rewrite the rule from the ground up, especially
the part that transforms types into equivalent "expressions",
making it truly recursive so that it handles more situations
correctly.

The tests have also been cleaned up, to make it clearer what
each test case is actually meant to be testing.