### PR TITLE
Update build instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ build `swift-format` using the following commands:
 
 ```
 git clone -b swift-5.1-branch https://github.com/apple/swift-format.git
+cd swift-format
 swift build
 ```
 


### PR DESCRIPTION
Fix build instructions. (You need to cd to the cloned directory before trying to build it.)