### PR TITLE
Remove calls to `FileHandle.synchronizeFile()`.

### DIFF
--- a/Sources/swift-format/Subcommands/Format.swift
+++ b/Sources/swift-format/Subcommands/Format.swift
@@ -108,7 +108,6 @@ private func formatMain(
       try bufferData.write(to: assumingFileURL, options: .atomic)
     } else {
       try formatter.format(source: source, assumingFileURL: assumingFileURL, to: &stdoutStream)
-      stdoutStream.synchronizeFile()
     }
   } catch SwiftFormatError.fileNotReadable {
     diagnosticEngine.diagnose(
@@ -122,7 +121,6 @@ private func formatMain(
         return
       }
       stdoutStream.write(source)
-      stdoutStream.synchronizeFile()
       return
     }
     let location = SourceLocationConverter(file: path, source: source).location(for: position)


### PR DESCRIPTION
Standard output does not support `fsync`, which is the system
call that this boils down to on Linux (and presumably on Darwin
as well). In both cases, `fsync` sets `errno` to `EINVAL`, but
unfortunately Foundation's behavior differs per platform: on
Darwin the error is silently swallowed, but on Linux it traps.