### PR TITLE
Merge newline token into break token.

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/CommentTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/CommentTests.swift
@@ -429,11 +429,6 @@ public class CommentTests: PrettyPrintTestCase {
   }
 
   public func testCommentOnContinuationLine() {
-
-    // FIXME: Based on the way that continuations are handled, comment don't support indentation
-    // based on breaks *after* the comment. This results in the incorrect indentation of
-    // `// comment` in the 2nd example. There isn't a clear solution, but the issue will be
-    // addressed in a later PR.
     let input =
       """
       func foo() {
@@ -444,7 +439,7 @@ public class CommentTests: PrettyPrintTestCase {
 
       func foo() {
         return
-        // comment
+          // comment
           false
       }
 
@@ -619,9 +614,6 @@ public class CommentTests: PrettyPrintTestCase {
          }
          """
 
-    // FIXME: Based on the way that continuations are handled, comment don't support indentation
-    // based on breaks *after* the comment. There isn't a clear solution, but the issue will be
-    // addressed in a later PR.
     let expected =
       """
       if foo.bar && false  // comment about foo.bar
@@ -636,8 +628,8 @@ public class CommentTests: PrettyPrintTestCase {
       {
       }
       if foo.bar && foo.baz
-      // comment about the next line
-      // another comment line
+        // comment about the next line
+        // another comment line
         && next.line
       {
       }

--- a/Tests/SwiftFormatPrettyPrintTests/ForInStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ForInStmtTests.swift
@@ -226,11 +226,6 @@ public class ForInStmtTests: PrettyPrintTestCase {
       }
       """
 
-    // FIXME: Based on the way that continuations are now handled, it's not clear that we can
-    // get `// comment #2` indented correctly based on what comes *after* it. I think the right
-    // approach here is to change the handling of full-line comments (and probably doc-comments as
-    // well) so that they are deferred until either just before the next text token is printed or
-    // the next close-break. But this is a larger change that I'll revisit in a separate PR.
     let expected =
       """
       for x in someCollection
@@ -255,7 +250,7 @@ public class ForInStmtTests: PrettyPrintTestCase {
           })
         // comment #1
         && someOtherCondition
-        // comment #2
+          // comment #2
           + thatUses + operators
         && binPackable && exprs
       {


### PR DESCRIPTION
The handling of separate newlines and breaks in the PrettyPrinter resulted in a fairly complex implementation. In particular, it required storing the most recent break, and mutating the indentation stack to retroactively "fire" a break. This has been a source of bugs.

This updates the TokenStreamCreator and PrettyPrinter to a model without an explicit newline token. Instead, newlines are encapsulated by breaks. The same types of newlines exist ("flexible", "discretionary", and "mandatory" newlines have equivalent counterparts), but they exist as associated data with a break. This means newlines always exist where breaks are by definition.

This refactor "broke" some cases where comments were working with the right indentation "by accident". In cases where a comment existed outside of any scoping tokens (i.e. open/close breaks, continue breaks, etc.), the PrettyPrinter carried over indentation of the last break even if that break wasn't really relevant. To fix this, I added `splitScopingBeforeTokens(of:)` which splits the before-tokens so that those that start a scope can be placed before comments when visiting a token. This fixed several existing comment indentation issues, and fixed comments whose indentation was only "accidentally" working thanks to the PrettyPrinter's break carry-over behavior.