### PR TITLE
Reverse `.break(.close)` and `.close` for array and dict literals.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -692,7 +692,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
 
   func visit(_ node: ArrayExprSyntax) -> SyntaxVisitorContinueKind {
     after(node.leftSquare, tokens: .break(.open, size: 0), .open)
-    before(node.rightSquare, tokens: .close, .break(.close, size: 0))
+    before(node.rightSquare, tokens: .break(.close, size: 0), .close)
     return .visitChildren
   }
 
@@ -709,7 +709,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
 
   func visit(_ node: DictionaryExprSyntax) -> SyntaxVisitorContinueKind {
     after(node.leftSquare, tokens: .break(.open, size: 0), .open)
-    before(node.rightSquare, tokens: .close, .break(.close, size: 0))
+    before(node.rightSquare, tokens: .break(.close, size: 0), .close)
     return .visitChildren
   }
 

--- a/Tests/SwiftFormatPrettyPrintTests/ArrayDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ArrayDeclTests.swift
@@ -4,6 +4,7 @@ public class ArrayDeclTests: PrettyPrintTestCase {
       """
       let a = [1, 2, 3]
       let a: [Bool] = [false, true, true, false]
+      let a = [11111111, 2222222, 33333333, 4444444]
       let a: [String] = ["One", "Two", "Three", "Four"]
       let a: [String] = ["One", "Two", "Three", "Four", "Five", "Six", "Seven"]
       let a: [String] = ["One", "Two", "Three", "Four", "Five", "Six", "Seven",]
@@ -13,6 +14,9 @@ public class ArrayDeclTests: PrettyPrintTestCase {
       """
       let a = [1, 2, 3]
       let a: [Bool] = [false, true, true, false]
+      let a = [
+        11111111, 2222222, 33333333, 4444444
+      ]
       let a: [String] = [
         "One", "Two", "Three", "Four"
       ]

--- a/Tests/SwiftFormatPrettyPrintTests/DictionaryDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/DictionaryDeclTests.swift
@@ -4,6 +4,7 @@ public class DictionaryDeclTests: PrettyPrintTestCase {
       """
       let a = [1: "a", 2: "b", 3: "c"]
       let a: [Int: String] = [1: "a", 2: "b", 3: "c"]
+      let a = [10000: "abc", 20000: "def", 30000: "ghij"]
       let a: [Int: String] = [1: "a", 2: "b", 3: "c", 4: "d"]
       let a: [Int: String] = [1: "a", 2: "b", 3: "c", 4: "d", 5: "e", 6: "f", 7: "g"]
       let a: [Int: String] = [1: "a", 2: "b", 3: "c", 4: "d", 5: "e", 6: "f", 7: "g",]
@@ -13,6 +14,9 @@ public class DictionaryDeclTests: PrettyPrintTestCase {
       """
       let a = [1: "a", 2: "b", 3: "c"]
       let a: [Int: String] = [1: "a", 2: "b", 3: "c"]
+      let a = [
+        10000: "abc", 20000: "def", 30000: "ghij"
+      ]
       let a: [Int: String] = [
         1: "a", 2: "b", 3: "c", 4: "d"
       ]


### PR DESCRIPTION
The previous order created an issue where the `.break(.close)` was outside of the group. The result was that it was possible just for the closing delimiter for an array/dict could break off from the rest of the literal. The new order of tokens places the break inside of the group, so the `.break(.open)` before the literal includes the length of the array/dict elements and the closing delimiter.