### PR TITLE
Support conditional indentation for dot-chained expressions to align dots

### DIFF
--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -80,6 +80,13 @@ top-level keys and values:
     conditional compilation blocks are indented. If this setting is `false` the body
     of `#if`, `#elseif`, and `#else` is not indented. Defaults to `true`.
 
+*  `lineBreakAroundMultilineExpressionChainComponents` _(boolean)_:  Determines whether
+   line breaks should be forced before and after multiline components of dot-chained
+   expressions, such as function calls and subscripts chained together through member
+   access (i.e. "." expressions). When any component is multiline and this option is
+   true, a line break is forced before the "." of the component and after the component's
+   closing delimiter (i.e. right paren, right bracket, right brace, etc.).
+
 > TODO: Add support for enabling/disabling specific syntax transformations in
 > the pipeline.
 

--- a/Sources/SwiftFormatConfiguration/Configuration.swift
+++ b/Sources/SwiftFormatConfiguration/Configuration.swift
@@ -32,6 +32,7 @@ public struct Configuration: Codable, Equatable {
     case lineBreakBeforeEachGenericRequirement
     case prioritizeKeepingFunctionOutputTogether
     case indentConditionalCompilationBlocks
+    case lineBreakAroundMultilineExpressionChainComponents
     case rules
   }
 
