### PR TITLE
Add a test case for stacking open-breaks.

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/SwitchStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/SwitchStmtTests.swift
@@ -83,6 +83,7 @@ final class SwitchStmtTests: PrettyPrintTestCase {
       case "a": print("a")
       case "b", "c": print("bc")
       case "d", "e", "f", "g", "h": print("defgh")
+      case someVeryLongVarName, someOtherLongVarName: foo(a: [1, 2, 3, 4, 5])
       default: print("default")
       }
       """
@@ -96,6 +97,11 @@ final class SwitchStmtTests: PrettyPrintTestCase {
       case "d", "e", "f",
         "g", "h":
         print("defgh")
+      case someVeryLongVarName,
+        someOtherLongVarName:
+        foo(a: [
+          1, 2, 3, 4, 5,
+        ])
       default:
         print("default")
       }


### PR DESCRIPTION
This test case exercises the case where an open break occurs adjacent to a reset break when the reset break fires. This verifies that the open breaks stack indentation when they occur on the same line, but one of the breaks is at the start of the line.