### PR TITLE
Force breaking in repeat body when while condition is too long.

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/RepeatStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/RepeatStmtTests.swift
@@ -10,6 +10,10 @@ final class RepeatStmtTests: PrettyPrintTestCase {
       while x
       repeat { foo() }
       while longcondition
+      repeat { f() }
+      while long.condition
+      repeat { f() } while long.condition
+      repeat { f() } while long.condition.that.ison.many.lines
       repeat {
         let a = 123
         var b = "abc"
@@ -29,6 +33,16 @@ final class RepeatStmtTests: PrettyPrintTestCase {
       repeat {
         foo()
       } while longcondition
+      repeat {
+        f()
+      } while long.condition
+      repeat {
+        f()
+      } while long.condition
+      repeat {
+        f()
+      } while long.condition
+        .that.ison.many.lines
       repeat {
         let a = 123
         var b = "abc"
@@ -50,6 +64,10 @@ final class RepeatStmtTests: PrettyPrintTestCase {
       repeat {} while x
       repeat { f() } while x
       repeat { foo() } while longcondition
+      repeat { f() }
+      while long.condition
+      repeat { f() } while long.condition
+      repeat { f() } while long.condition.that.ison.many.lines
       repeat {
         let a = 123
         var b = "abc"
@@ -68,6 +86,13 @@ final class RepeatStmtTests: PrettyPrintTestCase {
       repeat { f() } while x
       repeat { foo() }
       while longcondition
+      repeat { f() }
+      while long.condition
+      repeat { f() }
+      while long.condition
+      repeat { f() }
+      while long.condition.that
+        .ison.many.lines
       repeat {
         let a = 123
         var b = "abc"


### PR DESCRIPTION
Repeat-while-stmt is intended to have configurable breaking behavior between the right brace and the `while` token, like if-else statements. Previously, there wasn't a group so the pretty printer was allowing the repeat body to not have any breaks when the while condition overflowed the line.

The break before the `while` token should fire if the while + condition is too long for the rest of the line.