### PR TITLE
Test coverage for imports wrapped in conditional.

### DIFF
--- a/Tests/SwiftFormatRulesTests/OrderedImportsTests.swift
+++ b/Tests/SwiftFormatRulesTests/OrderedImportsTests.swift
@@ -541,4 +541,82 @@ final class OrderedImportsTests: LintOrFormatRuleTestCase {
 
     XCTAssertFormatting(OrderedImports.self, input: input, expected: expected)
   }
+
+  func testConditionalImports() {
+    let input =
+      """
+      import Zebras
+      import Apples
+      #if canImport(Darwin)
+        import Darwin
+      #elseif canImport(Glibc)
+        import Glibc
+      #endif
+      import Aardvarks
+
+      foo()
+      bar()
+      baz()
+      """
+
+    let expected =
+      """
+      import Aardvarks
+      import Apples
+      import Zebras
+
+      #if canImport(Darwin)
+        import Darwin
+        typealias SomeNativeTypeHandle = some_darwin_type_t
+      #elseif canImport(Glibc)
+        import Glibc
+        typealias SomeNativeTypeHandle = some_glibc_type_t
+      #endif
+
+      foo()
+      bar()
+      baz()
+      """
+
+    XCTAssertFormatting(OrderedImports.self, input: input, expected: expected)
+  }
+
+  func testIgnoredConditionalImports() {
+    let input =
+      """
+      import Zebras
+      import Apples
+      #if canImport(Darwin)
+        import Darwin
+      #elseif canImport(Glibc)
+        import Glibc
+      #endif
+      // swift-format-ignore
+      import Aardvarks
+
+      foo()
+      bar()
+      baz()
+      """
+
+    let expected =
+      """
+      import Apples
+      import Zebras
+
+      #if canImport(Darwin)
+        import Darwin
+      #elseif canImport(Glibc)
+        import Glibc
+      #endif
+      // swift-format-ignore
+      import Aardvarks
+
+      foo()
+      bar()
+      baz()
+      """
+
+    XCTAssertFormatting(OrderedImports.self, input: input, expected: expected)
+  }
 }

--- a/Tests/SwiftFormatRulesTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatRulesTests/XCTestManifests.swift
@@ -264,12 +264,14 @@ extension OrderedImportsTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__OrderedImportsTests = [
+        ("testConditionalImports", testConditionalImports),
         ("testDisableOrderedImports", testDisableOrderedImports),
         ("testDisableOrderedImportsMovingComments", testDisableOrderedImportsMovingComments),
         ("testDuplicateAttributedImports", testDuplicateAttributedImports),
         ("testDuplicateCommentedImports", testDuplicateCommentedImports),
         ("testDuplicateIgnoredImports", testDuplicateIgnoredImports),
         ("testEmptyFile", testEmptyFile),
+        ("testIgnoredConditionalImports", testIgnoredConditionalImports),
         ("testImportsOrderWithDocComment", testImportsOrderWithDocComment),
         ("testImportsOrderWithoutModuleType", testImportsOrderWithoutModuleType),
         ("testInvalidImportsOrder", testInvalidImportsOrder),


### PR DESCRIPTION
These don't receive any special treatment, and instead are sorted as code blocks. That's done intentionally because the code block in a conditional can be complex, containing multiple imports or even non-import code (e.g. a typealias). Sorting them in with other imports would only be a sepcial case for the simplest conditional blocks.

I considered treating these like ignored imports, which are kept as-is. That has the drawback of forcing all imports before and after the conditional to be kept in place, which prevents sorting.