### PR TITLE
Fix counting of consecutive newlines.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
@@ -211,7 +211,7 @@ public class PrettyPrinter {
       numberToPrint = consecutiveNewlineCount == 0 ? 1 : 0
     case .soft(let count, _):
       // We add 1 to the max blank lines because it takes 2 newlines to create the first blank line.
-      numberToPrint = min(count - consecutiveNewlineCount, configuration.maximumBlankLines + 1)
+      numberToPrint = min(count, configuration.maximumBlankLines + 1) - consecutiveNewlineCount
     case .hard(let count):
       numberToPrint = count
     }

--- a/Tests/SwiftFormatPrettyPrintTests/NewlineTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/NewlineTests.swift
@@ -74,4 +74,60 @@ final class NewlineTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
   }
+
+  func testNewlinesBetweenMembers() {
+    let input =
+      """
+
+
+      class MyClazz {
+
+        lazy var memberView: UIView = {
+          let view = UIView()
+          return view
+        }()
+
+
+        func doSomething() {
+          print("!")
+        }
+
+
+        func doSomethingElse() {
+          print("else!")
+        }
+
+
+        let constMember = 1
+
+
+
+      }
+      """
+
+    let expected =
+      """
+      class MyClazz {
+
+        lazy var memberView: UIView = {
+          let view = UIView()
+          return view
+        }()
+
+        func doSomething() {
+          print("!")
+        }
+
+        func doSomethingElse() {
+          print("else!")
+        }
+
+        let constMember = 1
+
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 100)
+  }
 }


### PR DESCRIPTION
The math for calculating how many blank lines to allow didn't account for existing consecutive blank lines when the maximum blank lines configuration value was used. That meant an existing newline in the output would result in allowing max blank lines + 1 blank lines.