### PR TITLE
OrderedImports improvements for non-newline separated code and ignored nodes.

### DIFF
--- a/Tests/SwiftFormatRulesTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatRulesTests/XCTestManifests.swift
@@ -269,6 +269,8 @@ extension OrderedImportsTests {
         ("testImportsOrderWithDocComment", testImportsOrderWithDocComment),
         ("testImportsOrderWithoutModuleType", testImportsOrderWithoutModuleType),
         ("testInvalidImportsOrder", testInvalidImportsOrder),
+        ("testMultipleCodeBlocksPerLine", testMultipleCodeBlocksPerLine),
+        ("testMultipleCodeBlocksWithImportsPerLine", testMultipleCodeBlocksWithImportsPerLine),
         ("testNonHeaderComment", testNonHeaderComment),
         ("testSeparatedFileHeader", testSeparatedFileHeader),
         ("testValidOrderedImport", testValidOrderedImport),


### PR DESCRIPTION
The rule had 2 issues addressed in this change:
1. Non-newline separated code blocks were destructively rewritten such that only the last code block was kept.
2. Ignored nodes containing import decls were always moved to be the last "group" of imports, between the other imports and the code blocks.

Fixing these issues required an overhaul of the `Line` data model used by OrderedImports, so I tackled both at the same time. Now you can have multiple code blocks separated by semicolons instead of newlines and OrderedImports handles it safely. For ignored nodes with import decls, these are "grouped" such that all imports before the ignored node are sorted and grouped as usual and then all imports after the ignored node grouped and sorted as usual. This results in always keeping the ignored node in the same place relatively to all other code blocks (& imports) in the file while still fixing up the other imports.

Note that I left my `debugDescription` implementation for `Line`, because I found it very helpful while working on this change and I think it could be helpful to anyone working on this rule in the future.