### PR TITLE
Add a consistent group around if-stmts.

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/IfStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/IfStmtTests.swift
@@ -381,7 +381,9 @@ final class IfStmtTests: PrettyPrintTestCase {
             SomeVeryLongTypeNameThatDefinitelyBreaks,
           baz: Baz
         ) = foo(a, b, c, d)
-      { return nil }
+      {
+        return nil
+      }
 
       """
 
@@ -514,5 +516,52 @@ final class IfStmtTests: PrettyPrintTestCase {
       """
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+  }
+
+  func testMultipleIfStmts() {
+    let input =
+      """
+      if foo && bar { baz() } else if bar { baz() } else if foo { baz() } else { blargh() }
+      if foo && bar && quxxe { baz() } else if bar { baz() } else if foo { baz() } else if quxxe { baz() } else { blargh() }
+      if let foo = getmyfoo(), let bar = getmybar(), foo.baz && bar.baz { foo() } else { bar() }
+      if let foo = getmyfoo(), let bar = getmybar(), foo.baz && bar.baz && someOtherCondition { foo() } else { bar() }
+      if let foo = getmyfoo(), let bar = getmybar(), foo.baz && bar.baz && someOtherCondition { foo() }
+      """
+
+    let expected =
+      """
+      if foo && bar { baz() } else if bar { baz() } else if foo { baz() } else { blargh() }
+      if foo && bar && quxxe {
+        baz()
+      } else if bar {
+        baz()
+      } else if foo {
+        baz()
+      } else if quxxe {
+        baz()
+      } else {
+        blargh()
+      }
+      if let foo = getmyfoo(), let bar = getmybar(), foo.baz && bar.baz {
+        foo()
+      } else {
+        bar()
+      }
+      if let foo = getmyfoo(), let bar = getmybar(),
+        foo.baz && bar.baz && someOtherCondition
+      {
+        foo()
+      } else {
+        bar()
+      }
+      if let foo = getmyfoo(), let bar = getmybar(),
+        foo.baz && bar.baz && someOtherCondition
+      {
+        foo()
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 85)
   }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -410,6 +410,7 @@ extension IfStmtTests {
         ("testIfStatement", testIfStatement),
         ("testLabeledIfStmt", testLabeledIfStmt),
         ("testMatchingPatternConditions", testMatchingPatternConditions),
+        ("testMultipleIfStmts", testMultipleIfStmts),
         ("testOptionalBindingConditions", testOptionalBindingConditions),
         ("testParenthesizedClauses", testParenthesizedClauses),
     ]


### PR DESCRIPTION
The consistent group forces the bodies of if-stmts with else clauses to have breaks around all braces when the stmt spans multiple lines. Previously. the breaks around the braces only fired if the body didn't fit on the line. That behavior lead to hard to read if-stmts because if was unclear where conditions stopped and the body started.