### PR TITLE
Restrict doc-block to doc-line transform to first doc comment.

### DIFF
--- a/Tests/SwiftFormatRulesTests/UseTripleSlashForDocumentationCommentsTests.swift
+++ b/Tests/SwiftFormatRulesTests/UseTripleSlashForDocumentationCommentsTests.swift
@@ -54,4 +54,95 @@ final class UseTripleSlashForDocumentationCommentsTests: LintOrFormatRuleTestCas
                 public var test = 1
                 """)
   }
+
+  func testMultipleTypesOfDocComments() {
+    XCTAssertFormatting(
+      UseTripleSlashForDocumentationComments.self,
+      input: """
+             /**
+              * This is my preamble. It could be important.
+              * This comment stays as-is.
+              */
+
+             /// This decl has a comment.
+             /// The comment is multiple lines long.
+             public class AClazz {
+             }
+             """,
+      expected: """
+                /**
+                 * This is my preamble. It could be important.
+                 * This comment stays as-is.
+                 */
+
+                /// This decl has a comment.
+                /// The comment is multiple lines long.
+                public class AClazz {
+                }
+                """)
+  }
+
+  func testMultipleDocLineComments() {
+    XCTAssertFormatting(
+      UseTripleSlashForDocumentationComments.self,
+      input: """
+             /// This is my preamble. It could be important.
+             /// This comment stays as-is.
+             ///
+
+             /// This decl has a comment.
+             /// The comment is multiple lines long.
+             public class AClazz {
+             }
+             """,
+      expected: """
+                /// This is my preamble. It could be important.
+                /// This comment stays as-is.
+                ///
+
+                /// This decl has a comment.
+                /// The comment is multiple lines long.
+                public class AClazz {
+                }
+                """)
+  }
+
+  func testManyDocComments() {
+    XCTAssertFormatting(
+      UseTripleSlashForDocumentationComments.self,
+      input: """
+             /**
+              * This is my preamble. It could be important.
+              * This comment stays as-is.
+              */
+
+             /// This is a doc-line comment!
+
+             /** This is a fairly short doc-block comment. */
+
+             /// Why are there so many comments?
+             /// Who knows! But there are loads.
+
+             /** AClazz is a class with good name. */
+             public class AClazz {
+             }
+             """,
+      expected: """
+                /**
+                 * This is my preamble. It could be important.
+                 * This comment stays as-is.
+                 */
+
+                /// This is a doc-line comment!
+
+                /** This is a fairly short doc-block comment. */
+
+                /// Why are there so many comments?
+                /// Who knows! But there are loads.
+
+                /// AClazz is a class with good name.
+                public class AClazz {
+                }
+                """)
+  }
 }

--- a/Tests/SwiftFormatRulesTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatRulesTests/XCTestManifests.swift
@@ -369,6 +369,9 @@ extension UseTripleSlashForDocumentationCommentsTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__UseTripleSlashForDocumentationCommentsTests = [
+        ("testManyDocComments", testManyDocComments),
+        ("testMultipleDocLineComments", testMultipleDocLineComments),
+        ("testMultipleTypesOfDocComments", testMultipleTypesOfDocComments),
         ("testRemoveDocBlockComments", testRemoveDocBlockComments),
         ("testRemoveDocBlockCommentsWithoutStars", testRemoveDocBlockCommentsWithoutStars),
     ]


### PR DESCRIPTION
The transform is intentionally meant to only apply to comments that are documenting a declaration. The distinction is made by finding the comment "closest" to the decl, searching through the trivia backwards. Unfortunately, the search didn't handle the fact that there could be multiple doc comments in the leading trivia of a decl. Multiple comments usually occur at the beginning of the file, when there's a file level comment (either doc block or doc line), followed by decl documentation, then the first decl.

It might make sense to convert doc-block comments in the file preamble to doc-line, but we've previously had issues converting general purpose block comments. This approach is safer because only comments that are documenting a decl (defined as closest to the decl) are converted.