### PR TITLE
Updates for recent syntax/toolchain changes (2020-04-19).

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,9 +14,9 @@
         "package": "SwiftSyntax",
         "repositoryURL": "https://github.com/apple/swift-syntax",
         "state": {
-          "branch": null,
-          "revision": "0688b9cfc4c3dd234e4f55f1f056b2affc849873",
-          "version": "0.50200.0"
+          "branch": "swift-DEVELOPMENT-SNAPSHOT-2020-04-19-a",
+          "revision": "a03d5112d29259d099d72abc7314ec165c3a9dc3",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -21,8 +21,14 @@ let package = Package(
     .library(name: "SwiftFormatConfiguration", targets: ["SwiftFormatConfiguration"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax", from: "0.50200.0"),
-    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.0.4")),
+    .package(
+      url: "https://github.com/apple/swift-syntax",
+      .revision("swift-DEVELOPMENT-SNAPSHOT-2020-04-19-a")
+    ),
+    .package(
+      url: "https://github.com/apple/swift-argument-parser.git",
+      .upToNextMinor(from: "0.0.4")
+    ),
   ],
   targets: [
     .target(

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ is also expressed in the `SwiftSyntax` dependency in
 
 | Xcode Release | Swift Version                           | `swift-format` Branch |
 |:-------------:|:---------------------------------------:|:----------------------|
-| –             | swift-5.2-RELEASE                       | `master`              |
+| –             | swift-DEVELOPMENT-SNAPSHOT-2020-04-19-a | `master`              |
 | Xcode 11.4    | Swift 5.2                               | `swift-5.2-branch`    |
 | Xcode 11.0    | Swift 5.1                               | `swift-5.1-branch`    |
 
@@ -46,12 +46,14 @@ version of Swift or on a developer snapshot. Changes committed to `master`
 that are compatible with the latest release branch will be cherry-picked into
 that branch.
 
-To test that the formatter was built succesfully and is compatible with your swift toolchain, you can run the following command:
+To test that the formatter was built succesfully and is compatible with your
+Swift toolchain, you can run the following command:
 
 ```
 swift test --parallel
 ```
-We recommend using the `--parallel` flag to speed up the test run since there are a large number of tests.
+We recommend using the `--parallel` flag to speed up the test run since there
+are a large number of tests.
 
 ## Command Line Usage
 

--- a/Sources/SwiftFormatConfiguration/Configuration.swift
+++ b/Sources/SwiftFormatConfiguration/Configuration.swift
@@ -228,23 +228,6 @@ public struct Configuration: Codable, Equatable {
   }
 }
 
-/// Configuration for the NoPlaygroundLiterals rule.
-public struct NoPlaygroundLiteralsConfiguration: Codable, Equatable {
-  public enum ResolveBehavior: String, Codable {
-    /// If not sure, use `UIColor` to replace `#colorLiteral`.
-    case useUIColor
-
-    /// If not sure, use `NSColor` to replace `#colorLiteral`.
-    case useNSColor
-
-    /// If not sure, raise an error.
-    case error
-  }
-
-  /// Resolution behavior to use when encountering an ambiguous `#colorLiteral`.
-  public let resolveAmbiguousColor: ResolveBehavior = .useUIColor
-}
-
 /// Configuration for the `FileScopedDeclarationPrivacy` rule.
 public struct FileScopedDeclarationPrivacyConfiguration: Codable, Equatable {
   public enum AccessLevel: String, Codable {

--- a/Tests/SwiftFormatPrettyPrintTests/TryCatchTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/TryCatchTests.swift
@@ -173,4 +173,62 @@ final class TryCatchTests: PrettyPrintTestCase {
       """
     assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 45)
   }
+
+  func testMultipleCatchItems() {
+    let input =
+      """
+      do { try thisMightFail() } catch error1, error2 { print("Nope") }
+      do { try thisMightFail() } catch longErrorType, error2 { print("Nope") }
+      do { try thisMightFail() } catch longErrorTypeName, longErrorType2(let someLongVariable) { print("Nope") }
+      do { try thisMightFail() } catch longErrorTypeName, longErrorType2 as SomeLongErrorType { print("Nope") }
+      do { try thisMightFail() } catch longErrorName where someCondition, longErrorType2 { print("Nope") }
+      do { try thisMightFail() } catch longErrorTypeName, longErrorType2 as SomeLongErrorType where someCondition, longErrorType3 { print("Nope") }
+      """
+
+    let expected =
+      """
+      do {
+        try thisMightFail()
+      } catch error1, error2 {
+        print("Nope")
+      }
+      do {
+        try thisMightFail()
+      } catch longErrorType,
+        error2
+      { print("Nope") }
+      do {
+        try thisMightFail()
+      } catch
+        longErrorTypeName,
+        longErrorType2(
+          let someLongVariable)
+      { print("Nope") }
+      do {
+        try thisMightFail()
+      } catch
+        longErrorTypeName,
+        longErrorType2
+          as SomeLongErrorType
+      { print("Nope") }
+      do {
+        try thisMightFail()
+      } catch longErrorName
+        where someCondition,
+        longErrorType2
+      { print("Nope") }
+      do {
+        try thisMightFail()
+      } catch
+        longErrorTypeName,
+        longErrorType2
+          as SomeLongErrorType
+          where someCondition,
+        longErrorType3
+      { print("Nope") }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 25)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/XCTestManifests.swift
@@ -747,6 +747,7 @@ extension TryCatchTests {
         ("testCatchWhere_noBreakBeforeCatch", testCatchWhere_noBreakBeforeCatch),
         ("testDoTryCatch_breakBeforeCatch", testDoTryCatch_breakBeforeCatch),
         ("testDoTryCatch_noBreakBeforeCatch", testDoTryCatch_noBreakBeforeCatch),
+        ("testMultipleCatchItems", testMultipleCatchItems),
         ("testNestedDo", testNestedDo),
     ]
 }


### PR DESCRIPTION
- Remove differentiation nodes that no longer exist.
- Add support for multiple `catch` clauses (SE-0276).
- Remove a never-used configuration helper type that
  incorrectly used a `let`-with-initial-value, which
  recent toolchain snapshots now issue a warning for
  in `Decodable` types.

This PR moves the `master` branch up to require the
`swift-DEVELOPMENT-SNAPSHOT-2020-04-19-a` development
snapshot toolchain.