### PR TITLE
Print indent and index of control tokens to debug output.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
@@ -665,7 +665,8 @@ public class PrettyPrinter {
       print(verbatim.print(indent: debugIndent))
 
     case .printerControl(let kind):
-      print("[PRINTER CONTROL Kind: \(kind)]")
+      printDebugIndent()
+      print("[PRINTER CONTROL Kind: \(kind) Idx: \(idx)]")
     }
   }
 


### PR DESCRIPTION
It looks like this was an oversight when I originally added support for these tokens to the pretty printer, and it doesn't show up very often since they're only used with #if config statements.