### PR TITLE
Ignore discretionary newlines in a number of new locations.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -510,7 +510,9 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     after(node.inKeyword, tokens: .space)
 
     if let typeAnnotation = node.typeAnnotation {
-      after(typeAnnotation.colon, tokens: .break(.open(kind: .continuation)))
+      after(
+        typeAnnotation.colon,
+        tokens: .break(.open(kind: .continuation), newlines: .elective(ignoresDiscretionary: true)))
       after(typeAnnotation.lastToken, tokens: .break(.close(mustBreak: false), size: 0))
     }
 
@@ -695,7 +697,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   /// - Parameter node: The tuple expression element to be arranged.
   private func arrangeAsTupleExprElement(_ node: TupleExprElementSyntax) {
     before(node.firstToken, tokens: .open)
-    after(node.colon, tokens: .break)
+    after(node.colon, tokens: .break(.continue, newlines: .elective(ignoresDiscretionary: true)))
     after(node.lastToken, tokens: .close)
   }
 
@@ -756,13 +758,13 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: DictionaryTypeSyntax) -> SyntaxVisitorContinueKind {
-    after(node.colon, tokens: .break)
+    after(node.colon, tokens: .break(.continue, newlines: .elective(ignoresDiscretionary: true)))
     return .visitChildren
   }
 
   override func visit(_ node: DictionaryElementSyntax) -> SyntaxVisitorContinueKind {
     before(node.firstToken, tokens: .open)
-    after(node.colon, tokens: .break)
+    after(node.colon, tokens: .break(.continue, newlines: .elective(ignoresDiscretionary: true)))
     after(node.lastToken, tokens: .close)
     return .visitChildren
   }
@@ -855,7 +857,11 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     // If we have an open delimiter following the colon, use a space instead of a continuation
     // break so that we don't awkwardly shift the delimiter down and indent it further if it
     // wraps.
