### PR TITLE
Move open group token past ifstmt's if token to avoid extra newlines.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1310,7 +1310,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     // This group applies to a top-level if-stmt so that all of the bodies will have the same
     // breaking behavior.
     if let ifStmt = node.item.as(IfStmtSyntax.self) {
-      before(ifStmt.firstToken, tokens: .open(.consistent))
+      before(ifStmt.conditions.firstToken, tokens: .open(.consistent))
       after(ifStmt.lastToken, tokens: .close)
     }
     return .visitChildren

--- a/Tests/SwiftFormatPrettyPrintTests/IfStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/IfStmtTests.swift
@@ -521,47 +521,51 @@ final class IfStmtTests: PrettyPrintTestCase {
   func testMultipleIfStmts() {
     let input =
       """
-      if foo && bar { baz() } else if bar { baz() } else if foo { baz() } else { blargh() }
-      if foo && bar && quxxe { baz() } else if bar { baz() } else if foo { baz() } else if quxxe { baz() } else { blargh() }
-      if let foo = getmyfoo(), let bar = getmybar(), foo.baz && bar.baz { foo() } else { bar() }
-      if let foo = getmyfoo(), let bar = getmybar(), foo.baz && bar.baz && someOtherCondition { foo() } else { bar() }
-      if let foo = getmyfoo(), let bar = getmybar(), foo.baz && bar.baz && someOtherCondition { foo() }
+      func foo() {
+        if foo && bar { baz() } else if bar { baz() } else if foo { baz() } else { blargh() }
+        if foo && bar && quxxe { baz() } else if bar { baz() } else if foo { baz() } else if quxxe { baz() } else { blargh() }
+        if let foo = getmyfoo(), let bar = getmybar(), foo.baz && bar.baz { foo() } else { bar() }
+        if let foo = getmyfoo(), let bar = getmybar(), foo.baz && bar.baz && someOtherCondition { foo() } else { bar() }
+        if let foo = getmyfoo(), let bar = getmybar(), foo.baz && bar.baz && someOtherCondition { foo() }
+      }
       """
 
     let expected =
       """
-      if foo && bar { baz() } else if bar { baz() } else if foo { baz() } else { blargh() }
-      if foo && bar && quxxe {
-        baz()
-      } else if bar {
-        baz()
-      } else if foo {
-        baz()
-      } else if quxxe {
-        baz()
-      } else {
-        blargh()
-      }
-      if let foo = getmyfoo(), let bar = getmybar(), foo.baz && bar.baz {
-        foo()
-      } else {
-        bar()
-      }
-      if let foo = getmyfoo(), let bar = getmybar(),
-        foo.baz && bar.baz && someOtherCondition
-      {
-        foo()
-      } else {
-        bar()
-      }
-      if let foo = getmyfoo(), let bar = getmybar(),
-        foo.baz && bar.baz && someOtherCondition
-      {
-        foo()
+      func foo() {
+        if foo && bar { baz() } else if bar { baz() } else if foo { baz() } else { blargh() }
+        if foo && bar && quxxe {
+          baz()
+        } else if bar {
+          baz()
+        } else if foo {
+          baz()
+        } else if quxxe {
+          baz()
+        } else {
+          blargh()
+        }
+        if let foo = getmyfoo(), let bar = getmybar(), foo.baz && bar.baz {
+          foo()
+        } else {
+          bar()
+        }
+        if let foo = getmyfoo(), let bar = getmybar(),
+          foo.baz && bar.baz && someOtherCondition
+        {
+          foo()
+        } else {
+          bar()
+        }
+        if let foo = getmyfoo(), let bar = getmybar(),
+          foo.baz && bar.baz && someOtherCondition
+        {
+          foo()
+        }
       }
 
       """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 85)
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 87)
   }
 }


### PR DESCRIPTION
The implementation of consistent groups forces breaking inside of the group if the group starts at the beginning of a line (i.e. was immediately preceded by a break that fired). That isn't exactly what we want for if-stmt because the stmt generally starts at the beginning of a line and we want the breaks to fire only if the group is longer than the rest of the line.

Moving the open token past the if `syntax` token resolves 2 known complexities with consistent groups:
1. Whether an immediately preceding break fired influences
2. The `spaceRemaining` value is only updated after printing the first `syntax` token on a new line

It's a little odd to group in this way, since it logically makes more sense to group around the entire if-stmt but there aren't any breaks between the if token and the first condition so moving the open token doesn't change the length of any breaks throughout the statement.