### PR TITLE
Disallow discretionary newlines before trailing closures.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -855,7 +855,9 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       (node.trailingClosure != nil && !isCompactSingleFunctionCallArgument(arguments))
       || mustBreakBeforeClosingDelimiter(of: node, argumentListPath: \.argumentList)
 
-    before(node.trailingClosure?.leftBrace, tokens: .break(.same))
+    before(
+      node.trailingClosure?.leftBrace,
+      tokens: .break(.same, newlines: .elective(ignoresDiscretionary: true)))
 
     arrangeFunctionCallArgumentList(
       arguments,
@@ -1048,7 +1050,9 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       node.trailingClosure != nil
       || mustBreakBeforeClosingDelimiter(of: node, argumentListPath: \.argumentList)
 
-    before(node.trailingClosure?.leftBrace, tokens: .space)
+    before(
+      node.trailingClosure?.leftBrace,
+      tokens: .break(.same, newlines: .elective(ignoresDiscretionary: true)))
 
     arrangeFunctionCallArgumentList(
       arguments,

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
@@ -259,6 +259,55 @@ final class FunctionCallTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20)
   }
 
+  func testDiscretionaryLineBreakBeforeTrailingClosure() {
+    let input =
+      """
+      foo(a, b, c)
+      {
+        blah()
+      }
+      foo(
+        a, b, c
+      )
+      {
+        blah()
+      }
+      foo(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+      {
+        blah()
+      }
+      foo(ab, arg1, arg2) {
+        blah()
+      }
+      """
+
+    let expected =
+      """
+      foo(a, b, c) {
+        blah()
+      }
+      foo(
+        a, b, c
+      ) {
+        blah()
+      }
+      foo(
+        arg1, arg2, arg3,
+        arg4, arg5, arg6,
+        arg7
+      ) {
+        blah()
+      }
+      foo(ab, arg1, arg2)
+      {
+        blah()
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20)
+  }
+
   func testGroupsTrailingComma() {
     let input =
       """

--- a/Tests/SwiftFormatPrettyPrintTests/SubscriptExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/SubscriptExprTests.swift
@@ -106,4 +106,53 @@ final class SubscriptExprTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 70)
   }
+
+  func testDiscretionaryLineBreakBeforeTrailingClosure() {
+    let input =
+      """
+      foo[a, b, c]
+      {
+        blah()
+      }
+      foo[
+        a, b, c
+      ]
+      {
+        blah()
+      }
+      foo[arg1, arg2, arg3, arg4, arg5, arg6, arg7]
+      {
+        blah()
+      }
+      foo[ab, arg1, arg2] {
+        blah()
+      }
+      """
+
+    let expected =
+      """
+      foo[a, b, c] {
+        blah()
+      }
+      foo[
+        a, b, c
+      ] {
+        blah()
+      }
+      foo[
+        arg1, arg2, arg3,
+        arg4, arg5, arg6,
+        arg7
+      ] {
+        blah()
+      }
+      foo[ab, arg1, arg2]
+      {
+        blah()
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -298,6 +298,7 @@ extension FunctionCallTests {
         ("testBasicFunctionCalls_packArguments", testBasicFunctionCalls_packArguments),
         ("testDiscretionaryLineBreakAfterColon", testDiscretionaryLineBreakAfterColon),
         ("testDiscretionaryLineBreakBeforeClosingParenthesis", testDiscretionaryLineBreakBeforeClosingParenthesis),
+        ("testDiscretionaryLineBreakBeforeTrailingClosure", testDiscretionaryLineBreakBeforeTrailingClosure),
         ("testDiscretionaryLineBreaksAreSelfCorrecting", testDiscretionaryLineBreaksAreSelfCorrecting),
         ("testGroupsTrailingComma", testGroupsTrailingComma),
         ("testNestedFunctionCallExprSequences", testNestedFunctionCallExprSequences),
@@ -697,6 +698,7 @@ extension SubscriptExprTests {
     static let __allTests__SubscriptExprTests = [
         ("testBasicSubscriptGetters", testBasicSubscriptGetters),
         ("testBasicSubscriptSetters", testBasicSubscriptSetters),
+        ("testDiscretionaryLineBreakBeforeTrailingClosure", testDiscretionaryLineBreakBeforeTrailingClosure),
         ("testGroupsTrailingComma", testGroupsTrailingComma),
         ("testSubscriptGettersWithTrailingClosures", testSubscriptGettersWithTrailingClosures),
         ("testSubscriptSettersWithTrailingClosures", testSubscriptSettersWithTrailingClosures),


### PR DESCRIPTION
The behavior was inconsistent between subscripts and function calls. They both use a same-break that ignores discretionary newlines now.

The break ignores discretionary because breaking before a trailing closure's left brace uses excessive vertical whitespace without improving readability. Now the brace is usually glued to the right paren/right square bracket, except when it doesn't fit due to line length.