### PR TITLE
Use a location specific diagnostic message when the input is invalid.

### DIFF
--- a/Sources/SwiftFormat/SwiftFormatError.swift
+++ b/Sources/SwiftFormat/SwiftFormatError.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftSyntax
+
 /// Errors that can be thrown by the `SwiftFormatter` and `SwiftLinter` APIs.
 public enum SwiftFormatError: Error {
 
@@ -20,5 +22,5 @@ public enum SwiftFormatError: Error {
   case isDirectory
 
   /// The file contains invalid or unrecognized Swift syntax and cannot be handled safely.
-  case fileContainsInvalidSyntax
+  case fileContainsInvalidSyntax(position: AbsolutePosition)
 }

--- a/Sources/SwiftFormat/SwiftFormatter.swift
+++ b/Sources/SwiftFormat/SwiftFormatter.swift
@@ -91,8 +91,8 @@ public final class SwiftFormatter {
   public func format<Output: TextOutputStream>(
     syntax: SourceFileSyntax, assumingFileURL url: URL?, to outputStream: inout Output
   ) throws {
-    guard isSyntaxValidForProcessing(Syntax(syntax)) else {
-      throw SwiftFormatError.fileContainsInvalidSyntax
+    if let position = firstInvalidSyntaxPosition(in: Syntax(syntax)) {
+      throw SwiftFormatError.fileContainsInvalidSyntax(position: position)
     }
 
     let assumedURL = url ?? URL(fileURLWithPath: "source")

--- a/Sources/SwiftFormat/SwiftLinter.swift
+++ b/Sources/SwiftFormat/SwiftLinter.swift
@@ -75,8 +75,8 @@ public final class SwiftLinter {
   ///   - url: A file URL denoting the filename/path that should be assumed for this syntax tree.
   /// - Throws: If an unrecoverable error occurs when formatting the code.
   public func lint(syntax: SourceFileSyntax, assumingFileURL url: URL) throws {
-    guard isSyntaxValidForProcessing(Syntax(syntax)) else {
-      throw SwiftFormatError.fileContainsInvalidSyntax
+    if let position = firstInvalidSyntaxPosition(in: Syntax(syntax)) {
+      throw SwiftFormatError.fileContainsInvalidSyntax(position: position)
     }
     
     let context = Context(

--- a/Sources/swift-format/Run.swift
+++ b/Sources/swift-format/Run.swift
@@ -48,13 +48,14 @@ func lintMain(
     diagnosticEngine.diagnose(
       Diagnostic.Message(.error, "Unable to lint \(path): file is not readable or does not exist."))
     return 1
-  } catch SwiftFormatError.fileContainsInvalidSyntax {
-     let path = assumingFileURL.path
-     diagnosticEngine.diagnose(
-       Diagnostic.Message(
-         .error, "Unable to line \(path): file contains invalid or unrecognized Swift syntax."))
-     return 1
-   } catch {
+  } catch SwiftFormatError.fileContainsInvalidSyntax(let position) {
+    let path = assumingFileURL.path
+    let location = SourceLocationConverter(file: path, source: source).location(for: position)
+    diagnosticEngine.diagnose(
+      Diagnostic.Message(.error, "file contains invalid or unrecognized Swift syntax."),
+      location: location)
+    return 1
+  } catch {
     let path = assumingFileURL.path
     diagnosticEngine.diagnose(Diagnostic.Message(.error, "Unable to lint \(path): \(error)"))
     exit(1)
@@ -107,11 +108,12 @@ func formatMain(
       Diagnostic.Message(
         .error, "Unable to format \(path): file is not readable or does not exist."))
     return 1
-  } catch SwiftFormatError.fileContainsInvalidSyntax {
+  } catch SwiftFormatError.fileContainsInvalidSyntax(let position) {
     let path = assumingFileURL.path
+    let location = SourceLocationConverter(file: path, source: source).location(for: position)
     diagnosticEngine.diagnose(
-      Diagnostic.Message(
-        .error, "Unable to format \(path): file contains invalid or unrecognized Swift syntax."))
+      Diagnostic.Message(.error, "file contains invalid or unrecognized Swift syntax."),
+      location: location)
     return 1
   } catch {
     let path = assumingFileURL.path


### PR DESCRIPTION
Previously, the diagnostic didn't include a location (i.e. filename, line number, and column number) so the diagnostic message included just the filename. Now the diagnostic is added at a location so that it's more consistent with other diagnostics and includes additional useful information in the same format as other diagnostics.

The diagnostic for an invalid file now looks like:
/path/to/file.swift:line:column: error: file contains invalid or unrecognized Swift syntax.