### PR TITLE
Use real line number when moving block indentation for close breaks.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
@@ -359,11 +359,14 @@ public class PrettyPrinter {
           = openCloseBreakCompensatingLineNumber != matchingOpenBreak.lineNumber
 
         if matchingOpenBreak.contributesBlockIndent {
+          // The actual line number is used, instead of the compensating line number. When the close
+          // break is at the start of a new line, the block indentation isn't carried to the new line.
+          let currentLine = lineNumber
           // When two or more open breaks are encountered on the same line, only the final open
           // break is allowed to increase the block indent, avoiding multiple block indents. As the
           // open breaks on that line are closed, the new final open break must be enabled again to
           // add a block indent.
-          if matchingOpenBreak.lineNumber == openCloseBreakCompensatingLineNumber,
+          if matchingOpenBreak.lineNumber == currentLine,
             let lastActiveOpenBreak = activeOpenBreaks.last,
             lastActiveOpenBreak.kind == .block,
             !lastActiveOpenBreak.contributesBlockIndent

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
@@ -135,8 +135,16 @@ final class FunctionCallTests: PrettyPrintTestCase {
   func testArgumentStartsWithOpenDelimiter() {
     let input =
       """
+      myFunc(someArray: [
+      ])
       myFunc(someArray: [1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000])
+      myFunc(someDictionary: [
+      :])
       myFunc(someDictionary: ["foo": "bar", "baz": "quux", "gli": "glop"])
+      myFunc(someClosure: {
+      })
+      myFunc(someClosure: { (a, b, c) in
+      })
       myFunc(someClosure: { foo, bar in baz(1000, 2000, 3000, 4000, 5000) })
       myFunc(someArray: [1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000]) { foo in bar() }
       myFunc(someArray: [1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000]) { foo in someMuchLongerLineBreakingBarFunction() }
@@ -144,13 +152,19 @@ final class FunctionCallTests: PrettyPrintTestCase {
 
     let expected =
       """
+      myFunc(someArray: [])
       myFunc(someArray: [
         1000, 2000, 3000, 4000, 5000, 6000, 7000,
         8000,
       ])
+      myFunc(someDictionary: [:])
       myFunc(someDictionary: [
         "foo": "bar", "baz": "quux", "gli": "glop",
       ])
+      myFunc(someClosure: {
+      })
+      myFunc(someClosure: { (a, b, c) in
+      })
       myFunc(someClosure: { foo, bar in
         baz(1000, 2000, 3000, 4000, 5000)
       })


### PR DESCRIPTION
The previous behavior carried a block indent onto the current line when a close break occurred at the start of a line. That happened because of moving the block indentation between active open breaks. Whenever the close break occurs on a different line than the open break, even at the start of a line, it should dedent that line.