### PR TITLE
No trailing commas in array/dict initializers.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -707,7 +707,12 @@ private final class TokenStreamCreator: SyntaxVisitor {
 
   func visit(_ node: ArrayElementListSyntax) -> SyntaxVisitorContinueKind {
     insertTokens(.break(.same), betweenElementsOf: node)
-    if let firstElement = node.first, let lastElement = node.last {
+
+    // The syntax library can't distinguish an array initializer (where the elements are types) from
+    // an array literal (where the elements are the contents of the array). We never want to add a
+    // trailing comma in the initializer case and there's always exactly 1 element, so we never add
+    // a trailing comma to 1 element arrays.
+    if let firstElement = node.first, let lastElement = node.last, firstElement != lastElement {
       before(firstElement.firstToken, tokens: .commaDelimitedRegionStart)
       let endToken = Token.commaDelimitedRegionEnd(
         hasTrailingComma: lastElement.trailingComma != nil, position: lastElement.endPosition)
@@ -733,7 +738,12 @@ private final class TokenStreamCreator: SyntaxVisitor {
 
   func visit(_ node: DictionaryElementListSyntax) -> SyntaxVisitorContinueKind {
     insertTokens(.break(.same), betweenElementsOf: node)
-    if let firstElement = node.first, let lastElement = node.last {
+
+    // The syntax library can't distinguish a dictionary initializer (where the elements are types)
+    // from a dictionary literal (where the elements are the contents of the dictionary). We never
+    // want to add a trailing comma in the initializer case and there's always exactly 1 element,
+    // so we never add a trailing comma to 1 element dictionaries.
+    if let firstElement = node.first, let lastElement = node.last, firstElement != lastElement {
       before(firstElement.firstToken, tokens: .commaDelimitedRegionStart)
       let endToken = Token.commaDelimitedRegionEnd(
         hasTrailingComma: lastElement.trailingComma != nil, position: lastElement.endPosition)

--- a/Tests/SwiftFormatPrettyPrintTests/ArrayDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ArrayDeclTests.swift
@@ -65,6 +65,23 @@ public class ArrayDeclTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
   }
 
+  public func testNoTrailingCommasInTypes() {
+    let input =
+      """
+      let a = [SomeSuperMegaLongTypeName]()
+      """
+
+    let expected =
+      """
+      let a = [
+        SomeSuperMegaLongTypeName
+      ]()
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 30)
+  }
+
   public func testWhitespaceOnlyDoesNotChangeTrailingComma() {
     let input =
       """

--- a/Tests/SwiftFormatPrettyPrintTests/DictionaryDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/DictionaryDeclTests.swift
@@ -48,6 +48,23 @@ public class DictionaryDeclTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
   }
 
+  public func testNoTrailingCommasInTypes() {
+    let input =
+      """
+      let a = [SomeVeryLongKeyType: SomePrettyLongValueType]()
+      """
+
+    let expected =
+      """
+      let a = [
+        SomeVeryLongKeyType: SomePrettyLongValueType
+      ]()
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+  }
+
   public func testWhitespaceOnlyDoesNotChangeTrailingComma() {
     let input =
       """

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -24,6 +24,7 @@ extension ArrayDeclTests {
     static let __allTests__ArrayDeclTests = [
         ("testArrayOfFunctions", testArrayOfFunctions),
         ("testBasicArrays", testBasicArrays),
+        ("testNoTrailingCommasInTypes", testNoTrailingCommasInTypes),
         ("testTrailingCommaDiagnostics", testTrailingCommaDiagnostics),
         ("testWhitespaceOnlyDoesNotChangeTrailingComma", testWhitespaceOnlyDoesNotChangeTrailingComma),
     ]
@@ -178,6 +179,7 @@ extension DictionaryDeclTests {
     // to regenerate.
     static let __allTests__DictionaryDeclTests = [
         ("testBasicDictionaries", testBasicDictionaries),
+        ("testNoTrailingCommasInTypes", testNoTrailingCommasInTypes),
         ("testTrailingCommaDiagnostics", testTrailingCommaDiagnostics),
         ("testWhitespaceOnlyDoesNotChangeTrailingComma", testWhitespaceOnlyDoesNotChangeTrailingComma),
     ]


### PR DESCRIPTION
swift-syntax doesn't differentiate the array/dict expr syntax used for initializing an array/dict (where the elements are type identifiers) from an array/dict expr syntax of a collection literal (where the elements are the contents of the collection). There isn't a straightforward way to determine which is which when visiting the array or dict, since it's based on the parent being a function call.

A simple solution is to never add a trailing comma to array/dict when there is only 1 element. This impacts multiline array/dict literals with only 1 element, but that's probably uncommon and it's reasonable to skip the trailing comma for only 1 element.