### PR TITLE
Group the closing paren of exprs into the enclosed open/close breaks.

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/GuardStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/GuardStmtTests.swift
@@ -197,4 +197,66 @@ final class GuardStmtTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
   }
+
+  func testParenthesizedClauses() {
+    let input =
+      """
+      guard foo && (
+          bar < 1 || bar > 1
+        ) && baz else {
+        // do something
+      }
+      guard muchLongerFoo && (
+          muchLongerBar < 1 || muchLongerBar > 1
+        ) && baz else {
+        // do something
+      }
+      guard muchLongerFoo && (
+          muchLongerBar < 1 || muchLongerBar > 100000000
+        ) && baz else {
+        // do something
+      }
+      guard muchLongerFoo && (
+          muchLongerBar < 1 || muchLongerBar > 100000000 || (
+            extraTerm1 + extraTerm2 + extraTerm3
+          )
+        ) && baz else {
+        // do something
+      }
+      """
+
+    let expected =
+      """
+      guard foo && (bar < 1 || bar > 1) && baz else {
+        // do something
+      }
+      guard
+        muchLongerFoo
+          && (muchLongerBar < 1 || muchLongerBar > 1)
+          && baz
+      else {
+        // do something
+      }
+      guard
+        muchLongerFoo
+          && (muchLongerBar < 1
+            || muchLongerBar > 100000000)
+          && baz
+      else {
+        // do something
+      }
+      guard
+        muchLongerFoo
+          && (muchLongerBar < 1
+            || muchLongerBar > 100000000
+            || (extraTerm1 + extraTerm2 + extraTerm3))
+          && baz
+      else {
+        // do something
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/IfStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/IfStmtTests.swift
@@ -387,4 +387,63 @@ final class IfStmtTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
   }
+
+  func testParenthesizedClauses() {
+    let input =
+      """
+      if foo && (
+          bar < 1 || bar > 1
+        ) && baz {
+        // do something
+      }
+      if muchLongerFoo && (
+          muchLongerBar < 1 || muchLongerBar > 1
+        ) && baz {
+        // do something
+      }
+      if muchLongerFoo && (
+          muchLongerBar < 1 || muchLongerBar > 100000000
+        ) && baz {
+        // do something
+      }
+      if muchLongerFoo && (
+          muchLongerBar < 1 || muchLongerBar > 100000000 || (
+            extraTerm1 + extraTerm2 + extraTerm3
+          )
+        ) && baz {
+        // do something
+      }
+      """
+
+    let expected =
+      """
+      if foo && (bar < 1 || bar > 1) && baz {
+        // do something
+      }
+      if muchLongerFoo
+        && (muchLongerBar < 1 || muchLongerBar > 1)
+        && baz
+      {
+        // do something
+      }
+      if muchLongerFoo
+        && (muchLongerBar < 1
+          || muchLongerBar > 100000000)
+        && baz
+      {
+        // do something
+      }
+      if muchLongerFoo
+        && (muchLongerBar < 1
+          || muchLongerBar > 100000000
+          || (extraTerm1 + extraTerm2 + extraTerm3))
+        && baz
+      {
+        // do something
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/ParenthesizedExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ParenthesizedExprTests.swift
@@ -8,6 +8,26 @@ final class ParenthesizedExprTests: PrettyPrintTestCase {
       x = zerothTerm + (firstTerm + secondTerm + thirdTerm)
       x = zerothTerm + (firstTerm + secondTerm + thirdTerm) - (firstTerm + secondTerm + thirdTerm)
       x = zerothTerm + (firstTerm + secondTerm + thirdTerm) - (firstTerm + secondTerm + thirdTerm) * (firstTerm + secondTerm + thirdTerm)
+      x = zerothTerm + (
+          firstTerm + secondTerm + thirdTerm
+        ) -
+        (
+          firstTerm + secondTerm + thirdTerm
+        )
+      x = zerothTerm + (
+        firstTerm + secondTerm + (
+            nestedFirstTerm + nestedSecondTerm + (
+              doubleNestedFirstTerm + doubleNestedSecondTerm
+            )
+        )
+      ) + thirdTerm
+      x = zerothTerm + (
+      firstTerm + secondTerm && thirdTerm + (
+          nestedFirstTerm || nestedSecondTerm + (
+            doubleNestedFirstTerm + doubleNestedSecondTerm
+          )
+        )
+      )
       """
 
     let expected =
@@ -45,6 +65,28 @@ final class ParenthesizedExprTests: PrettyPrintTestCase {
           + thirdTerm)
         * (firstTerm + secondTerm
           + thirdTerm)
+      x =
+        zerothTerm
+        + (firstTerm + secondTerm
+          + thirdTerm)
+        - (firstTerm + secondTerm
+          + thirdTerm)
+      x =
+        zerothTerm
+        + (firstTerm + secondTerm
+          + (nestedFirstTerm
+            + nestedSecondTerm
+            + (doubleNestedFirstTerm
+              + doubleNestedSecondTerm)))
+        + thirdTerm
+      x =
+        zerothTerm
+        + (firstTerm + secondTerm
+          && thirdTerm
+            + (nestedFirstTerm
+              || nestedSecondTerm
+                + (doubleNestedFirstTerm
+                  + doubleNestedSecondTerm)))
 
       """
 
@@ -154,5 +196,122 @@ final class ParenthesizedExprTests: PrettyPrintTestCase {
       """
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 80)
+  }
+
+  func testTupleSequenceExprs() {
+    let input =
+      """
+      let x = (
+        (
+          firstTupleElem,
+          secondTupleElem,
+          thirdTupleElem
+        ) == (
+          firstTupleElem,
+          secondTupleElem,
+          thirdTupleElem
+        ) && (
+          firstTupleElem,
+          secondTupleElem,
+          thirdTupleElem
+        ) || (
+          firstTupleElem,
+          secondTupleElem,
+          thirdTupleElem
+        )
+      )
+      let x = (
+        (
+          firstTupleElem,
+          secondTupleElem,
+          thirdTupleElem
+        ) && (
+          foo(firstFuncCallArg, second: secondFuncCallArg, third: thirdFuncCallArg, fourth: fourthFuncCallArg)
+        ) || (
+          firstTupleElem,
+          secondTupleElem,
+          thirdTupleElem
+        ) == (
+          foo(firstFuncCallArg, second: secondFuncCallArg, third: thirdFuncCallArg, fourth: fourthFuncCallArg
+        )
+        )
+      )
+      let x = (
+        foo(firstFuncCallArg, second: secondFuncCallArg, third: thirdFuncCallArg, fourth: fourthFuncCallArg
+        ) && (
+          firstTupleElem,
+          secondTupleElem,
+          thirdTupleElem
+        ) || (
+          firstTupleElem,
+          secondTupleElem,
+          thirdTupleElem
+        )
+      )
+      """
+
+    let expected =
+      """
+      let x =
+        ((
+          firstTupleElem,
+          secondTupleElem,
+          thirdTupleElem
+        ) == (
+          firstTupleElem,
+          secondTupleElem,
+          thirdTupleElem
+        )
+          && (
+            firstTupleElem,
+            secondTupleElem,
+            thirdTupleElem
+          )
+          || (
+            firstTupleElem,
+            secondTupleElem,
+            thirdTupleElem
+          ))
+      let x =
+        ((
+          firstTupleElem,
+          secondTupleElem,
+          thirdTupleElem
+        )
+          && (foo(
+            firstFuncCallArg, second: secondFuncCallArg,
+            third: thirdFuncCallArg,
+            fourth: fourthFuncCallArg))
+          || (
+            firstTupleElem,
+            secondTupleElem,
+            thirdTupleElem
+          )
+            == (foo(
+              firstFuncCallArg,
+              second: secondFuncCallArg,
+              third: thirdFuncCallArg,
+              fourth: fourthFuncCallArg
+            )))
+      let x =
+        (foo(
+          firstFuncCallArg, second: secondFuncCallArg,
+          third: thirdFuncCallArg,
+          fourth: fourthFuncCallArg
+        )
+          && (
+            firstTupleElem,
+            secondTupleElem,
+            thirdTupleElem
+          )
+          || (
+            firstTupleElem,
+            secondTupleElem,
+            thirdTupleElem
+          ))
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
   }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/TernaryExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/TernaryExprTests.swift
@@ -207,4 +207,38 @@ final class TernaryExprTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 25)
   }
+
+  func testParenthesizedTernary() {
+    let input =
+      """
+      let a = (
+          foo ?
+            bar : baz
+        )
+      a = (
+          foo ?
+            bar : baz
+        )
+      b = foo ? (
+        bar
+        ) : (
+        baz
+        )
+      c = foo ?
+        (
+          foo2 ? nestedBar : nestedBaz
+        ) : (baz)
+      """
+
+    let expected =
+      """
+      let a = (foo ? bar : baz)
+      a = (foo ? bar : baz)
+      b = foo ? (bar) : (baz)
+      c = foo ? (foo2 ? nestedBar : nestedBaz) : (baz)
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -341,6 +341,7 @@ extension GuardStmtTests {
         ("testGuardWithFuncCall", testGuardWithFuncCall),
         ("testOpenBraceIsGluedToElseKeyword", testOpenBraceIsGluedToElseKeyword),
         ("testOptionalBindingConditions", testOptionalBindingConditions),
+        ("testParenthesizedClauses", testParenthesizedClauses),
     ]
 }
 
@@ -373,6 +374,7 @@ extension IfStmtTests {
         ("testIfStatement", testIfStatement),
         ("testMatchingPatternConditions", testMatchingPatternConditions),
         ("testOptionalBindingConditions", testOptionalBindingConditions),
+        ("testParenthesizedClauses", testParenthesizedClauses),
     ]
 }
 
@@ -489,6 +491,7 @@ extension ParenthesizedExprTests {
         ("testInitializerClauseParens", testInitializerClauseParens),
         ("testNestedParentheses", testNestedParentheses),
         ("testSequenceExprParens", testSequenceExprParens),
+        ("testTupleSequenceExprs", testTupleSequenceExprs),
     ]
 }
 
@@ -676,6 +679,7 @@ extension TernaryExprTests {
     static let __allTests__TernaryExprTests = [
         ("testExpressionStartsWithTernary", testExpressionStartsWithTernary),
         ("testNestedTernaries", testNestedTernaries),
+        ("testParenthesizedTernary", testParenthesizedTernary),
         ("testTernaryExprs", testTernaryExprs),
         ("testTernaryExprsWithMultiplePartChoices", testTernaryExprsWithMultiplePartChoices),
         ("testTernaryWithWrappingExpressions", testTernaryWithWrappingExpressions),


### PR DESCRIPTION
The previous behavior kept line breaks before the right paren, but discarded line breaks after the left paren. This caused the formatter to create "unbalanced" parenthesized expressions where the left paren was glued to the first token in an expression but there could be a line break before the right paren.

Instead, both the left and right parens are now glued to tokens in the parenthesized expression.