### PR TITLE
Support IfConfigDecl clauses in UseEnumForNamespacing

### DIFF
--- a/Sources/SwiftFormatRules/UseEnumForNamespacing.swift
+++ b/Sources/SwiftFormatRules/UseEnumForNamespacing.swift
@@ -76,6 +76,18 @@ public final class UseEnumForNamespacing: SyntaxFormatRule {
         }
         // Do not append private initializer.
 
+      case let decl as IfConfigDeclSyntax:
+        let membersToKeep: [MemberDeclListSyntax] = decl.clauses
+          .compactMap { clause in
+            (clause.elements as? MemberDeclListSyntax).flatMap(membersToKeepIfUsedAsNamespace(_:))
+          }
+
+        if membersToKeep.count < decl.clauses.count {
+          return nil
+        } else {
+          declList.append(member)
+        }
+
       default:
         declList.append(member)
       }

--- a/Tests/SwiftFormatRulesTests/UseEnumForNamespacingTests.swift
+++ b/Tests/SwiftFormatRulesTests/UseEnumForNamespacingTests.swift
@@ -27,6 +27,64 @@ public class UseEnumForNamespacingTests: DiagnosingTestCase {
              final class E {
                static let a = 123
              }
+             struct Structure {
+               #if canImport(AppKit)
+                   var native: NSSomething
+               #elseif canImport(UIKit)
+                   var native: UISomething
+               #endif
+             }
+             struct Structure {
+               #if canImport(AppKit)
+                   static var native: NSSomething
+               #elseif canImport(UIKit)
+                   static var native: UISomething
+               #endif
+             }
+             struct Structure {
+               #if canImport(AppKit)
+                   var native: NSSomething
+               #elseif canImport(UIKit)
+                   static var native: UISomething
+               #endif
+             }
+             struct Structure {
+               #if canImport(AppKit)
+                   static var native: NSSomething
+               #else
+                   static var native: UISomething
+               #endif
+             }
+             struct Structure {
+               #if canImport(AppKit)
+                 #if swift(>=4.0)
+                   static var native: NSSomething
+                 #else
+                   static var deprecated_native: NSSomething
+                 #endif
+               #else
+                   #if swift(>=4.0)
+                     static var native: UISomething
+                   #else
+                     static var deprecated_native: UISomething
+                   #endif
+               #endif
+             }
+             struct Structure {
+               #if canImport(AppKit)
+                 #if swift(>=4.0)
+                   static var native: NSSomething
+                 #else
+                   static var deprecated_native: NSSomething
+                 #endif
+               #else
+                   #if swift(>=4.0)
+                     static var native: UISomething
+                   #else
+                     var deprecated_native: UISomething
+                   #endif
+               #endif
+             }
              """,
       expected: """
                 enum A {
@@ -45,6 +103,64 @@ public class UseEnumForNamespacingTests: DiagnosingTestCase {
                 }
                 final class E {
                   static let a = 123
+                }
+                struct Structure {
+                  #if canImport(AppKit)
+                      var native: NSSomething
+                  #elseif canImport(UIKit)
+                      var native: UISomething
+                  #endif
+                }
+                enum Structure {
+                  #if canImport(AppKit)
+                      static var native: NSSomething
+                  #elseif canImport(UIKit)
+                      static var native: UISomething
+                  #endif
+                }
+                struct Structure {
+                  #if canImport(AppKit)
+                      var native: NSSomething
+                  #elseif canImport(UIKit)
+                      static var native: UISomething
+                  #endif
+                }
+                enum Structure {
+                  #if canImport(AppKit)
+                      static var native: NSSomething
+                  #else
+                      static var native: UISomething
+                  #endif
+                }
+                enum Structure {
+                  #if canImport(AppKit)
+                    #if swift(>=4.0)
+                      static var native: NSSomething
+                    #else
+                      static var deprecated_native: NSSomething
+                    #endif
+                  #else
+                      #if swift(>=4.0)
+                        static var native: UISomething
+                      #else
+                        static var deprecated_native: UISomething
+                      #endif
+                  #endif
+                }
+                struct Structure {
+                  #if canImport(AppKit)
+                    #if swift(>=4.0)
+                      static var native: NSSomething
+                    #else
+                      static var deprecated_native: NSSomething
+                    #endif
+                  #else
+                      #if swift(>=4.0)
+                        static var native: UISomething
+                      #else
+                        var deprecated_native: UISomething
+                      #endif
+                  #endif
                 }
                 """)
   }


### PR DESCRIPTION
Anything inside a IfConfigDecl was ignored when determining if a struct
could be an enum. This looks for IfConfigDeclSyntax in the
MemberDeclListSyntax and only turns the struct into an enum when all of
the clauses have namespace compatible members.

Fixes: https://bugs.swift.org/browse/SR-11830