### PR TITLE
Allow right paren of enum case decl to be on the same line as the las…

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1186,7 +1186,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     after(node.trailingComma, tokens: .break)
 
     if let associatedValue = node.associatedValue {
-      arrangeParameterClause(associatedValue, forcesBreakBeforeRightParen: true)
+      arrangeParameterClause(associatedValue, forcesBreakBeforeRightParen: false)
     }
 
     return .visitChildren

--- a/Tests/SwiftFormatPrettyPrintTests/EnumDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/EnumDeclTests.swift
@@ -115,15 +115,14 @@ final class EnumDeclTests: PrettyPrintTestCase {
           fifth
         case sixth(Int)
         case seventh(
-          a: Int, b: Bool, c: Double
-        )
+          a: Int, b: Bool, c: Double)
       }
 
       """
 
     var config = Configuration()
     config.lineBreakBeforeEachArgument = false
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 30, configuration: config)
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 31, configuration: config)
   }
 
   func testIndirectEnum() {


### PR DESCRIPTION
…t param.

When enum cases have associated values, these are similar to function params. The right paren is allowed to stay on the same line for function params, and this makes enum cases consistent.

The break allows discretionary line breaks.