### PR TITLE
Disallow line breaks in completely empty array and dict exprs.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -733,8 +733,10 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: ArrayExprSyntax) -> SyntaxVisitorContinueKind {
-    after(node.leftSquare, tokens: .break(.open, size: 0), .open)
-    before(node.rightSquare, tokens: .break(.close, size: 0), .close)
+    if !node.elements.isEmpty || node.rightSquare.leadingTrivia.numberOfComments > 0 {
+      after(node.leftSquare, tokens: .break(.open, size: 0), .open)
+      before(node.rightSquare, tokens: .break(.close, size: 0), .close)
+    }
     return .visitChildren
   }
 
@@ -772,8 +774,15 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: DictionaryExprSyntax) -> SyntaxVisitorContinueKind {
-    after(node.leftSquare, tokens: .break(.open, size: 0), .open)
-    before(node.rightSquare, tokens: .break(.close, size: 0), .close)
+    // The node's content is either a `DictionaryElementListSyntax` or a `TokenSyntax` for a colon
+    // token (for an empty dictionary).
+    if !(node.content.as(DictionaryElementListSyntax.self)?.isEmpty ?? true)
+      || node.content.leadingTrivia?.numberOfComments ?? 0 > 0
+      || node.rightSquare.leadingTrivia.numberOfComments > 0
+    {
+      after(node.leftSquare, tokens: .break(.open, size: 0), .open)
+      before(node.rightSquare, tokens: .break(.close, size: 0), .close)
+    }
     return .visitChildren
   }
 

--- a/Tests/SwiftFormatPrettyPrintTests/ArrayDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ArrayDeclTests.swift
@@ -5,6 +5,12 @@ final class ArrayDeclTests: PrettyPrintTestCase {
   func testBasicArrays() {
     let input =
       """
+      let a = [ ]
+      let a = [
+      ]
+      let a = [
+        // Comment
+      ]
       let a = [1, 2, 3,]
       let a: [Bool] = [false, true, true, false]
       let a = [11111111, 2222222, 33333333, 4444444]
@@ -20,6 +26,11 @@ final class ArrayDeclTests: PrettyPrintTestCase {
 
     let expected =
       """
+      let a = []
+      let a = []
+      let a = [
+        // Comment
+      ]
       let a = [1, 2, 3]
       let a: [Bool] = [false, true, true, false]
       let a = [

--- a/Tests/SwiftFormatPrettyPrintTests/DictionaryDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/DictionaryDeclTests.swift
@@ -5,6 +5,15 @@ final class DictionaryDeclTests: PrettyPrintTestCase {
   func testBasicDictionaries() {
     let input =
       """
+      let a: [String: String] = [ : ]
+      let a: [String: String] = [
+      :
+      ]
+      let a: [String: String] = [
+      // Comment A
+      :
+      // Comment B
+      ]
       let a = [1: "a", 2: "b", 3: "c",]
       let a: [Int: String] = [1: "a", 2: "b", 3: "c"]
       let a = [10000: "abc", 20000: "def", 30000: "ghij"]
@@ -20,6 +29,13 @@ final class DictionaryDeclTests: PrettyPrintTestCase {
 
     let expected =
       """
+      let a: [String: String] = [:]
+      let a: [String: String] = [:]
+      let a: [String: String] = [
+        // Comment A
+        :
+        // Comment B
+      ]
       let a = [1: "a", 2: "b", 3: "c"]
       let a: [Int: String] = [1: "a", 2: "b", 3: "c"]
       let a = [


### PR DESCRIPTION
There's no reason to have a newline between the square brackets when there's nothing, other than a `:` for dict exprs, between the brackets.

Originally, I was making this change to mitigate a problem with indentation of this types of exprs in a function call. While this does fix the problem for arrays and dicts, it's not a suitable solution for closures. Regardless of future changes that would better mitigate the indentation problem, I think disallowing newlines in this contexts is an improvement.