### PR TITLE
Swap order of .close and .break around tuple exprs.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -656,7 +656,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
     } else if elementCount > 1 {
       // Tuples with more than one element are "true" tuples, and should indent as block structures.
       after(node.leftParen, tokens: .break(.open, size: 0), .open)
-      before(node.rightParen, tokens: .close, .break(.close, size: 0))
+      before(node.rightParen, tokens: .break(.close, size: 0), .close)
 
       insertTokens(.break(.same), betweenElementsOf: node.elementList)
 

--- a/Tests/SwiftFormatPrettyPrintTests/TupleDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/TupleDeclTests.swift
@@ -4,6 +4,7 @@ public class TupleDeclTests: PrettyPrintTestCase {
       """
       let a = (1, 2, 3)
       let a: (Int, Int, Int) = (1, 2, 3)
+      let a = (1, 2, 3, 4, 5, 6, 70, 80, 90)
       let a = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
       let a = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
       """
@@ -12,6 +13,9 @@ public class TupleDeclTests: PrettyPrintTestCase {
       """
       let a = (1, 2, 3)
       let a: (Int, Int, Int) = (1, 2, 3)
+      let a = (
+        1, 2, 3, 4, 5, 6, 70, 80, 90
+      )
       let a = (
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10
       )


### PR DESCRIPTION
The close group and close break were in the wrong order, causing the right paren's length to not be included in the length of the open break before first tuple element. This allowed the open break between the left paren and first element to NOT fire, but later the close break before the right paren DOES FIRE due to line length.

SR-12111