### PR TITLE
Add breaks around conditions of while-stmt.

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/WhileStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/WhileStmtTests.swift
@@ -63,6 +63,11 @@ final class WhileStmtTests: PrettyPrintTestCase {
         let a = 123
         var b = "abc"
       }
+      myLabel: while myVeryLongFirstCondition && condition2 || condition3
+      {
+        let a = 123
+        var b = "abc"
+      }
       """
 
     let expected =
@@ -82,6 +87,55 @@ final class WhileStmtTests: PrettyPrintTestCase {
       {
         let a = 123
         var b = "abc"
+      }
+      myLabel: while myVeryLongFirstCondition
+        && condition2 || condition3
+      {
+        let a = 123
+        var b = "abc"
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 29)
+  }
+
+  func testWhileLoopMultipleConditionElements() {
+    let input =
+      """
+      while x >= 0 && y >= 0 && x < foo && y < bar, let object = foo.value(at: y), let otherObject = foo.value(at: x), isEqual(a, b) {
+        foo()
+      }
+      while x >= 0 && y >= 0
+      && x < foo && y < bar,
+      let object =
+      foo.value(at: y),
+      let otherObject = foo.value(at: x), isEqual(a, b) {
+        foo()
+      }
+      """
+
+    let expected =
+      """
+      while x >= 0 && y >= 0
+        && x < foo && y < bar,
+        let object = foo.value(
+          at: y),
+        let otherObject =
+          foo.value(at: x),
+        isEqual(a, b)
+      {
+        foo()
+      }
+      while x >= 0 && y >= 0
+        && x < foo && y < bar,
+        let object =
+          foo.value(at: y),
+        let otherObject =
+          foo.value(at: x),
+        isEqual(a, b)
+      {
+        foo()
       }
 
       """

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -493,6 +493,7 @@ extension NewlineTests {
     static let __allTests__NewlineTests = [
         ("testLeadingNewlines", testLeadingNewlines),
         ("testLeadingNewlinesWithComments", testLeadingNewlinesWithComments),
+        ("testNewlinesBetweenMembers", testNewlinesBetweenMembers),
         ("testTrailingNewlines", testTrailingNewlines),
         ("testTrailingNewlinesWithComments", testTrailingNewlinesWithComments),
     ]
@@ -802,6 +803,7 @@ extension WhileStmtTests {
     static let __allTests__WhileStmtTests = [
         ("testBasicWhileLoops", testBasicWhileLoops),
         ("testLabeledWhileLoops", testLabeledWhileLoops),
+        ("testWhileLoopMultipleConditionElements", testWhileLoopMultipleConditionElements),
     ]
 }
 


### PR DESCRIPTION
This aligns the behavior of while-stmt and guard-stmt conditions. The while-stmt conditions didn't have open-breaks, which meant there was no additional indentation nor would continuation breaks be able to stack.

This means there's always a break before the first token of the condition element list when the while-stmt's condition is multiple lines. That is likely to cause some churn in existing code. An alternative would be to treat this like if-stmt, where there is no break after the while token.

## Issues
- This is likely to cause churn. I think we could minimize that by aligning with the if-stmt behavior, but I think it makes more sense to allow a break after `while`, like `guard`.