### PR TITLE
Various fixes to `ReturnVoidInsteadOfEmptyTuple`.

### DIFF
--- a/Sources/SwiftFormatRules/ReturnVoidInsteadOfEmptyTuple.swift
+++ b/Sources/SwiftFormatRules/ReturnVoidInsteadOfEmptyTuple.swift
@@ -25,14 +25,82 @@ public final class ReturnVoidInsteadOfEmptyTuple: SyntaxFormatRule {
   public override func visit(_ node: FunctionTypeSyntax) -> TypeSyntax {
     guard let returnType = node.returnType.as(TupleTypeSyntax.self),
       returnType.elements.count == 0
-    else { return TypeSyntax(node) }
-    diagnose(.returnVoid, on: node.returnType)
-    let voidKeyword = SyntaxFactory.makeSimpleTypeIdentifier(
+    else {
+      return super.visit(node)
+    }
+
+    diagnose(.returnVoid, on: returnType)
+
+    // If the user has put non-whitespace trivia inside the empty tuple, like a comment, then we
+    // still diagnose it as a lint error but we don't replace it because it's not obvious where the
+    // comment should go.
+    if hasNonWhitespaceLeadingTrivia(returnType.rightParen) {
+      return super.visit(node)
+    }
+
+    // Make sure that function types nested in the argument list are also rewritten (for example,
+    // `(Int -> ()) -> ()` should become `(Int -> Void) -> Void`).
+    let arguments = visit(node.arguments).as(TupleTypeElementListSyntax.self)!
+    let voidKeyword = makeVoidIdentifierType(toReplace: returnType)
+    return TypeSyntax(node.withArguments(arguments).withReturnType(TypeSyntax(voidKeyword)))
+  }
+
+  public override func visit(_ node: ClosureSignatureSyntax) -> Syntax {
+    guard let output = node.output,
+      let returnType = output.returnType.as(TupleTypeSyntax.self),
+      returnType.elements.count == 0
+    else {
+      return super.visit(node)
+    }
+
+    diagnose(.returnVoid, on: returnType)
+
+    // If the user has put non-whitespace trivia inside the empty tuple, like a comment, then we
+    // still diagnose it as a lint error but we don't replace it because it's not obvious where the
+    // comment should go.
+    if hasNonWhitespaceLeadingTrivia(returnType.rightParen) {
+      return super.visit(node)
+    }
+
+    let input: Syntax?
+    if let parameterClause = node.input?.as(ParameterClauseSyntax.self) {
+      // If the closure input is a complete parameter clause (variables and types), make sure that
+      // nested function types are also rewritten (for example, `label: (Int -> ()) -> ()` should
+      // become `label: (Int -> Void) -> Void`).
+      input = visit(parameterClause)
+    } else {
+      // Otherwise, it's a simple signature (just variable names, no types), so there is nothing to
+      // rewrite.
+      input = node.input
+    }
+    let voidKeyword = makeVoidIdentifierType(toReplace: returnType)
+    return Syntax(node.withInput(input).withOutput(output.withReturnType(TypeSyntax(voidKeyword))))
+  }
+
+  /// Returns a value indicating whether the leading trivia of the given token contained any
+  /// non-whitespace pieces.
+  private func hasNonWhitespaceLeadingTrivia(_ token: TokenSyntax) -> Bool {
+    for piece in token.leadingTrivia {
+      switch piece {
+      case .blockComment, .docBlockComment, .docLineComment, .garbageText, .lineComment:
+        return true
+      default:
+        break
+      }
+    }
+    return false
+  }
+
+  /// Returns a type syntax node with the identifier `Void` whose leading and trailing trivia have
+  /// been copied from the tuple type syntax node it is replacing.
+  private func makeVoidIdentifierType(toReplace node: TupleTypeSyntax) -> SimpleTypeIdentifierSyntax
+  {
+    return SyntaxFactory.makeSimpleTypeIdentifier(
       name: SyntaxFactory.makeIdentifier(
         "Void",
-        trailingTrivia: returnType.rightParen.trailingTrivia),
+        leadingTrivia: node.firstToken?.leadingTrivia ?? [],
+        trailingTrivia: node.lastToken?.trailingTrivia ?? []),
       genericArgumentClause: nil)
-    return TypeSyntax(node.withReturnType(TypeSyntax(voidKeyword)))
   }
 }
 

