### PR TITLE
Support an ignore directive to ignore an entire file.

### DIFF
--- a/Documentation/IgnoringSource.md
+++ b/Documentation/IgnoringSource.md
@@ -6,6 +6,22 @@ technical limitations of the formatter's implementation. When an ignore comment
 is present, the next ["node"](#understanding-nodes) in the source's AST
 representation is ignored by the formatter.
 
+## Ignore A File
+
+In the event that an entire file cannot be formatted, add a comment that contains 
+`swift-format-ignore-file` at the top of the file and the formatter will leave 
+the file completely unchanged.
+
+```swift
+// swift-format-ignore-file
+import Zoo
+import Arrays
+
+struct Foo {
+  func foo() { bar();baz(); }
+}
+```
+
 ## Ignoring Formatting (aka indentation, line breaks, line length, etc.)
 
 The formatter applies line length to add line breaks and indentation throughout

--- a/Tests/SwiftFormatCoreTests/RuleMaskTests.swift
+++ b/Tests/SwiftFormatCoreTests/RuleMaskTests.swift
@@ -171,4 +171,62 @@ final class RuleMaskTests: XCTestCase {
     XCTAssertEqual(mask.ruleState("TotallyMadeUpRule", at: location(ofLine: 3)), .default)
     XCTAssertEqual(mask.ruleState("rule1", at: location(ofLine: 4)), .default)
   }
+
+  func testAllRulesWholeFileIgnore() {
+    let text =
+      """
+      // This file has important contents.
+      // swift-format-ignore-file
+      // Everything in this file is ignored.
+
+      let a = 5
+      let b = 4
+
+      class Foo {
+        let member1 = 0
+        func foo() {
+          baz()
+        }
+      }
+
+      struct Baz {
+      }
+      """
+
+    let mask = createMask(sourceText: text)
+
+    let lineCount = text.split(separator: "\n").count
+    for i in 0..<lineCount {
+      XCTAssertEqual(mask.ruleState("rule1", at: location(ofLine: i)), .disabled)
+    }
+  }
+
+  func testAllRulesWholeFileIgnoreNestedInNode() {
+    let text =
+      """
+      // This file has important contents.
+      // Everything in this file is ignored.
+
+      let a = 5
+      let b = 4
+
+      class Foo {
+        // swift-format-ignore-file
+        let member1 = 0
+        func foo() {
+          baz()
+        }
+      }
+
+      struct Baz {
+      }
+      """
+
+    let mask = createMask(sourceText: text)
+
+    let lineCount = text.split(separator: "\n").count
+    for i in 0..<lineCount {
+      XCTAssertEqual(mask.ruleState("rule1", at: location(ofLine: i)), .default)
+    }
+  }
 }

--- a/Tests/SwiftFormatCoreTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatCoreTests/XCTestManifests.swift
@@ -6,6 +6,8 @@ extension RuleMaskTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__RuleMaskTests = [
+        ("testAllRulesWholeFileIgnore", testAllRulesWholeFileIgnore),
+        ("testAllRulesWholeFileIgnoreNestedInNode", testAllRulesWholeFileIgnoreNestedInNode),
         ("testDirectiveWithRulesList", testDirectiveWithRulesList),
         ("testDuplicateNested", testDuplicateNested),
         ("testIgnoreTwoRules", testIgnoreTwoRules),

--- a/Tests/SwiftFormatPrettyPrintTests/IgnoreNodeTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/IgnoreNodeTests.swift
@@ -289,4 +289,126 @@ final class IgnoreNodeTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
   }
+
+  func testIgnoreWholeFile() {
+    let input =
+      """
+      // swift-format-ignore-file
+      import Zoo
+      import Aoo
+      import foo
+
+          struct Foo {
+            private var baz: Bool {
+                return foo +
+                 bar + // poorly placed comment
+                  false
+            }
+
+            var a = true    // line comment
+                            // aligned line comment
+            var b = false  // correct trailing comment
+
+      var c = 0 +
+          1
+          + (2 + 3)
+      }
+
+            class Bar
+      {
+        var bazzle = 0 }
+      """
+
+    let expected =
+      """
+      // swift-format-ignore-file
+      import Zoo
+      import Aoo
+      import foo
+
+          struct Foo {
+            private var baz: Bool {
+                return foo +
+                 bar + // poorly placed comment
+                  false
+            }
+
+            var a = true    // line comment
+                            // aligned line comment
+            var b = false  // correct trailing comment
+
+      var c = 0 +
+          1
+          + (2 + 3)
+      }
+
+            class Bar
+      {
+        var bazzle = 0 }
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+  }
+
+  func testIgnoreWholeFileInNestedNode() {
+    let input =
+      """
+      import Zoo
+      import Aoo
+      import foo
+
+      // swift-format-ignore-file
+          struct Foo {
+            private var baz: Bool {
+                return foo +
+                 bar + // poorly placed comment
+                  false
+            }
+
+            var a = true    // line comment
+                            // aligned line comment
+            var b = false  // correct trailing comment
+
+      var c = 0 +
+          1
+          + (2 + 3)
+      }
+
+            class Bar
+      {
+      // swift-format-ignore-file
+        var bazzle = 0 }
+      """
+
+    let expected =
+      """
+      import Zoo
+      import Aoo
+      import foo
+
+      // swift-format-ignore-file
+      struct Foo {
+        private var baz: Bool {
+          return foo + bar  // poorly placed comment
+            + false
+        }
+
+        var a = true  // line comment
+        // aligned line comment
+        var b = false  // correct trailing comment
+
+        var c =
+          0 + 1
+          + (2 + 3)
+      }
+
+      class Bar {
+        // swift-format-ignore-file
+        var bazzle = 0
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -396,6 +396,8 @@ extension IgnoreNodeTests {
         ("testIgnoreInvalidAfterFirstToken", testIgnoreInvalidAfterFirstToken),
         ("testIgnoreMemberDeclListItems", testIgnoreMemberDeclListItems),
         ("testIgnoresNestedMembers", testIgnoresNestedMembers),
+        ("testIgnoreWholeFile", testIgnoreWholeFile),
+        ("testIgnoreWholeFileInNestedNode", testIgnoreWholeFileInNestedNode),
         ("testInvalidComment", testInvalidComment),
         ("testValidComment", testValidComment),
     ]


### PR DESCRIPTION
This is intentionally a different ignore directive (`swift-format-ignore-file` instead of `swift-format-ignore`) so that there won't be any confusion if someone wants to ignore formatting on the first node in a file (e.g. ignore the first import) but wants to format the rest of the file. If ignore file used the same comment as ignore a node, users would need to artificially structure their code in a way that avoids putting an ignore on the first node in the file when they want part of the file to be formatted.