### PR TITLE
Restore some discretionary newlines from PR #143

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -697,7 +697,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   /// - Parameter node: The tuple expression element to be arranged.
   private func arrangeAsTupleExprElement(_ node: TupleExprElementSyntax) {
     before(node.firstToken, tokens: .open)
-    after(node.colon, tokens: .break(.continue, newlines: .elective(ignoresDiscretionary: true)))
+    after(node.colon, tokens: .break)
     after(node.lastToken, tokens: .close)
     if let trailingComma = node.trailingComma {
       closingDelimiterTokens.insert(trailingComma)
@@ -764,13 +764,13 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: DictionaryTypeSyntax) -> SyntaxVisitorContinueKind {
-    after(node.colon, tokens: .break(.continue, newlines: .elective(ignoresDiscretionary: true)))
+    after(node.colon, tokens: .break)
     return .visitChildren
   }
 
   override func visit(_ node: DictionaryElementSyntax) -> SyntaxVisitorContinueKind {
     before(node.firstToken, tokens: .open)
-    after(node.colon, tokens: .break(.continue, newlines: .elective(ignoresDiscretionary: true)))
+    after(node.colon, tokens: .break)
     after(node.lastToken, tokens: .close)
     if let trailingComma = node.trailingComma {
       closingDelimiterTokens.insert(trailingComma)
@@ -869,10 +869,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     // If we have an open delimiter following the colon, use a space instead of a continuation
     // break so that we don't awkwardly shift the delimiter down and indent it further if it
     // wraps.
-    let tokenAfterColon: Token =
-      startsWithOpenDelimiter(Syntax(node.expression))
-      ? .space
-      : .break(.continue, newlines: .elective(ignoresDiscretionary: true))
+    let tokenAfterColon: Token = startsWithOpenDelimiter(Syntax(node.expression)) ? .space : .break
 
     after(node.colon, tokens: tokenAfterColon)
 
@@ -1049,7 +1046,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     before(
       node.secondName,
       tokens: .break(.continue, newlines: .elective(ignoresDiscretionary: true)))
-    after(node.colon, tokens: .break(.continue, newlines: .elective(ignoresDiscretionary: true)))
+    after(node.colon, tokens: .break)
 
     if let trailingComma = node.trailingComma {
       after(trailingComma, tokens: .close, .break(.same))
@@ -1274,7 +1271,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     before(
       node.secondName,
       tokens: .break(.continue, newlines: .elective(ignoresDiscretionary: true)))
-    after(node.colon, tokens: .break(.continue, newlines: .elective(ignoresDiscretionary: true)))
+    after(node.colon, tokens: .break)
 
     if let trailingComma = node.trailingComma {
       after(trailingComma, tokens: .close, .break(.same))
@@ -1788,7 +1785,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
   override func visit(_ node: GenericParameterSyntax) -> SyntaxVisitorContinueKind {
     before(node.firstToken, tokens: .open)
-    after(node.colon, tokens: .break(.continue, newlines: .elective(ignoresDiscretionary: true)))
+    after(node.colon, tokens: .break)
     if let trailingComma = node.trailingComma {
       after(trailingComma, tokens: .close, .break(.same))
     } else {

--- a/Tests/SwiftFormatPrettyPrintTests/DictionaryDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/DictionaryDeclTests.swift
@@ -95,7 +95,7 @@ final class DictionaryDeclTests: PrettyPrintTestCase {
     XCTAssertDiagnosed(.addTrailingComma, line: 4, column: 17)
   }
 
-  func testIgnoresDiscretionaryNewlineAfterColon() {
+  func testDiscretionaryNewlineAfterColon() {
     let input =
       """
       let a = [
@@ -105,6 +105,13 @@ final class DictionaryDeclTests: PrettyPrintTestCase {
       let a = [
         "shortKey":
           value
+      ]
+      let a = [
+        "shortKey": Very.Deeply.Nested.Member
+      ]
+      let a = [
+        "shortKey":
+          Very.Deeply.Nested.Member
       ]
       let a:
         [ReallyLongKeySoTheValueWillWrap:
@@ -121,13 +128,25 @@ final class DictionaryDeclTests: PrettyPrintTestCase {
           value
       ]
       let a = [
-        "shortKey": value
+        "shortKey":
+          value
+      ]
+      let a = [
+        "shortKey": Very
+          .Deeply.Nested
+          .Member
+      ]
+      let a = [
+        "shortKey":
+          Very.Deeply
+          .Nested.Member
       ]
       let a:
         [ReallyLongKeySoTheValueWillWrap:
           Value]
       let a:
-        [ShortKey: Value]
+        [ShortKey:
+          Value]
 
       """
 

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
@@ -226,23 +226,32 @@ final class FunctionCallTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 60)
   }
 
-  func testIgnoresDiscretionaryLineBreakAfterColon() {
+  func testDiscretionaryLineBreakAfterColon() {
     let input =
       """
       myFunc(
         a:
           foo,
         b:
-          bar + baz + quux
+          bar + baz + qux,
+        c: Very.Deeply.Nested.Member,
+        d:
+          Very.Deeply.Nested.Member
       )
       """
 
     let expected =
       """
       myFunc(
-        a: foo,
-        b: bar + baz
-          + quux
+        a:
+          foo,
+        b:
+          bar + baz + qux,
+        c: Very.Deeply
+          .Nested.Member,
+        d:
+          Very.Deeply
+          .Nested.Member
       )
 
       """

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
@@ -1058,7 +1058,7 @@ final class FunctionDeclTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 14)
   }
 
-  func testIgnoresDiscretionaryLineBreakAfterColonAndInout() {
+  func testDiscretionaryLineBreakAfterColonAndInout() {
     let input =
       """
       func foo(
@@ -1075,6 +1075,18 @@ final class FunctionDeclTests: PrettyPrintTestCase {
         reallyLongLabel
           reallyLongArg: E
       ) {}
+      func foo(
+        a: Very.Deeply.Nested.InnerMember,
+        b:
+          Also.Deeply.Nested.InnerMember,
+      ) {}
+      func foo(
+        cmp: @escaping (R) -> ()
+      ) {}
+      func foo(
+        cmp:
+          @escaping (R) -> ()
+      ) {}
       func foo<
         A:
           ReallyLongType,
@@ -1089,15 +1101,35 @@ final class FunctionDeclTests: PrettyPrintTestCase {
       func foo(
         a:
           ReallyLongTypeName,
-        b: ShortType,
-        c: inout C,
-        labeled d: D,
+        b:
+          ShortType,
+        c:
+          inout C,
+        labeled d:
+          D,
         reallyLongLabel
           reallyLongArg: E
       ) {}
+      func foo(
+        a: Very.Deeply.Nested
+          .InnerMember,
+        b:
+          Also.Deeply.Nested
+          .InnerMember,
+      ) {}
+      func foo(
+        cmp: @escaping (R) ->
+          ()
+      ) {}
+      func foo(
+        cmp:
+          @escaping (R) -> ()
+      ) {}
       func foo<
-        A: ReallyLongType,
-        B: ShortType
+        A:
+          ReallyLongType,
+        B:
+          ShortType
       >(a: A, b: B) {}
 
       """

--- a/Tests/SwiftFormatPrettyPrintTests/TupleDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/TupleDeclTests.swift
@@ -46,7 +46,7 @@ final class TupleDeclTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 30)
   }
 
-  func testIgnoresDiscretionaryNewlineAfterColon() {
+  func testDiscretionaryNewlineAfterColon() {
     let input =
       """
       let a = (
@@ -58,7 +58,10 @@ final class TupleDeclTests: PrettyPrintTestCase {
         shortKey:
           value,
         b:
-          c
+          c,
+        label: Deeply.Nested.InnerMember,
+        label2:
+          Deeply.Nested.InnerMember
       )
       """
 
@@ -70,8 +73,15 @@ final class TupleDeclTests: PrettyPrintTestCase {
         b: c
       )
       let a = (
-        shortKey: value,
-        b: c
+        shortKey:
+          value,
+        b:
+          c,
+        label: Deeply.Nested
+          .InnerMember,
+        label2:
+          Deeply.Nested
+          .InnerMember
       )
 
       """

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -182,8 +182,8 @@ extension DictionaryDeclTests {
     // to regenerate.
     static let __allTests__DictionaryDeclTests = [
         ("testBasicDictionaries", testBasicDictionaries),
+        ("testDiscretionaryNewlineAfterColon", testDiscretionaryNewlineAfterColon),
         ("testGroupsTrailingComma", testGroupsTrailingComma),
-        ("testIgnoresDiscretionaryNewlineAfterColon", testIgnoresDiscretionaryNewlineAfterColon),
         ("testNoTrailingCommasInTypes", testNoTrailingCommasInTypes),
         ("testTrailingCommaDiagnostics", testTrailingCommaDiagnostics),
         ("testWhitespaceOnlyDoesNotChangeTrailingComma", testWhitespaceOnlyDoesNotChangeTrailingComma),
@@ -270,10 +270,10 @@ extension FunctionCallTests {
         ("testArgumentStartsWithOpenDelimiter", testArgumentStartsWithOpenDelimiter),
         ("testBasicFunctionCalls_noPackArguments", testBasicFunctionCalls_noPackArguments),
         ("testBasicFunctionCalls_packArguments", testBasicFunctionCalls_packArguments),
+        ("testDiscretionaryLineBreakAfterColon", testDiscretionaryLineBreakAfterColon),
         ("testDiscretionaryLineBreakBeforeClosingParenthesis", testDiscretionaryLineBreakBeforeClosingParenthesis),
         ("testDiscretionaryLineBreaksAreSelfCorrecting", testDiscretionaryLineBreaksAreSelfCorrecting),
         ("testGroupsTrailingComma", testGroupsTrailingComma),
-        ("testIgnoresDiscretionaryLineBreakAfterColon", testIgnoresDiscretionaryLineBreakAfterColon),
         ("testNestedFunctionCallExprSequences", testNestedFunctionCallExprSequences),
         ("testSingleUnlabeledArgumentWithDelimiters", testSingleUnlabeledArgumentWithDelimiters),
     ]
@@ -294,6 +294,7 @@ extension FunctionDeclTests {
         ("testBreaksBeforeOrInsideOutputWithAttributes_prioritizingKeepingOutputTogether", testBreaksBeforeOrInsideOutputWithAttributes_prioritizingKeepingOutputTogether),
         ("testBreaksBeforeOrInsideOutputWithWhereClause", testBreaksBeforeOrInsideOutputWithWhereClause),
         ("testBreaksBeforeOrInsideOutputWithWhereClause_prioritizingKeepingOutputTogether", testBreaksBeforeOrInsideOutputWithWhereClause_prioritizingKeepingOutputTogether),
+        ("testDiscretionaryLineBreakAfterColonAndInout", testDiscretionaryLineBreakAfterColonAndInout),
         ("testDoesNotBreakInsideEmptyParens", testDoesNotBreakInsideEmptyParens),
         ("testDoesNotCollapseFunctionParameterAttributes", testDoesNotCollapseFunctionParameterAttributes),
         ("testDoesNotCollapseStackedFunctionParameterAttributes", testDoesNotCollapseStackedFunctionParameterAttributes),
@@ -308,7 +309,6 @@ extension FunctionDeclTests {
         ("testFunctionWhereClause", testFunctionWhereClause),
         ("testFunctionWhereClause_lineBreakBeforeEachGenericRequirement", testFunctionWhereClause_lineBreakBeforeEachGenericRequirement),
         ("testFunctionWithDefer", testFunctionWithDefer),
-        ("testIgnoresDiscretionaryLineBreakAfterColonAndInout", testIgnoresDiscretionaryLineBreakAfterColonAndInout),
         ("testOperatorOverloads", testOperatorOverloads),
         ("testRemovesLineBreakBeforeOpenBraceUnlessAbsolutelyNecessary", testRemovesLineBreakBeforeOpenBraceUnlessAbsolutelyNecessary),
     ]
@@ -723,8 +723,8 @@ extension TupleDeclTests {
     // to regenerate.
     static let __allTests__TupleDeclTests = [
         ("testBasicTuples", testBasicTuples),
+        ("testDiscretionaryNewlineAfterColon", testDiscretionaryNewlineAfterColon),
         ("testGroupsTrailingComma", testGroupsTrailingComma),
-        ("testIgnoresDiscretionaryNewlineAfterColon", testIgnoresDiscretionaryNewlineAfterColon),
         ("testLabeledTuples", testLabeledTuples),
     ]
 }


### PR DESCRIPTION
Several breaks were changed to disallow discretionary newlines in #143. In practice, some of these breaks actually require a more nuanced approach because grouping around the content after the `:` is frequently subjective. Depending on the length of the label/key before the `:` and the actual expr or type, it varies whether a group should be around the content after the `:`. The formatter's current model doesn't support modifying the tokens to add/remove group tokens once the token stream is created.

In a future patch, it would be nice to have a way to switch between grouping and not grouping the content after the `:` based on the preceding key or label.

Reverted `ignoresDiscretionary` breaks include after the colon in...
- a dictionary type
- a dictionary element
- a function call argument
- a function decl parameter
- a generic parameter
- a tuple type
- a tuple expr element