### PR TITLE
Don't apply `FileprivateAtFileScope` rule to extensions.

### DIFF
--- a/Sources/SwiftFormatRules/FileprivateAtFileScope.swift
+++ b/Sources/SwiftFormatRules/FileprivateAtFileScope.swift
@@ -92,13 +92,6 @@ public final class FileprivateAtFileScope: SyntaxFormatRule {
             modifiers: typealiasDecl.modifiers,
             factory: typealiasDecl.withModifiers)))
 
-      case .extensionDecl(let extensionDecl):
-        return codeBlockItem.withItem(
-          Syntax(rewrittenDecl(
-            extensionDecl,
-            modifiers: extensionDecl.modifiers,
-            factory: extensionDecl.withModifiers)))
-
       default:
         return codeBlockItem
       }

--- a/Tests/SwiftFormatRulesTests/FileprivateAtFileScopeTests.swift
+++ b/Tests/SwiftFormatRulesTests/FileprivateAtFileScopeTests.swift
@@ -10,7 +10,6 @@ final class FileprivateAtFileScopeTests: LintOrFormatRuleTestCase {
         private enum Foo {}
         private protocol Foo {}
         private typealias Foo = Bar
-        private extension Foo {}
         private func foo() {}
         private var foo: Bar
         """,
@@ -20,7 +19,6 @@ final class FileprivateAtFileScopeTests: LintOrFormatRuleTestCase {
         fileprivate enum Foo {}
         fileprivate protocol Foo {}
         fileprivate typealias Foo = Bar
-        fileprivate extension Foo {}
         fileprivate func foo() {}
         fileprivate var foo: Bar
         """)
@@ -31,7 +29,18 @@ final class FileprivateAtFileScopeTests: LintOrFormatRuleTestCase {
     XCTAssertDiagnosed(.replacePrivateWithFileprivate)
     XCTAssertDiagnosed(.replacePrivateWithFileprivate)
     XCTAssertDiagnosed(.replacePrivateWithFileprivate)
-    XCTAssertDiagnosed(.replacePrivateWithFileprivate)
+  }
+
+  func testFileScopeExtensionsAreNotChanged() {
+    XCTAssertFormatting(
+      FileprivateAtFileScope.self,
+      input: """
+        private extension Foo {}
+        """,
+      expected: """
+        private extension Foo {}
+        """)
+    XCTAssertNotDiagnosed(.replacePrivateWithFileprivate)
   }
 
   func testNonFileScopeDeclsAreNotChanged() {
@@ -70,7 +79,6 @@ final class FileprivateAtFileScopeTests: LintOrFormatRuleTestCase {
           private enum Foo {}
           private protocol Foo {}
           private typealias Foo = Bar
-          private extension Foo {}
           private func foo() {}
           private var foo: Bar
         #elseif BAR
@@ -79,7 +87,6 @@ final class FileprivateAtFileScopeTests: LintOrFormatRuleTestCase {
           private enum Foo {}
           private protocol Foo {}
           private typealias Foo = Bar
-          private extension Foo {}
           private func foo() {}
           private var foo: Bar
         #else
@@ -88,7 +95,6 @@ final class FileprivateAtFileScopeTests: LintOrFormatRuleTestCase {
           private enum Foo {}
           private protocol Foo {}
           private typealias Foo = Bar
-          private extension Foo {}
           private func foo() {}
           private var foo: Bar
         #endif
@@ -100,7 +106,6 @@ final class FileprivateAtFileScopeTests: LintOrFormatRuleTestCase {
           fileprivate enum Foo {}
           fileprivate protocol Foo {}
           fileprivate typealias Foo = Bar
-          fileprivate extension Foo {}
           fileprivate func foo() {}
           fileprivate var foo: Bar
         #elseif BAR
@@ -109,7 +114,6 @@ final class FileprivateAtFileScopeTests: LintOrFormatRuleTestCase {
           fileprivate enum Foo {}
           fileprivate protocol Foo {}
           fileprivate typealias Foo = Bar
-          fileprivate extension Foo {}
           fileprivate func foo() {}
           fileprivate var foo: Bar
         #else
@@ -118,7 +122,6 @@ final class FileprivateAtFileScopeTests: LintOrFormatRuleTestCase {
           fileprivate enum Foo {}
           fileprivate protocol Foo {}
           fileprivate typealias Foo = Bar
-          fileprivate extension Foo {}
           fileprivate func foo() {}
           fileprivate var foo: Bar
         #endif
@@ -136,7 +139,6 @@ final class FileprivateAtFileScopeTests: LintOrFormatRuleTestCase {
             private enum Foo {}
             private protocol Foo {}
             private typealias Foo = Bar
-            private extension Foo {}
             private func foo() {}
             private var foo: Bar
           #endif
@@ -150,7 +152,6 @@ final class FileprivateAtFileScopeTests: LintOrFormatRuleTestCase {
             fileprivate enum Foo {}
             fileprivate protocol Foo {}
             fileprivate typealias Foo = Bar
-            fileprivate extension Foo {}
             fileprivate func foo() {}
             fileprivate var foo: Bar
           #endif

--- a/Tests/SwiftFormatRulesTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatRulesTests/XCTestManifests.swift
@@ -70,6 +70,7 @@ extension FileprivateAtFileScopeTests {
         ("testFileScopeDecls", testFileScopeDecls),
         ("testFileScopeDeclsInsideConditionals", testFileScopeDeclsInsideConditionals),
         ("testFileScopeDeclsInsideNestedConditionals", testFileScopeDeclsInsideNestedConditionals),
+        ("testFileScopeExtensionsAreNotChanged", testFileScopeExtensionsAreNotChanged),
         ("testLeadingTriviaIsPreserved", testLeadingTriviaIsPreserved),
         ("testModifierDetailIsPreserved", testModifierDetailIsPreserved),
         ("testNonFileScopeDeclsAreNotChanged", testNonFileScopeDeclsAreNotChanged),


### PR DESCRIPTION
This is a subtlety of SE-0169. For most decls, `private` at file
scope is equivalent to `fileprivate`. But for extensions, since that
visibility is distributed throughout the extension's members,
changing `private` to `fileprivate` would increase the visibility of
those members. When `private`, those members would only be visible
within the same extension scope and within other extensions to the
same type and to the main type decl itself *that occur within the
same file.* If they were made `fileprivate`, then this would make
them visible to *all* declarations within the same file.