### PR TITLE
Absorb condition element trailing commas and case label colons in grouped compound exprs

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/GuardStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/GuardStmtTests.swift
@@ -259,4 +259,49 @@ final class GuardStmtTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
   }
+
+  func testCompoundClauses() {
+    let input =
+      """
+      guard foo &&
+          bar < 1 || bar
+            > 1,
+        let quxxe = 0
+      else {
+        // do something
+      }
+      guard
+        bar < 1 && (
+          baz
+            > 1
+          ),
+        let quxxe = 0
+      else {
+        // blah
+      }
+      """
+
+    let expected =
+      """
+      guard
+        foo && bar < 1
+          || bar
+            > 1,
+        let quxxe = 0
+      else {
+        // do something
+      }
+      guard
+        bar < 1
+          && (baz
+            > 1),
+        let quxxe = 0
+      else {
+        // blah
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/IfStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/IfStmtTests.swift
@@ -446,4 +446,46 @@ final class IfStmtTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
   }
+
+  func testCompoundClauses() {
+    let input =
+      """
+      if foo &&
+          bar < 1 || bar
+            > 1,
+        let quxxe = 0
+      {
+        // do something
+      }
+      if bar < 1 && (
+        baz
+          > 1
+        ),
+      let quxxe = 0
+      {
+        // blah
+      }
+      """
+
+    let expected =
+      """
+      if foo && bar < 1
+        || bar
+          > 1,
+        let quxxe = 0
+      {
+        // do something
+      }
+      if bar < 1
+        && (baz
+          > 1),
+        let quxxe = 0
+      {
+        // blah
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/SwitchStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/SwitchStmtTests.swift
@@ -256,4 +256,36 @@ final class SwitchStmtTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 80)
   }
+
+  func testSwitchSequenceExprCases() {
+    let input =
+      """
+      switch foo {
+      case bar && baz
+        + quxxe:
+        break
+      case baz where bar && (quxxe
+        + 10000):
+        break
+      }
+      """
+
+    let expected =
+      """
+      switch foo {
+      case bar
+        && baz
+          + quxxe:
+        break
+      case baz
+      where bar
+        && (quxxe
+          + 10000):
+        break
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -336,6 +336,7 @@ extension GuardStmtTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__GuardStmtTests = [
+        ("testCompoundClauses", testCompoundClauses),
         ("testContinuationLineBreaking", testContinuationLineBreaking),
         ("testGuardStatement", testGuardStatement),
         ("testGuardWithFuncCall", testGuardWithFuncCall),
@@ -364,6 +365,7 @@ extension IfStmtTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__IfStmtTests = [
+        ("testCompoundClauses", testCompoundClauses),
         ("testConditionExpressionOperatorGrouping", testConditionExpressionOperatorGrouping),
         ("testConditionExpressionOperatorGroupingMixedWithParentheses", testConditionExpressionOperatorGroupingMixedWithParentheses),
         ("testContinuationLineBreakIndentation", testContinuationLineBreakIndentation),
@@ -667,6 +669,7 @@ extension SwitchStmtTests {
         ("testNewlinesDisambiguatingWhereClauses", testNewlinesDisambiguatingWhereClauses),
         ("testSwitchCases", testSwitchCases),
         ("testSwitchCompoundCases", testSwitchCompoundCases),
+        ("testSwitchSequenceExprCases", testSwitchSequenceExprCases),
         ("testSwitchValueBinding", testSwitchValueBinding),
         ("testUnknownDefault", testUnknownDefault),
     ]


### PR DESCRIPTION
The groups around compound exprs were causing `.break(.close,...)` tokens to be inserted before the trailing comma & colon in these situations. This is pretty much the same problem as #139 so I have extended that solution to include other kinds of closing or trailing delimiters.

Fixes SR-12110.