### PR TITLE
Add a group around member types used in return clauses.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1049,6 +1049,13 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
   override func visit(_ node: ReturnClauseSyntax) -> SyntaxVisitorContinueKind {
     after(node.arrow, tokens: .space)
+
+    // Member type identifier is used when the return type is a member of another type. Add a group
+    // here so that the base, dot, and member type are kept together when they fit.
+    if node.returnType.is(MemberTypeIdentifierSyntax.self) {
+      before(node.returnType.firstToken, tokens: .open)
+      after(node.returnType.lastToken, tokens: .close)
+    }
     return .visitChildren
   }
 

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
@@ -90,7 +90,6 @@ final class FunctionDeclTests: PrettyPrintTestCase {
   }
 
   func testFunctionDeclReturns() {
-    // TODO: The tuple return case needs a lot of work.
     let input =
       """
       func myFun(var1: Int, var2: Double) -> Double {
@@ -103,6 +102,12 @@ final class FunctionDeclTests: PrettyPrintTestCase {
       }
       func tupleFunc() throws -> (one: Int, two: Double, three: Bool, four: String) {
         return (one: 1, two: 2.0, three: true, four: "four")
+      }
+      func memberTypeThrowingFunc() throws -> SomeBaseType<GenericArg1, GenericArg2, GenericArg3>.SomeInnerType {
+      }
+      func memberTypeReallyLongNameFunc() -> Type.InnerMember {
+      }
+      func tupleMembersFunc() -> (Type.Inner, Type2.Inner2) {
       }
       """
 
@@ -124,6 +129,20 @@ final class FunctionDeclTests: PrettyPrintTestCase {
         return (
           one: 1, two: 2.0, three: true, four: "four"
         )
+      }
+      func memberTypeThrowingFunc() throws
+        -> SomeBaseType<
+          GenericArg1, GenericArg2, GenericArg3
+        >.SomeInnerType
+      {
+      }
+      func memberTypeReallyLongNameFunc()
+        -> Type.InnerMember
+      {
+      }
+      func tupleMembersFunc() -> (
+        Type.Inner, Type2.Inner2
+      ) {
       }
 
       """


### PR DESCRIPTION
Without the group, the pretty printer would add a newline at the first break in the return clause where the column limit would overflow. This could fall inside of a member type identifier, before the dot. That results in odd formatting where a func decl has its return clause partially on the first line and partially on the second line (which is only allowed for tuples because of the opening paren special case).

With the group, the func decl breaks before the -> when the type would overflow the line.