@@ -111,6 +112,13 @@ public struct Configuration: Codable, Equatable {
   /// Determines the indentation behavior for `#if`, `#elseif`, and `#else`.
   public var indentConditionalCompilationBlocks = true
 
+  /// Determines whether line breaks should be forced before and after multiline components of
+  /// dot-chained expressions, such as function calls and subscripts chained together through member
+  /// access (i.e. "." expressions). When any component is multiline and this option is true, a line
+  /// break is forced before the "." of the component and after the component's closing delimiter
+  /// (i.e. right paren, right bracket, right brace, etc.).
+  public var lineBreakAroundMultilineExpressionChainComponents = false
+
   /// Constructs a Configuration with all default values.
   public init() {
     self.version = highestSupportedConfigurationVersion
@@ -157,6 +165,9 @@ public struct Configuration: Codable, Equatable {
       = try container.decodeIfPresent(Bool.self, forKey: .prioritizeKeepingFunctionOutputTogether) ?? false
     self.indentConditionalCompilationBlocks
       = try container.decodeIfPresent(Bool.self, forKey: .indentConditionalCompilationBlocks) ?? true
+    self.lineBreakAroundMultilineExpressionChainComponents =
+      try container.decodeIfPresent(
+        Bool.self, forKey: .lineBreakAroundMultilineExpressionChainComponents) ?? false
 
     // If the `rules` key is not present at all, default it to the built-in set
     // so that the behavior is the same as if the configuration had been
@@ -181,6 +192,9 @@ public struct Configuration: Codable, Equatable {
     try container.encode(lineBreakBeforeEachGenericRequirement, forKey: .lineBreakBeforeEachGenericRequirement)
     try container.encode(prioritizeKeepingFunctionOutputTogether, forKey: .prioritizeKeepingFunctionOutputTogether)
     try container.encode(indentConditionalCompilationBlocks, forKey: .indentConditionalCompilationBlocks)
+    try container.encode(
+      lineBreakAroundMultilineExpressionChainComponents,
+      forKey: .lineBreakAroundMultilineExpressionChainComponents)
     try container.encode(rules, forKey: .rules)
   }
 }

--- a/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
@@ -44,6 +44,25 @@ public class PrettyPrinter {
     var contributesBlockIndent: Bool
   }
 
+  /// Records state of `contextualBreakingStart` tokens.
+  private struct ActiveBreakingContext {
+    /// The line number in the `outputBuffer` where a start token appeared.
+    let lineNumber: Int
+
+    enum BreakingBehavior {
+      /// The behavior hasn't been determined. This is treated as `continuation`.
+      case unset
+      /// The break is created as a `continuation` break, setting `currentLineIsContinuation` when
+      /// it fires.
+      case continuation
+      /// The break maintains the existing value of `currentLineIsContinuation` when it fires.
+      case maintain
+    }
+
+    /// The behavior to use when a `contextual` break fires inside of this break context.
+    var contextualBreakingBehavior = BreakingBehavior.unset
+  }
+
   private let context: Context
   private var configuration: Configuration { return context.configuration }
   private let maxLineLength: Int
@@ -74,6 +93,12 @@ public class PrettyPrinter {
   /// Keeps track of the line numbers and indentation states of the open (and unclosed) breaks seen
   /// so far.
   private var activeOpenBreaks: [ActiveOpenBreak] = []
+
+  /// Stack of the active breaking contexts.
+  private var activeBreakingContexts: [ActiveBreakingContext] = []
+
+  /// The most recently ended breaking context, used to force certain following `contextual` breaks.
+  private var lastEndedBreakingContext: ActiveBreakingContext? = nil
 
   /// Keeps track of the current line number being printed.
   private var lineNumber: Int = 1
@@ -243,6 +268,24 @@ public class PrettyPrinter {
     assert(length >= 0, "Token lengths must be positive")
 
     switch token {
+    case .contextualBreakingStart:
+      activeBreakingContexts.append(ActiveBreakingContext(lineNumber: lineNumber))
+
+      // Discard the last finished breaking context to keep it from effecting breaks inside of the
+      // new context. The discarded context has already either had an impact on the contextual break
+      // after it or there was no relevant contextual break, so it's safe to discard.
+      lastEndedBreakingContext = nil
+
+    case .contextualBreakingEnd:
+      guard let closedContext = activeBreakingContexts.popLast() else {
+        fatalError("Encountered unmatched contextualBreakingEnd token.")
+      }
+
+      // Break contexts create scopes, and a breaking context should never be carried between
+      // scopes. When there's no active break context, discard the popped one to prevent carrying it
+      // into a new scope.
+      lastEndedBreakingContext = activeBreakingContexts.isEmpty ? nil : closedContext
+
     // Check if we need to force breaks in this group, and calculate the indentation to be used in
     // the group.
     case .open(let breaktype):
@@ -384,6 +427,42 @@ public class PrettyPrinter {
 
       case .reset:
         mustBreak = currentLineIsContinuation
+
+      case .contextual:
+        // When the last context spanned multiple lines, move the next context (in the same parent
+        // break context scope) onto its own line. For example, this is used when the previous
+        // context includes a multiline trailing closure or multiline function argument list.
+        if let lastBreakingContext = lastEndedBreakingContext {
+          if configuration.lineBreakAroundMultilineExpressionChainComponents {
+            mustBreak = lastBreakingContext.lineNumber != lineNumber
+          }
+        }
+
+        // Wait for a contextual break to fire and then update the breaking behavior for the rest of
+        // the contextual breaks in this scope to match the behavior of the one that fired.
+        let willFire = (!isAtStartOfLine && length > spaceRemaining) || mustBreak
+        if willFire {
+          // Update the active breaking context according to the most recently finished breaking
+          // context so all following contextual breaks in this scope to have matching behavior.
+          if let closedContext = lastEndedBreakingContext,
+            let activeContext = activeBreakingContexts.last,
+            case .unset = activeContext.contextualBreakingBehavior
+          {
+            activeBreakingContexts[activeBreakingContexts.count - 1].contextualBreakingBehavior =
+              (closedContext.lineNumber == lineNumber) ? .continuation : .maintain
+          }
+        }
+
+        if let activeBreakingContext = activeBreakingContexts.last {
+          switch activeBreakingContext.contextualBreakingBehavior {
+          case .unset, .continuation:
+            isContinuationIfBreakFires = true
+          case .maintain:
+            isContinuationIfBreakFires = currentLineIsContinuation
+          }
+        }
+
+        lastEndedBreakingContext = nil
       }
 
       var overrideBreakingSuppressed = false
@@ -494,6 +573,12 @@ public class PrettyPrinter {
     // Calculate token lengths
     for (i, token) in tokens.enumerated() {
       switch token {
+      case .contextualBreakingStart:
+        lengths.append(0)
+
+      case .contextualBreakingEnd:
+        lengths.append(0)
+
       // Open tokens have lengths equal to the total of the contents of its group. The value is
       // calcualted when close tokens are encountered.
       case .open:
@@ -674,9 +759,17 @@ public class PrettyPrinter {
       printDebugIndent()
       print("[COMMA DELIMITED START Idx: \(idx)]")
 
-      case .commaDelimitedRegionEnd:
-        printDebugIndent()
-        print("[COMMA DELIMITED END Idx: \(idx)]")
+    case .commaDelimitedRegionEnd:
+      printDebugIndent()
+      print("[COMMA DELIMITED END Idx: \(idx)]")
+
+    case .contextualBreakingStart:
+      printDebugIndent()
+      print("[START BREAKING CONTEXT Idx: \(idx)]")
+
+    case .contextualBreakingEnd:
+      printDebugIndent()
+      print("[END BREAKING CONTEXT Idx: \(idx)]")
     }
   }
 

--- a/Sources/SwiftFormatPrettyPrint/Token.swift
+++ b/Sources/SwiftFormatPrettyPrint/Token.swift
@@ -111,6 +111,19 @@ enum BreakKind: Equatable {
   /// ```
   case reset
 
+  /// A `contextual` break acts as either a `continue` break or maintains the existing level of
+  /// indentation when it fires. The contextual breaking beahvior of a given contextual breaking
+  /// scope (i.e. inside a `contextualBreakingStart`/`contextualBreakingEnd` region) is set by the
+  /// first child `contextualBreakingStart`/`contextualBreakingEnd` pair. When the first child is
+  /// multiline the contextual breaks maintain indentation and they are continuations otherwise.
+  ///
+  /// These are used when multiple related breaks need to exhibit the same behavior based the
+  /// context in which they appear. For example, when breaks exist between expressions that are
+  /// chained together (e.g. member access) and indenting the line *after* a closing paren/brace
+  /// looks better indented when the previous expr was 1 line but not indented when the expr was
+  /// multiline.
+  case contextual
+
   /// A `close` break that defaults to forced breaking behavior.
   static let close = BreakKind.close(mustBreak: true)
 
@@ -178,6 +191,12 @@ enum Token {
   /// Marks the end of a comma delimited collection, where a trailing comma should be inserted
   /// if and only if the collection spans multiple lines.
   case commaDelimitedRegionEnd(hasTrailingComma: Bool)
+
+  /// Starts a scope where `contextual` breaks have consistent behavior.
+  case contextualBreakingStart
+
+  /// Ends a scope where `contextual` breaks have consistent behavior.
+  case contextualBreakingEnd
 
   // Convenience overloads for the enum types
   static let open = Token.open(.inconsistent, 0)

--- a/Tests/SwiftFormatPrettyPrintTests/GuardStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/GuardStmtTests.swift
@@ -65,17 +65,20 @@ public class GuardStmtTests: PrettyPrintTestCase {
       guard
         let myvar = myClass.itsFunc(
           first: .someStuff,
-          second: .moreStuff).first
+          second: .moreStuff
+        ).first
       else {
         // do stuff
       }
       guard
         let myvar1 = myClass.itsFunc(
           first: .someStuff,
-          second: .moreStuff).first,
+          second: .moreStuff
+        ).first,
         let myvar2 = myClass.diffFunc(
           first: .someStuff,
-          second: .moreStuff).first
+          second: .moreStuff
+        ).first
       else {
         // do stuff
       }

--- a/Tests/SwiftFormatPrettyPrintTests/MemberAccessExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/MemberAccessExprTests.swift
@@ -1,3 +1,5 @@
+import SwiftFormatConfiguration
+
 public class MemberAccessExprTests: PrettyPrintTestCase {
   public func testMemberAccess() {
     let input =
@@ -63,19 +65,64 @@ public class MemberAccessExprTests: PrettyPrintTestCase {
     let input =
       """
       let result = [1, 2, 3, 4, 5].filter { $0 % 2 == 0 }.map { $0 * $0 }
+      array.filter { $0 }.map { $0 as FooBarBaz }.compactMap { $0 }
+      array.filter {
+        $0 is FooBarBaz
+      }.map { $0 as FooBarBaz }.compactMap { $0 }
       """
 
-    let expected =
+    let expectedNoForcedBreaks =
       """
       let result = [
         1, 2, 3, 4, 5,
       ].filter {
         $0 % 2 == 0
       }.map { $0 * $0 }
+      array.filter { $0 }
+        .map {
+          $0 as FooBarBaz
+        }.compactMap {
+          $0
+        }
+      array.filter {
+        $0 is FooBarBaz
+      }.map {
+        $0 as FooBarBaz
+      }.compactMap { $0 }
 
       """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20)
+    assertPrettyPrintEqual(input: input, expected: expectedNoForcedBreaks, linelength: 20)
+
+    let expectedWithForcedBreaks =
+      """
+      let result = [
+        1, 2, 3, 4, 5,
+      ]
+      .filter {
+        $0 % 2 == 0
+      }
+      .map { $0 * $0 }
+      array.filter { $0 }
+        .map {
+          $0 as FooBarBaz
+        }
+        .compactMap { $0 }
+      array.filter {
+        $0 is FooBarBaz
+      }
+      .map {
+        $0 as FooBarBaz
+      }
+      .compactMap { $0 }
+
+      """
+
+    var configuration = Configuration()
+    configuration.lineBreakAroundMultilineExpressionChainComponents = true
+    assertPrettyPrintEqual(
+      input: input, expected: expectedWithForcedBreaks, linelength: 20,
+      configuration: configuration)
   }
 
   public func testContinuationRestorationAfterGroup() {
@@ -122,5 +169,352 @@ public class MemberAccessExprTests: PrettyPrintTestCase {
       """
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 60)
+  }
+
+  public func testBaselessMemberAccess() {
+    let input =
+      """
+      foo.bar(.someImplicitlyTypedMemberFunc(
+        a, b, c))
+      """
+
+    let expected =
+      """
+      foo.bar(
+        .someImplicitlyTypedMemberFunc(
+          a, b, c))
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 60)
+  }
+
+  public func testChainsUsingNonTrailingClosures() {
+    let input =
+      """
+      myWeirdFunc(foo: bar, withClosure: { abc in
+        abc.frob() }).map { $0 }.filter { $0.isFrobbed }
+      myWeirdFunc(withClosure: { abc in
+        abc.frob() }).map { $0 }.filter { $0.isFrobbed }
+
+      """
+
+    let expectedNoForcedBreaking =
+      """
+      myWeirdFunc(
+        foo: bar,
+        withClosure: { abc in
+          abc.frob()
+        }
+      ).map { $0 }.filter {
+        $0.isFrobbed
+      }
+      myWeirdFunc(withClosure: { abc in
+        abc.frob()
+      }).map { $0 }.filter {
+        $0.isFrobbed
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expectedNoForcedBreaking, linelength: 35)
+
+    let expectedWithForcedBreaking =
+      """
+      myWeirdFunc(
+        foo: bar,
+        withClosure: { abc in
+          abc.frob()
+        }
+      )
+      .map { $0 }.filter { $0.isFrobbed }
+      myWeirdFunc(withClosure: { abc in
+        abc.frob()
+      })
+      .map { $0 }.filter { $0.isFrobbed }
+
+      """
+
+    var configuration = Configuration()
+    configuration.lineBreakAroundMultilineExpressionChainComponents = true
+    assertPrettyPrintEqual(
+      input: input, expected: expectedWithForcedBreaking, linelength: 35,
+      configuration: configuration)
+  }
+
+  public func testMemberItemClosureChaining() {
+    let input =
+      """
+      struct ContentView: View {
+        var body: some View {
+          VStack(alignment: .leading) {
+            Text("Turtle Rock")
+              .headlineTextRenderingFont(.title)
+            HStack {
+              Text("Joshua Tree National Park")
+                .font(.subheadline) { Color(.blue) }
+                .bold(true)
+            }
+            Image(.turtle) {
+              presentTurtle()
+            }.foreground[tintColors]
+            Image(.swiftyBird) {
+              presentBirds()
+            }
+            .highlight[tintColors]
+          }
+          .padding(10)
+          Text("Rabbit Rock") { Font(.serifs) }
+            .backgroundColor(.red)
+        }
+      }
+      """
+
+    let expectedNoForcedBreaks =
+      """
+      struct ContentView: View {
+        var body: some View {
+          VStack(alignment: .leading) {
+            Text("Turtle Rock")
+              .headlineTextRenderingFont(.title)
+            HStack {
+              Text("Joshua Tree National Park")
+                .font(.subheadline) { Color(.blue) }
+                .bold(true)
+            }
+            Image(.turtle) {
+              presentTurtle()
+            }.foreground[tintColors]
+            Image(.swiftyBird) {
+              presentBirds()
+            }
+            .highlight[tintColors]
+          }
+          .padding(10)
+          Text("Rabbit Rock") { Font(.serifs) }
+            .backgroundColor(.red)
+        }
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expectedNoForcedBreaks, linelength: 50)
+
+    let expectedWithForcedBreaks =
+      """
+      struct ContentView: View {
+        var body: some View {
+          VStack(alignment: .leading) {
+            Text("Turtle Rock")
+              .headlineTextRenderingFont(.title)
+            HStack {
+              Text("Joshua Tree National Park")
+                .font(.subheadline) { Color(.blue) }
+                .bold(true)
+            }
+            Image(.turtle) {
+              presentTurtle()
+            }
+            .foreground[tintColors]
+            Image(.swiftyBird) {
+              presentBirds()
+            }
+            .highlight[tintColors]
+          }
+          .padding(10)
+          Text("Rabbit Rock") { Font(.serifs) }
+            .backgroundColor(.red)
+        }
+      }
+
+      """
+
+    var configuration = Configuration()
+    configuration.lineBreakAroundMultilineExpressionChainComponents = true
+    assertPrettyPrintEqual(
+      input: input, expected: expectedWithForcedBreaks, linelength: 50,
+      configuration: configuration)
+  }
+
+  public func testChainedTrailingClosureMethods() {
+    let input =
+      """
+      var button =  View.Button { Text("ABC") }.action { presentAction() }.background(.red).text(.blue).text(.red).font(.appleSans)
+      var button =  View.Button {
+        // comment #0
+        Text("ABC")
+      }.action { presentAction() }.background(.red).text(.blue).text(.red).font(.appleSans)
+      var button =  View.Button { Text("ABC") }
+        .action { presentAction() }.background(.red).text(.blue) .text(.red).font(.appleSans)
+      var button =  View.Button { Text("ABC") }
+        .action {
+          // comment #1
+          presentAction()  // comment #2
+        }.background(.red).text(.blue) .text(.red).font(.appleSans) /* trailing comment */
+    var button =  View.Button { Text("ABC") }.action { presentAction() }.background(.red).text(.blue).text(.red).font(.appleSans).foo {
+      abc in
+      return abc.foo.bar
+    }
+    """
+
+    let expectedNoForcedBreaks =
+      """
+      var button = View.Button { Text("ABC") }.action {
+        presentAction()
+      }.background(.red).text(.blue).text(.red).font(
+        .appleSans)
+      var button = View.Button {
+        // comment #0
+        Text("ABC")
+      }.action { presentAction() }.background(.red)
+        .text(.blue).text(.red).font(.appleSans)
+      var button = View.Button { Text("ABC") }
+        .action { presentAction() }.background(.red)
+        .text(.blue).text(.red).font(.appleSans)
+      var button = View.Button { Text("ABC") }
+        .action {
+          // comment #1
+          presentAction()  // comment #2
+        }.background(.red).text(.blue).text(.red).font(
+          .appleSans) /* trailing comment */
+      var button = View.Button { Text("ABC") }.action {
+        presentAction()
+      }.background(.red).text(.blue).text(.red).font(
+        .appleSans
+      ).foo {
+        abc in
+        return abc.foo.bar
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expectedNoForcedBreaks, linelength: 50)
+
+    let expectedWithForcedBreaks =
+      """
+      var button = View.Button { Text("ABC") }
+        .action { presentAction() }.background(.red)
+        .text(.blue).text(.red).font(.appleSans)
+      var button =
+        View.Button {
+          // comment #0
+          Text("ABC")
+        }
+        .action { presentAction() }.background(.red)
+        .text(.blue).text(.red).font(.appleSans)
+      var button = View.Button { Text("ABC") }
+        .action { presentAction() }.background(.red)
+        .text(.blue).text(.red).font(.appleSans)
+      var button = View.Button { Text("ABC") }
+        .action {
+          // comment #1
+          presentAction()  // comment #2
+        }
+        .background(.red).text(.blue).text(.red)
+        .font(.appleSans) /* trailing comment */
+      var button = View.Button { Text("ABC") }
+        .action { presentAction() }.background(.red)
+        .text(.blue).text(.red).font(.appleSans)
+        .foo {
+          abc in
+          return abc.foo.bar
+        }
+
+      """
+
+    var configuration = Configuration()
+    configuration.lineBreakAroundMultilineExpressionChainComponents = true
+    assertPrettyPrintEqual(
+      input: input, expected: expectedWithForcedBreaks, linelength: 50,
+      configuration: configuration)
+  }
+
+  public func testChainedSubscriptExprs() {
+    let input =
+      """
+      var button =  View.Button[5, 4, 3] { Text("ABC") }.action { presentAction() }.background(.red).text(.blue).text(.red).font(.appleSans)
+      var button =  View.Button[5,
+        4, 3] { Text("ABC") }.action { presentAction() }.background(.red).text(.blue).text(.red).font(.appleSans)
+      var button =  View.Button[5, 4, 3
+      ] {
+        // comment #0
+        Text("ABC")
+      }.action {
+        // comment #1
+        presentAction() }.background(.red).text(.blue).text(.red).font(.appleSans) /* trailing comment */
+      var button =  View.Button[5, 4, 3] {
+        Text("ABC")
+      }.action { presentAction() }.background(.red).text(.blue).text(.red).font(.appleSans)[5]
+      """
+
+    let expectedNoForcedBreaks =
+      """
+      var button = View.Button[5, 4, 3] { Text("ABC") }
+        .action { presentAction() }.background(.red)
+        .text(.blue).text(.red).font(.appleSans)
+      var button = View.Button[
+        5,
+        4, 3
+      ] { Text("ABC") }.action { presentAction() }
+        .background(.red).text(.blue).text(.red).font(
+          .appleSans)
+      var button = View.Button[
+        5, 4, 3
+      ] {
+        // comment #0
+        Text("ABC")
+      }.action {
+        // comment #1
+        presentAction()
+      }.background(.red).text(.blue).text(.red).font(
+        .appleSans) /* trailing comment */
+      var button = View.Button[5, 4, 3] {
+        Text("ABC")
+      }.action { presentAction() }.background(.red)
+        .text(.blue).text(.red).font(.appleSans)[5]
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expectedNoForcedBreaks, linelength: 50)
+
+    let expectedWithForcedBreaks =
+      """
+      var button = View.Button[5, 4, 3] { Text("ABC") }
+        .action { presentAction() }.background(.red)
+        .text(.blue).text(.red).font(.appleSans)
+      var button =
+        View.Button[
+          5,
+          4, 3
+        ] { Text("ABC") }
+        .action { presentAction() }.background(.red)
+        .text(.blue).text(.red).font(.appleSans)
+      var button =
+        View.Button[
+          5, 4, 3
+        ] {
+          // comment #0
+          Text("ABC")
+        }
+        .action {
+          // comment #1
+          presentAction()
+        }
+        .background(.red).text(.blue).text(.red)
+        .font(.appleSans) /* trailing comment */
+      var button =
+        View.Button[5, 4, 3] {
+          Text("ABC")
+        }
+        .action { presentAction() }.background(.red)
+        .text(.blue).text(.red).font(.appleSans)[5]
+
+      """
+
+    var configuration = Configuration()
+    configuration.lineBreakAroundMultilineExpressionChainComponents = true
+    assertPrettyPrintEqual(
+      input: input, expected: expectedWithForcedBreaks, linelength: 50,
+      configuration: configuration)
   }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -396,9 +396,14 @@ extension MemberAccessExprTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__MemberAccessExprTests = [
+        ("testBaselessMemberAccess", testBaselessMemberAccess),
+        ("testChainedSubscriptExprs", testChainedSubscriptExprs),
+        ("testChainedTrailingClosureMethods", testChainedTrailingClosureMethods),
+        ("testChainsUsingNonTrailingClosures", testChainsUsingNonTrailingClosures),
         ("testContinuationRestorationAfterGroup", testContinuationRestorationAfterGroup),
         ("testImplicitMemberAccess", testImplicitMemberAccess),
         ("testMemberAccess", testMemberAccess),
+        ("testMemberItemClosureChaining", testMemberItemClosureChaining),
         ("testMethodChainingWithClosures", testMethodChainingWithClosures),
         ("testMethodChainingWithClosuresFullWrap", testMethodChainingWithClosuresFullWrap),
         ("testOperatorChainedMemberAccessExprs", testOperatorChainedMemberAccessExprs),


### PR DESCRIPTION
When expressions are chained together as member access expressions, it's not always appropriate to treat the breaks between the expressions (at the `.`) as continuations. Per formatting of Swift UI examples, it actually looks better if the `.` is aligned with the closing delimiter (e.g. right brace, right paren) of the preceding expression.

In order to support that behavior, we need a break that conditionally switches from "continuation" or "maintain" (where maintain means to maintain the current continuation state). For that break to make a decision about its behavior, we also need to create scopes around the breaks.

New tokens:
- `.break(.contextual, _, _`: A break that conditionally switches between continuation and maintain behavior, based on the contextual breaking scope.
- `.contextualBreakingStart`/`.contextualBreakingEnd`: Creates scopes where contextual breaks fire with the same behavior. Also mark the start/end of nested expressions to track whether an expression is multiline.

See the new and updated tests for examples of the formatting.