### PR TITLE
Move conditional compilation directive inside tests.

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/DifferentiationAttributeTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/DifferentiationAttributeTests.swift
@@ -43,8 +43,8 @@ final class DifferentiationAttributeTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 43)
   }
 
-  #if HAS_DERIVATIVE_REGISTRATION_ATTRIBUTE
-    func testDerivative() {
+  func testDerivative() {
+    #if HAS_DERIVATIVE_REGISTRATION_ATTRIBUTE
       let input =
         """
         @derivative(of: foo, wrt: x)
@@ -78,9 +78,11 @@ final class DifferentiationAttributeTests: PrettyPrintTestCase {
         """
 
       assertPrettyPrintEqual(input: input, expected: expected, linelength: 28)
-    }
+    #endif
+  }
 
-    func testTranspose() {
+  func testTranspose() {
+    #if HAS_DERIVATIVE_REGISTRATION_ATTRIBUTE
       let input =
         """
         @transpose(of: foo, wrt: 0)
@@ -114,6 +116,6 @@ final class DifferentiationAttributeTests: PrettyPrintTestCase {
         """
 
       assertPrettyPrintEqual(input: input, expected: expected, linelength: 27)
-    }
-  #endif
+    #endif
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -207,7 +207,9 @@ extension DifferentiationAttributeTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__DifferentiationAttributeTests = [
+        ("testDerivative", testDerivative),
         ("testDifferentiable", testDifferentiable),
+        ("testTranspose", testTranspose),
     ]
 }
 


### PR DESCRIPTION
This ensures that the test function always exists, even if the
symbol is not defined, so that `--generate-linuxmain` contains
the symbol in both cases. When the symbol is undefined, the
empty test will vacuously succeed.