### PR TITLE
Don't propagate the diagnostic engine when formatting.

### DIFF
--- a/Sources/swift-format/Run.swift
+++ b/Sources/swift-format/Run.swift
@@ -77,7 +77,10 @@ func formatMain(
   configuration: Configuration, sourceFile: FileHandle, assumingFilename: String?, inPlace: Bool,
   debugOptions: DebugOptions, diagnosticEngine: DiagnosticEngine
 ) -> Int {
-  let formatter = SwiftFormatter(configuration: configuration, diagnosticEngine: diagnosticEngine)
+  // Even though `diagnosticEngine` is defined, it's use is reserved for fatal messages. Pass nil
+  // to the formatter to suppress other messages since they will be fixed or can't be automatically
+  // fixed anyway.
+  let formatter = SwiftFormatter(configuration: configuration, diagnosticEngine: nil)
   formatter.debugOptions = debugOptions
   let assumingFileURL = URL(fileURLWithPath: assumingFilename ?? "<stdin>")
 


### PR DESCRIPTION
This supresses printing diagnostic messages when using the format mode. When formatting, the issues in the source are either going to be fixed or they can't be fixed automatically. In either case, the formatter should be quiet about it.

Linting continues to use the `DiagnosticEngine` so that lint findings are displayed as before.