### PR TITLE
Relocate comments around operators and allow if/else comments

### DIFF
--- a/Sources/SwiftFormatCore/Trivia+Convenience.swift
+++ b/Sources/SwiftFormatCore/Trivia+Convenience.swift
@@ -63,6 +63,14 @@ extension Trivia {
     return count
   }
 
+  /// Returns whether the trivia contains at least 1 `lineComment`.
+  public var hasLineComment: Bool {
+    return self.contains {
+      if case .lineComment = $0 { return true }
+      return false
+    }
+  }
+
   public var hasSpaces: Bool {
     for piece in self {
       if case .tabs = piece { return true }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -146,6 +146,10 @@ extension CommentTests {
     static let __allTests__CommentTests = [
         ("testBlockComments", testBlockComments),
         ("testCommentOnContinuationLine", testCommentOnContinuationLine),
+        ("testCommentsAllowedInParenthesizedExpressions", testCommentsAllowedInParenthesizedExpressions),
+        ("testCommentsAroundIfElseStatements", testCommentsAroundIfElseStatements),
+        ("testCommentsInIfStatements", testCommentsInIfStatements),
+        ("testCommentsMoveAroundOperators", testCommentsMoveAroundOperators),
         ("testContainerLineComments", testContainerLineComments),
         ("testDocumentationBlockComments", testDocumentationBlockComments),
         ("testDocumentationComments", testDocumentationComments),


### PR DESCRIPTION
This fixes a few issues with formatting of comments, most notably relocating comments around operator tokens to reduce excessive line breaks.

# Problem
The combination of swift-format's behavior to break _before_ operators and commonplace practices to place comments _after_ operators results in subpar formatting. It typically results in breaking both *before and after* the operator, when only breaking once would be sufficient.

Comments around if/else statements and some special single element tuples were being moved because newlines around the comment were deleted since there were no breaks.

# Solution
Instead of trying to implement a general purpose "comment moving" algorithm, I've instead identified a few constructs where comments were handled poorly and implemented targeted fixes. A more general purpose algorithm for moving any comment to the right location proved challenging, because it's difficult to: identify the right token(s) that a comment refers to, identify the right break in the token stream, and move the comment around open/close tokens to get the right scope.

To relocate comments around operators, I implemented a `SyntaxRewriter` which identifies the tokens where trivia is misplaced and rewrites the tokens with corrected trivia. This proved to be simpler than trying to apply the fix directly while visiting the syntax tree to create the token stream. When visiting the tokens for the token stream, it's not possible to update the trivia on a token so I would have needed to implement suppressing portions of the trivia while moving other portions to different tokens using extra state in the `TokenStreamCreator` object.

# Notes on existing issues
There are preexisting examples of comments with incorrect indentation, such as `ForInStmtTests.testForStatementWithNestedExpressions`. The problem occurs because comments don't indent based on *upcoming* breaks. I've identified a couple more cases where thi same problem is exhibited and documented them in test cases.

I experimented with some solutions, but I feel they are too complex to merge into this PR.