### PR TITLE
[NFC] Remove links to Google's style guide in comments.

### DIFF
--- a/Sources/SwiftFormatRules/AllPublicDeclarationsHaveDocumentation.swift
+++ b/Sources/SwiftFormatRules/AllPublicDeclarationsHaveDocumentation.swift
@@ -17,8 +17,6 @@ import SwiftSyntax
 /// All public or open declarations must have a top-level documentation comment.
 ///
 /// Lint: If a public declaration is missing a documentation comment, a lint error is raised.
-///
-/// - SeeAlso: https://google.github.io/swift#where-to-document
 public final class AllPublicDeclarationsHaveDocumentation: SyntaxLintRule {
 
   public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {

--- a/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
+++ b/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
@@ -19,8 +19,6 @@ import SwiftSyntax
 ///
 /// Lint: If an identifier contains underscores or begins with a capital letter, a lint error is
 ///       raised.
-///
-/// - SeeAlso: https://google.github.io/swift#identifiers
 public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
 
   public override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {

--- a/Sources/SwiftFormatRules/AmbiguousTrailingClosureOverload.swift
+++ b/Sources/SwiftFormatRules/AmbiguousTrailingClosureOverload.swift
@@ -18,8 +18,6 @@ import SwiftSyntax
 ///
 /// Lint: If two overloaded functions with one closure parameter appear in the same scope, a lint
 ///       error is raised.
-///
-/// - SeeAlso: https://google.github.io/swift#trailing-closures
 public final class AmbiguousTrailingClosureOverload: SyntaxLintRule {
 
   func diagnoseBadOverloads(_ overloads: [String: [FunctionDeclSyntax]]) {

--- a/Sources/SwiftFormatRules/BeginDocumentationCommentWithOneLineSummary.swift
+++ b/Sources/SwiftFormatRules/BeginDocumentationCommentWithOneLineSummary.swift
@@ -17,8 +17,6 @@ import SwiftSyntax
 /// All documentation comments must begin with a one-line summary of the declaration.
 ///
 /// Lint: If a comment does not begin with a single-line summary, a lint error is raised.
-///
-/// - SeeAlso: https://google.github.io/swift#single-sentence-summary
 public final class BeginDocumentationCommentWithOneLineSummary: SyntaxLintRule {
 
   /// Unit tests can testably import this module and set this to true in order to force the rule

--- a/Sources/SwiftFormatRules/DoNotUseSemicolons.swift
+++ b/Sources/SwiftFormatRules/DoNotUseSemicolons.swift
@@ -19,8 +19,6 @@ import SwiftSyntax
 /// Lint: If a semicolon appears anywhere, a lint error is raised.
 ///
 /// Format: All semicolons will be replaced with line breaks.
-///
-/// - SeeAlso: https://google.github.io/swift#semicolons
 public final class DoNotUseSemicolons: SyntaxFormatRule {
 
   /// Creates a new version of the given node which doesn't contain any semicolons. The node's

--- a/Sources/SwiftFormatRules/DontRepeatTypeInStaticProperties.swift
+++ b/Sources/SwiftFormatRules/DontRepeatTypeInStaticProperties.swift
@@ -21,8 +21,6 @@ import SwiftSyntax
 /// `public class var redColor: UIColor` would trigger this rule.
 ///
 /// Lint: Static properties of a type that return that type will yield a lint error.
-///
-/// - SeeAlso: https://google.github.io/swift#static-and-class-properties
 public final class DontRepeatTypeInStaticProperties: SyntaxLintRule {
 
   public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {

--- a/Sources/SwiftFormatRules/FullyIndirectEnum.swift
+++ b/Sources/SwiftFormatRules/FullyIndirectEnum.swift
@@ -21,8 +21,6 @@ import SwiftSyntax
 ///
 /// Format: Enums where all cases are `indirect` will be rewritten such that the enum is marked
 ///         `indirect`, and each case is not.
-///
-/// - SeeAlso: https://google.github.io/swift#enum-cases
 public final class FullyIndirectEnum: SyntaxFormatRule {
 
   public override func visit(_ node: EnumDeclSyntax) -> DeclSyntax {

--- a/Sources/SwiftFormatRules/GroupNumericLiterals.swift
+++ b/Sources/SwiftFormatRules/GroupNumericLiterals.swift
@@ -26,8 +26,6 @@ import SwiftSyntax
 /// TODO: Minimum numeric literal length bounds and numeric groupings have been selected arbitrarily;
 /// these could be reevaluated.
 /// TODO: Handle floating point literals.
-///
-/// - SeeAlso: https://google.github.io/swift#numeric-literals
 public final class GroupNumericLiterals: SyntaxFormatRule {
   public override func visit(_ node: IntegerLiteralExprSyntax) -> ExprSyntax {
     var originalDigits = node.digits.text

--- a/Sources/SwiftFormatRules/IdentifiersMustBeASCII.swift
+++ b/Sources/SwiftFormatRules/IdentifiersMustBeASCII.swift
@@ -17,8 +17,6 @@ import SwiftSyntax
 /// All identifiers must be ASCII.
 ///
 /// Lint: If an identifier contains non-ASCII characters, a lint error is raised.
-///
-/// - SeeAlso: https://google.github.io/swift#identifiers
 public final class IdentifiersMustBeASCII: SyntaxLintRule {
 
   public override func visit(_ node: IdentifierPatternSyntax) -> SyntaxVisitorContinueKind {

--- a/Sources/SwiftFormatRules/NeverForceUnwrap.swift
+++ b/Sources/SwiftFormatRules/NeverForceUnwrap.swift
@@ -16,9 +16,6 @@ import SwiftSyntax
 /// Force-unwraps are strongly discouraged and must be documented.
 ///
 /// Lint: If a force unwrap is used, a lint warning is raised.
-///       TODO(abl): consider having documentation (e.g. a comment) cancel the warning?
-///
-/// - SeeAlso: https://google.github.io/swift#force-unwrapping-and-force-casts
 public final class NeverForceUnwrap: SyntaxLintRule {
 
   public override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {

--- a/Sources/SwiftFormatRules/NeverUseForceTry.swift
+++ b/Sources/SwiftFormatRules/NeverUseForceTry.swift
@@ -22,8 +22,6 @@ import SwiftSyntax
 /// Lint: Using `try!` results in a lint error.
 ///
 /// TODO: Create exception for NSRegularExpression
-///
-/// - SeeAlso: https://google.github.io/swift#error-types
 public final class NeverUseForceTry: SyntaxLintRule {
 
   public override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {

--- a/Sources/SwiftFormatRules/NeverUseImplicitlyUnwrappedOptionals.swift
+++ b/Sources/SwiftFormatRules/NeverUseImplicitlyUnwrappedOptionals.swift
@@ -24,8 +24,6 @@ import SwiftSyntax
 /// TODO: Create exceptions for other UI elements (ex: viewDidLoad)
 ///
 /// Lint: Declaring a property with an implicitly unwrapped type yields a lint error.
-///
-/// - SeeAlso: https://google.github.io/swift#implicitly-unwrapped-optionals
 public final class NeverUseImplicitlyUnwrappedOptionals: SyntaxLintRule {
 
   // Checks if "XCTest" is an import statement

--- a/Sources/SwiftFormatRules/NoAccessLevelOnExtensionDeclaration.swift
+++ b/Sources/SwiftFormatRules/NoAccessLevelOnExtensionDeclaration.swift
@@ -23,8 +23,6 @@ import SwiftSyntax
 ///         `internal`, as that is the default access level) have the explicit access level removed.
 ///
 /// TODO: Find a better way to access modifiers and keyword tokens besides casting each declaration
-///
-/// - SeeAlso: https://google.github.io/swift#access-levels
 public final class NoAccessLevelOnExtensionDeclaration: SyntaxFormatRule {
 
   public override func visit(_ node: ExtensionDeclSyntax) -> DeclSyntax {

--- a/Sources/SwiftFormatRules/NoBlockComments.swift
+++ b/Sources/SwiftFormatRules/NoBlockComments.swift
@@ -17,8 +17,6 @@ import SwiftSyntax
 /// Block comments should be avoided in favor of line comments.
 ///
 /// Lint: If a block comment appears, a lint error is raised.
-///
-/// - SeeAlso: https://google.github.io/swift#non-documentation-comments
 public final class NoBlockComments: SyntaxLintRule {
   public override func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
     for triviaIndex in token.leadingTrivia.indices {

--- a/Sources/SwiftFormatRules/NoCasesWithOnlyFallthrough.swift
+++ b/Sources/SwiftFormatRules/NoCasesWithOnlyFallthrough.swift
@@ -20,8 +20,6 @@ import SwiftSyntax
 ///
 /// Format: The fallthrough `case` is added as a prefix to the next case unless the next case is
 ///         `default`; in that case, the fallthrough `case` is deleted.
-///
-/// - SeeAlso: https://google.github.io/swift#fallthrough-in-switch-statements
 public final class NoCasesWithOnlyFallthrough: SyntaxFormatRule {
 
   public override func visit(_ node: SwitchCaseListSyntax) -> Syntax {

--- a/Sources/SwiftFormatRules/NoEmptyTrailingClosureParentheses.swift
+++ b/Sources/SwiftFormatRules/NoEmptyTrailingClosureParentheses.swift
@@ -20,8 +20,6 @@ import SwiftSyntax
 ///       a lint error is raised.
 ///
 /// Format: Empty parentheses in function calls with trailing closures will be removed.
-///
-/// - SeeAlso: https://google.github.io/swift#trailing-closures
 public final class NoEmptyTrailingClosureParentheses: SyntaxFormatRule {
 
   public override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {

--- a/Sources/SwiftFormatRules/NoLabelsInCasePatterns.swift
+++ b/Sources/SwiftFormatRules/NoLabelsInCasePatterns.swift
@@ -22,8 +22,6 @@ import SwiftSyntax
 ///       binding identifier.
 ///
 /// Format: Redundant labels in case patterns are removed.
-///
-/// - SeeAlso: https://google.github.io/swift#pattern-matching
 public final class NoLabelsInCasePatterns: SyntaxFormatRule {
   public override func visit(_ node: SwitchCaseLabelSyntax) -> Syntax {
 

--- a/Sources/SwiftFormatRules/NoLeadingUnderscores.swift
+++ b/Sources/SwiftFormatRules/NoLeadingUnderscores.swift
@@ -24,8 +24,6 @@ import SwiftSyntax
 /// sites.
 ///
 /// Lint: Declaring an identifier with a leading underscore yields a lint error.
-///
-/// - SeeAlso: https://google.github.io/swift#naming-conventions-are-not-access-control
 public final class NoLeadingUnderscores: SyntaxLintRule {
 
   public override func visit(_ node: AssociatedtypeDeclSyntax) -> SyntaxVisitorContinueKind {

--- a/Sources/SwiftFormatRules/NoParensAroundConditions.swift
+++ b/Sources/SwiftFormatRules/NoParensAroundConditions.swift
@@ -26,8 +26,6 @@ import SwiftSyntax
 /// Format: Parentheses around such expressions are removed, if they do not cause a parse ambiguity.
 ///         Specifically, parentheses are allowed if and only if the expression contains a function
 ///         call with a trailing closure.
-///
-/// - SeeAlso: https://google.github.io/swift#parentheses
 public final class NoParensAroundConditions: SyntaxFormatRule {
   func extractExpr(_ tuple: TupleExprSyntax) -> ExprSyntax {
     assert(tuple.elementList.count == 1)

--- a/Sources/SwiftFormatRules/NoPlaygroundLiterals.swift
+++ b/Sources/SwiftFormatRules/NoPlaygroundLiterals.swift
@@ -26,8 +26,6 @@ import SwiftSyntax
 ///         `#colorLiteral(...)` becomes `UIColor(...)`
 ///
 /// Configuration: resolveAmbiguousColor
-///
-/// - SeeAlso: https://google.github.io/swift#playground-literals
 public final class NoPlaygroundLiterals: SyntaxFormatRule {
 
 }

--- a/Sources/SwiftFormatRules/NoVoidReturnOnFunctionSignature.swift
+++ b/Sources/SwiftFormatRules/NoVoidReturnOnFunctionSignature.swift
@@ -19,8 +19,6 @@ import SwiftSyntax
 ///
 /// Format: Function declarations with explicit returns of `()` or `Void` will have their return
 ///         signature stripped.
-///
-/// - SeeAlso: https://google.github.io/swift#types-with-shorthand-names
 public final class NoVoidReturnOnFunctionSignature: SyntaxFormatRule {
   /// Remove the `-> Void` return type for function signatures. Do not remove
   /// it for closure signatures, because that may introduce an ambiguity when closure signatures

--- a/Sources/SwiftFormatRules/OneCasePerLine.swift
+++ b/Sources/SwiftFormatRules/OneCasePerLine.swift
@@ -21,8 +21,6 @@ import SwiftSyntax
 ///
 /// Format: All case declarations with associated values or raw values will be moved to their own
 ///         case declarations.
-///
-/// - SeeAlso: https://google.github.io/swift#enum-cases
 public final class OneCasePerLine: SyntaxFormatRule {
 
   /// A state machine that collects case elements encountered during visitation and allows new case

--- a/Sources/SwiftFormatRules/OneVariableDeclarationPerLine.swift
+++ b/Sources/SwiftFormatRules/OneVariableDeclarationPerLine.swift
@@ -20,8 +20,6 @@ import SwiftSyntax
 ///
 /// Format: If a variable declaration declares multiple variables, it will be split into multiple
 ///         declarations, each declaring one of the variables.
-///
-/// - SeeAlso: https://google.github.io/swift#properties
 public final class OneVariableDeclarationPerLine: SyntaxFormatRule {
   func splitVariableDecls(
     _ items: CodeBlockItemListSyntax

--- a/Sources/SwiftFormatRules/OnlyOneTrailingClosureArgument.swift
+++ b/Sources/SwiftFormatRules/OnlyOneTrailingClosureArgument.swift
@@ -18,8 +18,6 @@ import SwiftSyntax
 ///
 /// Lint: If a function call with a trailing closure also contains a non-trailing closure argument,
 ///       a lint error is raised.
-///
-/// - SeeAlso: https://google.github.io/swift#trailing-closures
 public final class OnlyOneTrailingClosureArgument: SyntaxLintRule {
 
   public override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {

--- a/Sources/SwiftFormatRules/OrderedImports.swift
+++ b/Sources/SwiftFormatRules/OrderedImports.swift
@@ -24,8 +24,6 @@ import SwiftSyntax
 ///       raised.
 ///
 /// Format: Imports will be reordered and grouped at the top of the file.
-///
-/// - SeeAlso: https://google.github.io/swift#import-statements
 public final class OrderedImports: SyntaxFormatRule {
 
   public override func visit(_ node: SourceFileSyntax) -> Syntax {

--- a/Sources/SwiftFormatRules/ReturnVoidInsteadOfEmptyTuple.swift
+++ b/Sources/SwiftFormatRules/ReturnVoidInsteadOfEmptyTuple.swift
@@ -22,8 +22,6 @@ import SwiftSyntax
 /// Lint: Returning `()` in a signature yields a lint error.
 ///
 /// Format: `-> ()` is replaced with `-> Void`
-///
-/// - SeeAlso: https://google.github.io/swift#types-with-shorthand-names
 public final class ReturnVoidInsteadOfEmptyTuple: SyntaxFormatRule {
   public override func visit(_ node: FunctionTypeSyntax) -> TypeSyntax {
     guard let returnType = node.returnType.as(TupleTypeSyntax.self),

--- a/Sources/SwiftFormatRules/UseEarlyExits.swift
+++ b/Sources/SwiftFormatRules/UseEarlyExits.swift
@@ -43,8 +43,6 @@ import SwiftSyntax
 ///
 /// Format: `if ... else { return/throw/break/continue }` constructs will be replaced with
 ///         equivalent `guard ... else { return/throw/break/continue }` constructs.
-///
-/// - SeeAlso: https://google.github.io/swift#guards-for-early-exits
 public final class UseEarlyExits: SyntaxFormatRule {
 
   public override func visit(_ node: CodeBlockItemListSyntax) -> Syntax {

--- a/Sources/SwiftFormatRules/UseEnumForNamespacing.swift
+++ b/Sources/SwiftFormatRules/UseEnumForNamespacing.swift
@@ -26,8 +26,6 @@ import SwiftSyntax
 /// Lint: `struct`s consisting of only `static let/func`s will yield a lint error.
 ///
 /// Format: Rewrite the `struct` as an `enum`.
-///
-/// - SeeAlso: https://google.github.io/swift#nesting-and-namespacing
 public final class UseEnumForNamespacing: SyntaxFormatRule {
 
   public override func visit(_ node: StructDeclSyntax) -> DeclSyntax {

--- a/Sources/SwiftFormatRules/UseLetInEveryBoundCaseVariable.swift
+++ b/Sources/SwiftFormatRules/UseLetInEveryBoundCaseVariable.swift
@@ -19,11 +19,6 @@ import SwiftSyntax
 /// e.g. `case let .label(foo, bar)` is forbidden.
 ///
 /// Lint: `case let ...` will yield a lint error.
-///
-/// Format: The `let` will be distributed across each element.
-///         TODO(abl): This is not a neutral format operation.
-///
-/// - SeeAlso: https://google.github.io/swift#pattern-matching
 public final class UseLetInEveryBoundCaseVariable: SyntaxLintRule {
 
   public override func visit(_ node: SwitchCaseLabelSyntax) -> SyntaxVisitorContinueKind {

--- a/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
+++ b/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
@@ -21,8 +21,6 @@ import SwiftSyntax
 ///
 /// Format: Where possible, shorthand types replace long form types; e.g. `Array<Element>` is
 ///         converted to `[Element]`.
-///
-/// - SeeAlso: https://google.github.io/swift#types-with-shorthand-names
 public final class UseShorthandTypeNames: SyntaxFormatRule {
 
   public override func visit(_ node: SimpleTypeIdentifierSyntax) -> TypeSyntax {

--- a/Sources/SwiftFormatRules/UseSingleLinePropertyGetter.swift
+++ b/Sources/SwiftFormatRules/UseSingleLinePropertyGetter.swift
@@ -19,8 +19,6 @@ import SwiftSyntax
 /// Lint: Read-only computed properties with explicit `get` blocks yield a lint error.
 ///
 /// Format: Explicit `get` blocks are rendered implicit by removing the `get`.
-///
-/// - SeeAlso: https://google.github.io/swift#properties-2
 public final class UseSingleLinePropertyGetter: SyntaxFormatRule {
 
   public override func visit(_ node: PatternBindingSyntax) -> Syntax {

--- a/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
+++ b/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
@@ -21,8 +21,6 @@ import SwiftSyntax
 ///
 /// Lint: (Non-public) memberwise initializers with the same structure as the synthesized
 ///       initializer will yield a lint error.
-///
-/// - SeeAlso: https://google.github.io/swift#initializers-2
 public final class UseSynthesizedInitializer: SyntaxLintRule {
 
   public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {

--- a/Sources/SwiftFormatRules/UseTripleSlashForDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/UseTripleSlashForDocumentationComments.swift
@@ -23,8 +23,6 @@ import SwiftSyntax
 /// Format: If a doc block comment appears on its own on a line, or if a doc block comment spans
 ///         multiple lines without appearing on the same line as code, it will be replaced with
 ///         multiple doc line comments.
-///
-/// - SeeAlso: https://google.github.io/swift#general-format
 public final class UseTripleSlashForDocumentationComments: SyntaxFormatRule {
   public override func visit(_ node: FunctionDeclSyntax) -> DeclSyntax {
     return convertDocBlockCommentToDocLineComment(DeclSyntax(node))

--- a/Sources/SwiftFormatRules/UseWhereClausesInForLoops.swift
+++ b/Sources/SwiftFormatRules/UseWhereClausesInForLoops.swift
@@ -20,8 +20,6 @@ import SwiftSyntax
 ///
 /// Format: `for` loops that consist of a single `if` statement have the conditional of that
 ///         statement factored out to a `where` clause.
-///
-/// - SeeAlso: https://google.github.io/swift#for-where-loops
 public final class UseWhereClausesInForLoops: SyntaxFormatRule {
 
   public override func visit(_ node: ForInStmtSyntax) -> StmtSyntax {

--- a/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
@@ -20,8 +20,6 @@ import SwiftSyntax
 ///
 /// Lint: Documentation comments that are incomplete (e.g. missing parameter documentation) or
 ///       invalid (uses `Parameters` when there is only one parameter) will yield a lint error.
-///
-/// - SeeAlso: https://google.github.io/swift#parameter-returns-and-throws-tags
 public final class ValidateDocumentationComments: SyntaxLintRule {
 
   public override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {


### PR DESCRIPTION
These links were present for historical reasons but aren't relevant
anymore.