### PR TITLE
Rearrange breaks so class decls won't overflow line length.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1981,10 +1981,11 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: TypeInheritanceClauseSyntax) -> SyntaxVisitorContinueKind {
-    after(node.colon, tokens: .break(.open, size: 1))
-    before(node.inheritedTypeCollection.firstToken, tokens: .open)
-    after(node.inheritedTypeCollection.lastToken, tokens: .close)
-    after(node.lastToken, tokens: .break(.close, size: 0))
+    // Normally, the open-break is placed before the open token. In this case, it's intentionally
+    // ordered differently so that the inheritance list can start on the current line and only
+    // breaks if the first item in the list would overflow the column limit.
+    before(node.inheritedTypeCollection.firstToken, tokens: .open, .break(.open, size: 1))
+    after(node.inheritedTypeCollection.lastToken, tokens: .break(.close, size: 0), .close)
     return .visitChildren
   }
 

--- a/Tests/SwiftFormatPrettyPrintTests/ClassDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ClassDeclTests.swift
@@ -140,6 +140,15 @@ final class ClassDeclTests: PrettyPrintTestCase {
         let A: Int
         let B: Bool
       }
+      class MyClass:
+        SuperOne, SuperTwo, SuperThree {
+        let A: Int
+        let B: Bool
+      }
+      class MyClassWhoseNameIsVeryLong: SuperOne, SuperTwo, SuperThree {
+        let A: Int
+        let B: Bool
+      }
       """
 
     let expected =
@@ -154,6 +163,18 @@ final class ClassDeclTests: PrettyPrintTestCase {
       }
       class MyClass: SuperOne, SuperTwo,
         SuperThree
+      {
+        let A: Int
+        let B: Bool
+      }
+      class MyClass:
+        SuperOne, SuperTwo, SuperThree
+      {
+        let A: Int
+        let B: Bool
+      }
+      class MyClassWhoseNameIsVeryLong:
+        SuperOne, SuperTwo, SuperThree
       {
         let A: Int
         let B: Bool

--- a/Tests/SwiftFormatPrettyPrintTests/ExtensionDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ExtensionDeclTests.swift
@@ -316,8 +316,8 @@ final class ExtensionDeclTests: PrettyPrintTestCase {
     let expected =
 
       """
-      public extension MyContainer: MyContainerProtocolOne,
-        MyContainerProtocolTwo,
+      public extension MyContainer:
+        MyContainerProtocolOne, MyContainerProtocolTwo,
         SomeoneElsesContainerProtocol,
         SomeFrameworkContainerProtocol
       where
@@ -346,8 +346,8 @@ final class ExtensionDeclTests: PrettyPrintTestCase {
     let expected =
 
     """
-      public extension MyContainer: MyContainerProtocolOne,
-        MyContainerProtocolTwo,
+      public extension MyContainer:
+        MyContainerProtocolOne, MyContainerProtocolTwo,
         SomeoneElsesContainerProtocol,
         SomeFrameworkContainerProtocol
       where


### PR DESCRIPTION
The inheritance list for type and extension decls is wrapped with open/close tokens, but the relevant open-break token was nested inside of a different group. The previous token layout created the correct indentation of the tokens in the inheritance list, but meant the break between the colon and first token in the inheritance list could never fire because it was followed by a close token.

This resulted in type and extension decls that overflow the column limit when the type name + `:` + first token in the inhertance list together was longer than the column limit.

I fixed this by moving the open break inside of the open/close tokens surrounding the inheritance list. Normally, the open break comes before the open but that would force a break before the first token in the inheritance list if the entire list doesn't fit. That behavior wouldn't be consistent with existing behavior. Instead, placing the open break inside of the open only breaks if the first token in the inheritance list is too long.