--- a/Tests/SwiftFormatRulesTests/ReturnVoidInsteadOfEmptyTupleTests.swift
+++ b/Tests/SwiftFormatRulesTests/ReturnVoidInsteadOfEmptyTupleTests.swift
@@ -1,20 +1,161 @@
 import SwiftFormatRules
 
 final class ReturnVoidInsteadOfEmptyTupleTests: LintOrFormatRuleTestCase {
-  func testEmptyTupleReturns() {
+  func testBasic() {
     XCTAssertFormatting(
       ReturnVoidInsteadOfEmptyTuple.self,
-      input: """
-             let callback: () -> ()
-             typealias x = Int -> ()
-             func y() -> Int -> () { return }
-             func z(d: Bool -> ()) {}
-             """,
-      expected: """
-                let callback: () -> Void
-                typealias x = Int -> Void
-                func y() -> Int -> Void { return }
-                func z(d: Bool -> Void) {}
-                """)
+      input:
+        """
+        let callback: () -> ()
+        typealias x = Int -> ()
+        func y() -> Int -> () { return }
+        func z(d: Bool -> ()) {}
+        """,
+      expected:
+        """
+        let callback: () -> Void
+        typealias x = Int -> Void
+        func y() -> Int -> Void { return }
+        func z(d: Bool -> Void) {}
+        """,
+      checkForUnassertedDiagnostics: true
+    )
+    XCTAssertDiagnosed(.returnVoid, line: 1, column: 21)
+    XCTAssertDiagnosed(.returnVoid, line: 2, column: 22)
+    XCTAssertDiagnosed(.returnVoid, line: 3, column: 20)
+    XCTAssertDiagnosed(.returnVoid, line: 4, column: 19)
+  }
+
+  func testNestedFunctionTypes() {
+    XCTAssertFormatting(
+      ReturnVoidInsteadOfEmptyTuple.self,
+      input:
+        """
+        typealias Nested1 = (() -> ()) -> Int
+        typealias Nested2 = (() -> ()) -> ()
+        typealias Nested3 = Int -> (() -> ())
+        """,
+      expected:
+        """
+        typealias Nested1 = (() -> Void) -> Int
+        typealias Nested2 = (() -> Void) -> Void
+        typealias Nested3 = Int -> (() -> Void)
+        """,
+      checkForUnassertedDiagnostics: true
+    )
+    XCTAssertDiagnosed(.returnVoid, line: 1, column: 28)
+    XCTAssertDiagnosed(.returnVoid, line: 2, column: 28)
+    XCTAssertDiagnosed(.returnVoid, line: 2, column: 35)
+    XCTAssertDiagnosed(.returnVoid, line: 3, column: 35)
+  }
+
+  func testClosureSignatures() {
+    XCTAssertFormatting(
+      ReturnVoidInsteadOfEmptyTuple.self,
+      input:
+        """
+        callWithTrailingClosure(arg) { arg -> () in body }
+        callWithTrailingClosure(arg) { arg -> () in
+          nestedCallWithTrailingClosure(arg) { arg -> () in
+            body
+          }
+        }
+        callWithTrailingClosure(arg) { (arg: () -> ()) -> Int in body }
+        callWithTrailingClosure(arg) { (arg: () -> ()) -> () in body }
+        """,
+      expected:
+        """
+        callWithTrailingClosure(arg) { arg -> Void in body }
+        callWithTrailingClosure(arg) { arg -> Void in
+          nestedCallWithTrailingClosure(arg) { arg -> Void in
+            body
+          }
+        }
+        callWithTrailingClosure(arg) { (arg: () -> Void) -> Int in body }
+        callWithTrailingClosure(arg) { (arg: () -> Void) -> Void in body }
+        """,
+      checkForUnassertedDiagnostics: true
+    )
+    XCTAssertDiagnosed(.returnVoid, line: 1, column: 39)
+    XCTAssertDiagnosed(.returnVoid, line: 2, column: 39)
+    XCTAssertDiagnosed(.returnVoid, line: 3, column: 47)
+    XCTAssertDiagnosed(.returnVoid, line: 7, column: 44)
+    XCTAssertDiagnosed(.returnVoid, line: 8, column: 44)
+    XCTAssertDiagnosed(.returnVoid, line: 8, column: 51)
+  }
+
+  func testTriviaPreservation() {
+    XCTAssertFormatting(
+      ReturnVoidInsteadOfEmptyTuple.self,
+      input:
+        """
+        let callback: () -> /*foo*/()/*bar*/
+        let callback: (Int ->   /*foo*/   ()   /*bar*/) -> ()
+        """,
+      expected:
+        """
+        let callback: () -> /*foo*/Void/*bar*/
+        let callback: (Int ->   /*foo*/   Void   /*bar*/) -> Void
+        """,
+      checkForUnassertedDiagnostics: true
+    )
+    XCTAssertDiagnosed(.returnVoid, line: 1, column: 28)
+    XCTAssertDiagnosed(.returnVoid, line: 2, column: 35)
+    XCTAssertDiagnosed(.returnVoid, line: 2, column: 52)
+  }
+
+  func testEmptyTupleWithInternalCommentsIsDiagnosedButNotReplaced() {
+    XCTAssertFormatting(
+      ReturnVoidInsteadOfEmptyTuple.self,
+      input:
+        """
+        let callback: () -> ( )
+        let callback: () -> (\t)
+        let callback: () -> (
+        )
+        let callback: () -> ( /* please don't change me! */ )
+        let callback: () -> ( /** please don't change me! */ )
+        let callback: () -> (
+          // don't change me either!
+        )
+        let callback: () -> (
+          /// don't change me either!
+        )
+        let callback: () -> (\u{feff})
+
+        let callback: (() -> ()) -> ( /* please don't change me! */ )
+        callWithTrailingClosure(arg) { (arg: () -> ()) -> ( /* no change */ ) in body }
+        """,
+      expected:
+        """
+        let callback: () -> Void
+        let callback: () -> Void
+        let callback: () -> Void
+        let callback: () -> ( /* please don't change me! */ )
+        let callback: () -> ( /** please don't change me! */ )
+        let callback: () -> (
+          // don't change me either!
+        )
+        let callback: () -> (
+          /// don't change me either!
+        )
+        let callback: () -> (\u{feff})
+
+        let callback: (() -> Void) -> ( /* please don't change me! */ )
+        callWithTrailingClosure(arg) { (arg: () -> Void) -> ( /* no change */ ) in body }
+        """,
+      checkForUnassertedDiagnostics: true
+    )
+    XCTAssertDiagnosed(.returnVoid, line: 1, column: 21)
+    XCTAssertDiagnosed(.returnVoid, line: 2, column: 21)
+    XCTAssertDiagnosed(.returnVoid, line: 3, column: 21)
+    XCTAssertDiagnosed(.returnVoid, line: 5, column: 21)
+    XCTAssertDiagnosed(.returnVoid, line: 6, column: 21)
+    XCTAssertDiagnosed(.returnVoid, line: 7, column: 21)
+    XCTAssertDiagnosed(.returnVoid, line: 10, column: 21)
+    XCTAssertDiagnosed(.returnVoid, line: 15, column: 22)
+    XCTAssertDiagnosed(.returnVoid, line: 15, column: 29)
+    XCTAssertDiagnosed(.returnVoid, line: 16, column: 44)
+    XCTAssertDiagnosed(.returnVoid, line: 16, column: 51)
   }
 }

--- a/Tests/SwiftFormatRulesTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatRulesTests/XCTestManifests.swift
@@ -290,7 +290,11 @@ extension ReturnVoidInsteadOfEmptyTupleTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__ReturnVoidInsteadOfEmptyTupleTests = [
-        ("testEmptyTupleReturns", testEmptyTupleReturns),
+        ("testBasic", testBasic),
+        ("testClosureSignatures", testClosureSignatures),
+        ("testEmptyTupleWithInternalCommentsIsDiagnosedButNotReplaced", testEmptyTupleWithInternalCommentsIsDiagnosedButNotReplaced),
+        ("testNestedFunctionTypes", testNestedFunctionTypes),
+        ("testTriviaPreservation", testTriviaPreservation),
     ]
 }
 


### PR DESCRIPTION
- Handle `()` in closure signature return types.
- Handle `()` when nested in the argument lists of function types and closures.
- Ensure leading/trailing trivia of the original `()` is preserved.
- Don't replace `()` if it has internal comments, like `(/*foo*/)`.