### PR TITLE
Handle derivative attr without params.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -2136,7 +2136,8 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       // `@transpose(...)` attribute.
       before(node.ofLabel, tokens: .open)
       after(node.colon, tokens: .break(.continue, newlines: .elective(ignoresDiscretionary: true)))
-      after(node.comma, tokens: .close)
+      // The comma after originalDeclName is optional and is only present if there are diffParams.
+      after(node.comma ?? node.originalDeclName.lastToken, tokens: .close)
 
       if let diffParams = node.diffParams {
         before(diffParams.firstToken, tokens: .break(.same), .open)

--- a/Tests/SwiftFormatPrettyPrintTests/DifferentiationAttributeTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/DifferentiationAttributeTests.swift
@@ -99,6 +99,9 @@ final class DifferentiationAttributeTests: PrettyPrintTestCase {
     #if HAS_DERIVATIVE_REGISTRATION_ATTRIBUTE
       let input =
         """
+        @derivative(of: foo)
+        func deriv<T>() {}
+
         @derivative(of: foo, wrt: x)
         func deriv<T>(_ x: T) {}
 
@@ -111,6 +114,9 @@ final class DifferentiationAttributeTests: PrettyPrintTestCase {
 
       let expected =
         """
+        @derivative(of: foo)
+        func deriv<T>() {}
+
         @derivative(of: foo, wrt: x)
         func deriv<T>(_ x: T) {}
 


### PR DESCRIPTION
Using `@derivative(of:...)` without a `wrt` clause previously crashed the formatter, due to an unmatched open token. Now the close token is added when there is no `wrt` clause too.