### PR TITLE
Delete duplicate imports.

### DIFF
--- a/Tests/SwiftFormatRulesTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatRulesTests/XCTestManifests.swift
@@ -266,6 +266,9 @@ extension OrderedImportsTests {
     static let __allTests__OrderedImportsTests = [
         ("testDisableOrderedImports", testDisableOrderedImports),
         ("testDisableOrderedImportsMovingComments", testDisableOrderedImportsMovingComments),
+        ("testDuplicateAttributedImports", testDuplicateAttributedImports),
+        ("testDuplicateCommentedImports", testDuplicateCommentedImports),
+        ("testDuplicateIgnoredImports", testDuplicateIgnoredImports),
         ("testEmptyFile", testEmptyFile),
         ("testImportsOrderWithDocComment", testImportsOrderWithDocComment),
         ("testImportsOrderWithoutModuleType", testImportsOrderWithoutModuleType),
@@ -273,6 +276,7 @@ extension OrderedImportsTests {
         ("testMultipleCodeBlocksPerLine", testMultipleCodeBlocksPerLine),
         ("testMultipleCodeBlocksWithImportsPerLine", testMultipleCodeBlocksWithImportsPerLine),
         ("testNonHeaderComment", testNonHeaderComment),
+        ("testRemovesDuplicateImports", testRemovesDuplicateImports),
         ("testSeparatedFileHeader", testSeparatedFileHeader),
         ("testValidOrderedImport", testValidOrderedImport),
     ]


### PR DESCRIPTION
The criteria for deletion is:
- Has an identical path, excluding whitespace, as an existing import
- No more than 1 of the matching imports have a trailing comment

The trailing comment rule is necessary because it's impossible to safely combine multiple trailing comments such that they all stay grouped to the relevant import. Leading comments are safe to combine, because OrderedImports keeps multiple lines of leading comments grouped to the next import. Rather than trying to keep the trailing comments on 1 line together or promote 1 trailing comment to a leading comment, it's safer to raise the diagnostic and keep both imports.