-    let tokenAfterColon: Token = startsWithOpenDelimiter(Syntax(node.expression)) ? .space : .break
+    let tokenAfterColon: Token =
+      startsWithOpenDelimiter(Syntax(node.expression))
+      ? .space
+      : .break(.continue, newlines: .elective(ignoresDiscretionary: true))
+
     after(node.colon, tokens: tokenAfterColon)
 
     if let trailingComma = node.trailingComma {
@@ -1028,8 +1034,10 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   override func visit(_ node: FunctionParameterSyntax) -> SyntaxVisitorContinueKind {
     before(node.firstToken, tokens: .open)
     arrangeAttributeList(node.attributes)
-    after(node.colon, tokens: .break)
-    before(node.secondName, tokens: .break)
+    before(
+      node.secondName,
+      tokens: .break(.continue, newlines: .elective(ignoresDiscretionary: true)))
+    after(node.colon, tokens: .break(.continue, newlines: .elective(ignoresDiscretionary: true)))
 
     if let trailingComma = node.trailingComma {
       after(trailingComma, tokens: .close, .break(.same))
@@ -1240,9 +1248,10 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
   override func visit(_ node: TupleTypeElementSyntax) -> SyntaxVisitorContinueKind {
     before(node.firstToken, tokens: .open)
-    after(node.colon, tokens: .break)
-    after(node.inOut, tokens: .break)
-    before(node.secondName, tokens: .break)
+    before(
+      node.secondName,
+      tokens: .break(.continue, newlines: .elective(ignoresDiscretionary: true)))
+    after(node.colon, tokens: .break(.continue, newlines: .elective(ignoresDiscretionary: true)))
 
     if let trailingComma = node.trailingComma {
       after(trailingComma, tokens: .close, .break(.same))
@@ -1303,7 +1312,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
   override func visit(_ node: AvailabilityLabeledArgumentSyntax) -> SyntaxVisitorContinueKind {
     before(node.label, tokens: .open)
-    after(node.colon, tokens: .break(.continue, size: 1))
+    after(node.colon, tokens: .break(.continue, newlines: .elective(ignoresDiscretionary: true)))
     after(node.value.lastToken, tokens: .close)
     return .visitChildren
   }
@@ -1578,7 +1587,9 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     var closeAfterToken: TokenSyntax? = nil
 
     if let typeAnnotation = node.typeAnnotation {
-      after(typeAnnotation.colon, tokens: .break(.open(kind: .continuation)))
+      after(
+        typeAnnotation.colon,
+        tokens: .break(.open(kind: .continuation), newlines: .elective(ignoresDiscretionary: true)))
       closesNeeded += 1
       closeAfterToken = typeAnnotation.lastToken
     }
@@ -1664,7 +1675,9 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
   override func visit(_ node: AttributedTypeSyntax) -> SyntaxVisitorContinueKind {
     arrangeAttributeList(node.attributes)
-    after(node.specifier, tokens: .break)
+    after(
+      node.specifier,
+      tokens: .break(.continue, newlines: .elective(ignoresDiscretionary: true)))
     return .visitChildren
   }
 
@@ -1751,7 +1764,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
   override func visit(_ node: GenericParameterSyntax) -> SyntaxVisitorContinueKind {
     before(node.firstToken, tokens: .open)
-    after(node.colon, tokens: .break)
+    after(node.colon, tokens: .break(.continue, newlines: .elective(ignoresDiscretionary: true)))
     if let trailingComma = node.trailingComma {
       after(trailingComma, tokens: .close, .break(.same))
     } else {
@@ -1958,7 +1971,9 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     after(node.letOrVarKeyword, tokens: .break)
 
     if let typeAnnotation = node.typeAnnotation {
-      after(typeAnnotation.colon, tokens: .break(.open(kind: .continuation)))
+      after(
+        typeAnnotation.colon,
+        tokens: .break(.open(kind: .continuation), newlines: .elective(ignoresDiscretionary: true)))
       after(typeAnnotation.lastToken, tokens: .break(.close(mustBreak: false), size: 0))
     }
 

--- a/Tests/SwiftFormatPrettyPrintTests/AttributeTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/AttributeTests.swift
@@ -290,4 +290,28 @@ final class AttributeTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 80)
   }
+
+  func testIgnoresDiscretionaryLineBreakAfterColon() {
+    let input =
+      """
+      @available(
+        *, unavailable,
+        renamed:
+          "MyRenamedFunction"
+      )
+      func f() {}
+      """
+
+    let expected =
+      """
+      @available(
+        *, unavailable,
+        renamed: "MyRenamedFunction"
+      )
+      func f() {}
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 30)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/DictionaryDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/DictionaryDeclTests.swift
@@ -94,4 +94,43 @@ final class DictionaryDeclTests: PrettyPrintTestCase {
     XCTAssertDiagnosed(.removeTrailingComma, line: 1, column: 32)
     XCTAssertDiagnosed(.addTrailingComma, line: 4, column: 17)
   }
+
+  func testIgnoresDiscretionaryNewlineAfterColon() {
+    let input =
+      """
+      let a = [
+        "reallyLongKeySoTheValueWillWrap":
+          value
+      ]
+      let a = [
+        "shortKey":
+          value
+      ]
+      let a:
+        [ReallyLongKeySoTheValueWillWrap:
+          Value]
+      let a:
+        [ShortKey:
+          Value]
+      """
+
+    let expected =
+      """
+      let a = [
+        "reallyLongKeySoTheValueWillWrap":
+          value
+      ]
+      let a = [
+        "shortKey": value
+      ]
+      let a:
+        [ReallyLongKeySoTheValueWillWrap:
+          Value]
+      let a:
+        [ShortKey: Value]
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/ForInStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ForInStmtTests.swift
@@ -306,4 +306,27 @@ final class ForInStmtTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
   }
+
+  func testTypeAnnotationIgnoresDiscretionaryNewlineAfterColon() {
+    let input =
+      """
+      for i:
+        ExplicitType in mycontainer
+      {
+        let a = 123
+        let b = i
+      }
+      """
+
+    let expected =
+      """
+      for i: ExplicitType in mycontainer {
+        let a = 123
+        let b = i
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 80)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
@@ -225,4 +225,28 @@ final class FunctionCallTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 60)
   }
+
+  func testIgnoresDiscretionaryLineBreakAfterColon() {
+    let input =
+      """
+      myFunc(
+        a:
+          foo,
+        b:
+          bar + baz + quux
+      )
+      """
+
+    let expected =
+      """
+      myFunc(
+        a: foo,
+        b: bar + baz
+          + quux
+      )
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
@@ -1038,4 +1038,51 @@ final class FunctionDeclTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 14)
   }
+
+  func testIgnoresDiscretionaryLineBreakAfterColonAndInout() {
+    let input =
+      """
+      func foo(
+        a:
+          ReallyLongTypeName,
+        b:
+          ShortType,
+        c:
+          inout
+            C,
+        labeled
+          d:
+            D,
+        reallyLongLabel
+          reallyLongArg: E
+      ) {}
+      func foo<
+        A:
+          ReallyLongType,
+        B:
+          ShortType
+      >(a: A, b: B) {}
+
+      """
+
+    let expected =
+      """
+      func foo(
+        a:
+          ReallyLongTypeName,
+        b: ShortType,
+        c: inout C,
+        labeled d: D,
+        reallyLongLabel
+          reallyLongArg: E
+      ) {}
+      func foo<
+        A: ReallyLongType,
+        B: ShortType
+      >(a: A, b: B) {}
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 23)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/PatternBindingTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/PatternBindingTests.swift
@@ -23,4 +23,24 @@ final class PatternBindingTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
   }
+
+  func testIgnoresDiscretionaryNewlineAfterColon() {
+    let input =
+      """
+      let someObject:
+        Foo = object
+      let someObject:
+        Foo = longerObjectName
+      """
+
+    let expected =
+      """
+      let someObject: Foo = object
+      let someObject: Foo =
+        longerObjectName
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 28)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/TupleDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/TupleDeclTests.swift
@@ -45,4 +45,37 @@ final class TupleDeclTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 30)
   }
+
+  func testIgnoresDiscretionaryNewlineAfterColon() {
+    let input =
+      """
+      let a = (
+        reallyLongKeySoTheValueWillWrap:
+          value,
+        b: c
+      )
+      let a = (
+        shortKey:
+          value,
+        b:
+          c
+      )
+      """
+
+    let expected =
+      """
+      let a = (
+        reallyLongKeySoTheValueWillWrap:
+          value,
+        b: c
+      )
+      let a = (
+        shortKey: value,
+        b: c
+      )
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 25)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -63,6 +63,7 @@ extension AttributeTests {
         ("testAttributeFormattingRespectsDiscretionaryLineBreaks", testAttributeFormattingRespectsDiscretionaryLineBreaks),
         ("testAttributeInterArgumentBinPackedLineBreaking", testAttributeInterArgumentBinPackedLineBreaking),
         ("testAttributeParamSpacing", testAttributeParamSpacing),
+        ("testIgnoresDiscretionaryLineBreakAfterColon", testIgnoresDiscretionaryLineBreakAfterColon),
         ("testObjCAttributesDiscretionaryLineBreaking", testObjCAttributesDiscretionaryLineBreaking),
         ("testObjCAttributesPerLineBreaking", testObjCAttributesPerLineBreaking),
         ("testObjCBinPackedAttributes", testObjCBinPackedAttributes),
@@ -180,6 +181,7 @@ extension DictionaryDeclTests {
     // to regenerate.
     static let __allTests__DictionaryDeclTests = [
         ("testBasicDictionaries", testBasicDictionaries),
+        ("testIgnoresDiscretionaryNewlineAfterColon", testIgnoresDiscretionaryNewlineAfterColon),
         ("testNoTrailingCommasInTypes", testNoTrailingCommasInTypes),
         ("testTrailingCommaDiagnostics", testTrailingCommaDiagnostics),
         ("testWhitespaceOnlyDoesNotChangeTrailingComma", testWhitespaceOnlyDoesNotChangeTrailingComma),
@@ -254,6 +256,7 @@ extension ForInStmtTests {
         ("testForStatementWithNestedExpressions", testForStatementWithNestedExpressions),
         ("testForWhereLoop", testForWhereLoop),
         ("testForWithRanges", testForWithRanges),
+        ("testTypeAnnotationIgnoresDiscretionaryNewlineAfterColon", testTypeAnnotationIgnoresDiscretionaryNewlineAfterColon),
     ]
 }
 
@@ -267,6 +270,7 @@ extension FunctionCallTests {
         ("testBasicFunctionCalls_packArguments", testBasicFunctionCalls_packArguments),
         ("testDiscretionaryLineBreakBeforeClosingParenthesis", testDiscretionaryLineBreakBeforeClosingParenthesis),
         ("testDiscretionaryLineBreaksAreSelfCorrecting", testDiscretionaryLineBreaksAreSelfCorrecting),
+        ("testIgnoresDiscretionaryLineBreakAfterColon", testIgnoresDiscretionaryLineBreakAfterColon),
         ("testNestedFunctionCallExprSequences", testNestedFunctionCallExprSequences),
         ("testSingleUnlabeledArgumentWithDelimiters", testSingleUnlabeledArgumentWithDelimiters),
     ]
@@ -301,6 +305,7 @@ extension FunctionDeclTests {
         ("testFunctionWhereClause", testFunctionWhereClause),
         ("testFunctionWhereClause_lineBreakBeforeEachGenericRequirement", testFunctionWhereClause_lineBreakBeforeEachGenericRequirement),
         ("testFunctionWithDefer", testFunctionWithDefer),
+        ("testIgnoresDiscretionaryLineBreakAfterColonAndInout", testIgnoresDiscretionaryLineBreakAfterColonAndInout),
         ("testOperatorOverloads", testOperatorOverloads),
         ("testRemovesLineBreakBeforeOpenBraceUnlessAbsolutelyNecessary", testRemovesLineBreakBeforeOpenBraceUnlessAbsolutelyNecessary),
     ]
@@ -503,6 +508,7 @@ extension PatternBindingTests {
     // to regenerate.
     static let __allTests__PatternBindingTests = [
         ("testBindingIncludingTypeAnnotation", testBindingIncludingTypeAnnotation),
+        ("testIgnoresDiscretionaryNewlineAfterColon", testIgnoresDiscretionaryNewlineAfterColon),
     ]
 }
 
@@ -709,6 +715,7 @@ extension TupleDeclTests {
     // to regenerate.
     static let __allTests__TupleDeclTests = [
         ("testBasicTuples", testBasicTuples),
+        ("testIgnoresDiscretionaryNewlineAfterColon", testIgnoresDiscretionaryNewlineAfterColon),
         ("testLabeledTuples", testLabeledTuples),
     ]
 }


### PR DESCRIPTION
- After the colon in...
  - ...a type annotation (`x: Int`)
  - ...a tuple type (`(a: A, b: B) -> Void`)
  - ...a tuple expression element (`(x: 10, y: 20)`)
  - ...a dictionary type (`[Key: Value]`)
  - ...a dictionary element (`["key": "value"]`)
  - ...a function call argument (`foo(x: 10, y: 20)`)
  - ...a function declaration parameter (`func foo(x: Int)`)
  - ...a generic parameter (`struct A<T: P> {}`)
  - ...an availability attribute (`@attribute(renamed: "foo")`)
- Between the first and second name of a parameter in a function
  declaration (`func foo(firstName secondName: Type)`)
- After the specifier in an attributed type (`inout Foo`)

We still allow wrapping in all of these locations, but only if the
formatter determines that it is necessary to make the contents fit.