### PR TITLE
Add `ignore-unparsable-files` to silence diagnostics for invalid syntax

### DIFF
--- a/Sources/swift-format/CommandLineOptions.swift
+++ b/Sources/swift-format/CommandLineOptions.swift
@@ -71,6 +71,16 @@ struct SwiftFormatCommand: ParsableCommand {
     help: "Recursively run on '.swift' files in any provided directories.")
   var recursive: Bool
 
+  /// Whether unparsable files, due to syntax errors or unrecognized syntax, should be ignored or
+  /// treated as containing an error. When ignored, unparsable files are output verbatim in format
+  /// mode and no diagnostics are raised in lint mode. When not ignored, unparsable files raise a
+  /// diagnostic in both format and lint mode.
+  @Flag(help: """
+    Ignores unparsable files, disabling all diagnostics and formatting for files that contain \
+    invalid syntax.
+    """)
+  var ignoreUnparsableFiles: Bool
+
   /// The list of paths to Swift source files that should be formatted or linted.
   @Argument(help: "One or more input filenames")
   var paths: [String]

--- a/Sources/swift-format/main.swift
+++ b/Sources/swift-format/main.swift
@@ -10,13 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+import ArgumentParser
 import Foundation
 import SwiftFormat
 import SwiftFormatConfiguration
 import SwiftFormatCore
 import SwiftSyntax
 import TSCBasic
-import ArgumentParser
 
 extension SwiftFormatCommand {
   func run() throws {
@@ -29,36 +29,44 @@ extension SwiftFormatCommand {
         formatMain(
           configuration: configuration, sourceFile: FileHandle.standardInput,
           assumingFilename: assumeFilename, inPlace: false,
+          ignoreUnparsableFiles: ignoreUnparsableFiles,
           debugOptions: debugOptions, diagnosticEngine: diagnosticEngine)
       } else {
-        try processSources(from: paths, configurationPath: configurationPath, diagnosticEngine: diagnosticEngine) {
+        try processSources(
+          from: paths, configurationPath: configurationPath, diagnosticEngine: diagnosticEngine
+        ) {
           (sourceFile, path, configuration) in
           formatMain(
             configuration: configuration, sourceFile: sourceFile, assumingFilename: path,
-            inPlace: inPlace, debugOptions: debugOptions, diagnosticEngine: diagnosticEngine)
+            inPlace: inPlace, ignoreUnparsableFiles: ignoreUnparsableFiles,
+            debugOptions: debugOptions, diagnosticEngine: diagnosticEngine)
         }
       }
-      
+
     case .lint:
       if paths.isEmpty {
         let configuration = try loadConfiguration(
           forSwiftFile: nil, configFilePath: configurationPath)
         lintMain(
-            configuration: configuration, sourceFile: FileHandle.standardInput,
-            assumingFilename: assumeFilename, debugOptions: debugOptions, diagnosticEngine: diagnosticEngine)
+          configuration: configuration, sourceFile: FileHandle.standardInput,
+          assumingFilename: assumeFilename, ignoreUnparsableFiles: ignoreUnparsableFiles,
+          debugOptions: debugOptions, diagnosticEngine: diagnosticEngine)
       } else {
-        try processSources(from: paths, configurationPath: configurationPath, diagnosticEngine: diagnosticEngine) {
+        try processSources(
+          from: paths, configurationPath: configurationPath, diagnosticEngine: diagnosticEngine
+        ) {
           (sourceFile, path, configuration) in
           lintMain(
             configuration: configuration, sourceFile: sourceFile, assumingFilename: path,
+            ignoreUnparsableFiles: ignoreUnparsableFiles,
             debugOptions: debugOptions, diagnosticEngine: diagnosticEngine)
         }
       }
-      
+
     case .dumpConfiguration:
       try dumpDefaultConfiguration()
     }
-    
+
     // If any of the operations have generated diagnostics, exit with the
     // error status code.
     if !diagnosticEngine.diagnostics.isEmpty {
@@ -140,7 +148,8 @@ private func dumpDefaultConfiguration() throws {
     guard let jsonString = String(data: data, encoding: .utf8) else {
       // This should never happen, but let's make sure we fail more gracefully than crashing, just
       // in case.
-      throw FormatError(message: "Could not dump the default configuration: the JSON was not valid UTF-8")
+      throw FormatError(
+        message: "Could not dump the default configuration: the JSON was not valid UTF-8")
     }
     print(jsonString)
   } catch {


### PR DESCRIPTION
Without this flag, a diagnostic is raised for any file that contains invalid syntax. With the flag, files containing invalid syntax are silently ignored and output verbatim when output is expected (e.g. in format mode with in-place disabled).

The Swift language evolves quickly, with new syntax becoming available and old syntax becoming invalid, and it's difficult to always have swift-format support cutting edge syntax. Before this change, the formatter correctly refused to format such files but the diagnostic to `stderr` would typically be seen as a fatal error by tooling that automates formatting. This flag provides a way to acknowledge the syntax may be invalid as a non-error condition.