### PR TITLE
Discard newlines when sorting imports.

### DIFF
--- a/Sources/SwiftFormatRules/OrderedImports.swift
+++ b/Sources/SwiftFormatRules/OrderedImports.swift
@@ -503,7 +503,7 @@ fileprivate class Line {
     else {
       return ""
     }
-    return importDecl.path.description.trimmingCharacters(in: .whitespaces)
+    return importDecl.path.description.trimmingCharacters(in: .whitespacesAndNewlines)
   }
 
   /// Returns the first `TokenSyntax` in the code block(s) from this Line, or nil when this Line

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -207,9 +207,7 @@ extension DifferentiationAttributeTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__DifferentiationAttributeTests = [
-        ("testDerivative", testDerivative),
         ("testDifferentiable", testDifferentiable),
-        ("testTranspose", testTranspose),
     ]
 }
 

--- a/Tests/SwiftFormatRulesTests/OrderedImportsTests.swift
+++ b/Tests/SwiftFormatRulesTests/OrderedImportsTests.swift
@@ -396,6 +396,30 @@ final class OrderedImportsTests: LintOrFormatRuleTestCase {
     )
   }
 
+  func testImportsContainingNewlines() {
+    let input =
+      """
+      import
+        zeta
+      import Zeta
+      import
+        Alpha
+      import Beta
+      """
+
+    let expected =
+      """
+      import
+        Alpha
+      import Beta
+      import Zeta
+      import
+        zeta
+      """
+
+    XCTAssertFormatting(OrderedImports.self, input: input, expected: expected)
+  }
+
   func testRemovesDuplicateImports() {
     let input =
       """

--- a/Tests/SwiftFormatRulesTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatRulesTests/XCTestManifests.swift
@@ -272,6 +272,7 @@ extension OrderedImportsTests {
         ("testDuplicateIgnoredImports", testDuplicateIgnoredImports),
         ("testEmptyFile", testEmptyFile),
         ("testIgnoredConditionalImports", testIgnoredConditionalImports),
+        ("testImportsContainingNewlines", testImportsContainingNewlines),
         ("testImportsOrderWithDocComment", testImportsOrderWithDocComment),
         ("testImportsOrderWithoutModuleType", testImportsOrderWithoutModuleType),
         ("testInvalidImportsOrder", testInvalidImportsOrder),


### PR DESCRIPTION
When the author inserts a newline between the `import` token and the imported path, that newline shouldn't be considered when sorting the paths.