### PR TITLE
Remove swift-tools-support-core dependency.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -18,15 +18,6 @@
           "revision": "0688b9cfc4c3dd234e4f55f1f056b2affc849873",
           "version": "0.50200.0"
         }
-      },
-      {
-        "package": "swift-tools-support-core",
-        "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
-        "state": {
-          "branch": null,
-          "revision": "693aba4c4c9dcc4767cc853a0dd38bf90ad8c258",
-          "version": "0.0.1"
-        }
       }
     ]
   },

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,6 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-syntax", from: "0.50200.0"),
-    .package(url: "https://github.com/apple/swift-tools-support-core.git", from: "0.0.1"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.0.4")),
   ],
   targets: [
@@ -62,12 +61,11 @@ let package = Package(
     .target(
       name: "swift-format",
       dependencies: [
+        "ArgumentParser",
         "SwiftFormat",
         "SwiftFormatConfiguration",
         "SwiftFormatCore",
         "SwiftSyntax",
-        "SwiftToolsSupport-auto",
-        "ArgumentParser",
       ]
     ),
     .testTarget(

--- a/Sources/swift-format/Subcommands/DumpConfiguration.swift
+++ b/Sources/swift-format/Subcommands/DumpConfiguration.swift
@@ -13,8 +13,6 @@
 import ArgumentParser
 import Foundation
 import SwiftFormatConfiguration
-import TSCBasic
-import TSCUtility
 
 extension SwiftFormatCommand {
   /// Dumps the tool's default configuration in JSON format to standard output.

--- a/Sources/swift-format/Subcommands/LegacyMain.swift
+++ b/Sources/swift-format/Subcommands/LegacyMain.swift
@@ -16,7 +16,6 @@ import SwiftFormat
 import SwiftFormatConfiguration
 import SwiftFormatCore
 import SwiftSyntax
-import TSCBasic
 
 extension SwiftFormatCommand {
   /// Keep the legacy `-m/--mode` flag working temporarily when no other subcommand is specified.

--- a/Sources/swift-format/Subcommands/Lint.swift
+++ b/Sources/swift-format/Subcommands/Lint.swift
@@ -15,7 +15,6 @@ import Foundation
 import SwiftFormat
 import SwiftFormatConfiguration
 import SwiftSyntax
-import TSCBasic
 
 extension SwiftFormatCommand {
   /// Emits style diagnostics for one or more files containing Swift code.

--- a/Sources/swift-format/Utilities/FileHandle+TextOutputStream.swift
+++ b/Sources/swift-format/Utilities/FileHandle+TextOutputStream.swift
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+extension FileHandle: TextOutputStream {
+  public func write(_ string: String) {
+    self.write(string.data(using: .utf8)!)  // Conversion to UTF-8 cannot fail
+  }
+}

--- a/Sources/swift-format/Utilities/Helpers.swift
+++ b/Sources/swift-format/Utilities/Helpers.swift
@@ -16,7 +16,6 @@ import SwiftFormat
 import SwiftFormatConfiguration
 import SwiftFormatCore
 import SwiftSyntax
-import TSCBasic
 
 /// Throws an error that causes the current command to exit the process with a failure exit code if
 /// any of the preceding operations emitted diagnostics.


### PR DESCRIPTION
TSC was mostly used for its argument parser. Now that
we've migrated to swift-argument-parser, the remaining
file system and path APIs in TSC are only used by the
Format command and can be fairly easily replaced by
Foundation APIs instead.