### PR TITLE
Minor updates to `@differentiable`.

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/DifferentiationAttributeTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/DifferentiationAttributeTests.swift
@@ -2,38 +2,28 @@ final class DifferentiationAttributeTests: PrettyPrintTestCase {
   func testDifferentiable() {
     let input =
       """
-      @differentiable(wrt: x, vjp: d where T: D)
+      @differentiable(wrt: x where T: D)
       func foo<T>(_ x: T) -> T {}
 
-      @differentiable(wrt: x, vjp: deriv where T: D)
+      @differentiable(wrt: x where T: Differentiable)
       func foo<T>(_ x: T) -> T {}
 
-      @differentiable(wrt: x, vjp: derivativeFoo where T: Differentiable)
-      func foo<T>(_ x: T) -> T {}
-
-      @differentiable(wrt: theVariableNamedX, vjp: derivativeFoo where T: Differentiable)
+      @differentiable(wrt: theVariableNamedX where T: Differentiable)
       func foo<T>(_ theVariableNamedX: T) -> T {}
       """
 
     let expected =
       """
-      @differentiable(wrt: x, vjp: d where T: D)
+      @differentiable(wrt: x where T: D)
       func foo<T>(_ x: T) -> T {}
 
       @differentiable(
-        wrt: x, vjp: deriv where T: D
+        wrt: x where T: Differentiable
       )
       func foo<T>(_ x: T) -> T {}
 
       @differentiable(
-        wrt: x, vjp: derivativeFoo
-        where T: Differentiable
-      )
-      func foo<T>(_ x: T) -> T {}
-
-      @differentiable(
-        wrt: theVariableNamedX,
-        vjp: derivativeFoo
+        wrt: theVariableNamedX
         where T: Differentiable
       )
       func foo<T>(_ theVariableNamedX: T) -> T {}


### PR DESCRIPTION
https://github.com/apple/swift/pull/30001 removed the logic
from the parser to handle the `jvp:` and `vjp:` arguments of
the attribute (but left the syntax definitions in place for
the time being). Since this causes an attribute with those
arguments to fail to parse, I've removed them from the tests
so that those tests continue to pass under the new behavior.
(The arguments were always optional, so they pass under the
old behavior as well.)

This also caught and fixed a bug where an attribute with
only a `wrt:` and a `where` clause wasn't getting formatted
correctly.