### PR TITLE
Transform nested structs in UseEnumForNamespacing.

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -136,6 +136,7 @@ extension ClosureExprTests {
         ("testClosureArgumentsWithTrailingClosure", testClosureArgumentsWithTrailingClosure),
         ("testClosureCapture", testClosureCapture),
         ("testClosureCaptureWithoutArguments", testClosureCaptureWithoutArguments),
+        ("testClosureOutputGrouping", testClosureOutputGrouping),
         ("testClosuresWithIfs", testClosuresWithIfs),
         ("testClosureVariables", testClosureVariables),
         ("testTrailingClosure", testTrailingClosure),

--- a/Tests/SwiftFormatRulesTests/UseEnumForNamespacingTests.swift
+++ b/Tests/SwiftFormatRulesTests/UseEnumForNamespacingTests.swift
@@ -164,4 +164,65 @@ public class UseEnumForNamespacingTests: DiagnosingTestCase {
                 }
                 """)
   }
+
+  public func testNestedEnumsForNameSpaces() {
+     XCTAssertFormatting(
+       UseEnumForNamespacing.self,
+       input: """
+              struct A {
+                static func fooA() {}
+                struct B {
+                  static func fooB() {}
+                }
+              }
+              struct C {
+                func fooC() {}
+                struct D {
+                  static func fooB() {}
+                }
+              }
+              struct E {
+                static func fooE() {}
+                struct F {
+                  func fooF() {}
+                }
+              }
+              struct G {
+                func fooG() {}
+                #if useH
+                struct H {
+                  static func fooH() {}
+                }
+                #endif
+              }
+              """,
+       expected: """
+                 enum A {
+                   static func fooA() {}
+                   enum B {
+                     static func fooB() {}
+                   }
+                 }
+                 struct C {
+                   func fooC() {}
+                   enum D {
+                     static func fooB() {}
+                   }
+                 }
+                 enum E {
+                   static func fooE() {}
+                   struct F {
+                     func fooF() {}
+                   }
+                 }
+                 struct G {
+                   func fooG() {}
+                   #if useH
+                   enum H {
+                     static func fooH() {}
+                   }
+                   #endif
+                 }
+                 """)
+   }
 }

--- a/Tests/SwiftFormatRulesTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatRulesTests/XCTestManifests.swift
@@ -288,6 +288,7 @@ extension UseEnumForNamespacingTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__UseEnumForNamespacingTests = [
+        ("testNestedEnumsForNameSpaces", testNestedEnumsForNameSpaces),
         ("testNonEnumsUsedAsNamespaces", testNonEnumsUsedAsNamespaces),
     ]
 }


### PR DESCRIPTION
The rule was not visiting any structs nested in other structs, because it wasn't calling super to visit the node's children.

I tried to combine `super.visit` with the member enumeration in `membersToKeepIfUsedAsNamespace(_:)` but that method intentionally returns nil to signal that the decl shouldn't be rewritten which would discard the changes to the nested nodes. Instead, the rule now visits the members and uses the rewritten member list even if it's not converted to an enum to keep any changes to nested structs.