### PR TITLE
Add whitespaceOnly option to configuration file

### DIFF
--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -23,6 +23,10 @@ top-level keys and values:
     *   `tabs` _(number)_: One level of indentation is the given number of
         tabs.
 
+*   `whitespaceOnly` _(boolean)_: If true, only apply whitespace changes and
+    omit changes that insert or remove non-whitespace characters (like
+    trailing commas). Defaults to `false`.
+
 *   `tabWidth` _(number)_: The number of spaces that should be considered
     equivalent to one tab character. This is used during line length
     calculations when tabs are used for indentation.
@@ -93,6 +97,7 @@ An example `.swift-format` configuration file is shown below.
     "indentation": {
         "spaces": 2
     },
+    "whitespaceOnly": true,
     "maximumBlankLines": 1,
     "respectsExistingLineBreaks": true,
     "lineBreakBeforeControlFlowKeywords": true,

--- a/Sources/SwiftFormat/SwiftFormatter.swift
+++ b/Sources/SwiftFormat/SwiftFormatter.swift
@@ -113,7 +113,7 @@ public final class SwiftFormatter {
       operatorContext: operatorContext,
       node: transformedSyntax,
       printTokenStream: debugOptions.contains(.dumpTokenStream),
-      whitespaceOnly: false)
+      whitespaceOnly: configuration.whitespaceOnly)
     outputStream.write(printer.prettyPrint())
   }
 }

--- a/Sources/SwiftFormatConfiguration/Configuration.swift
+++ b/Sources/SwiftFormatConfiguration/Configuration.swift
@@ -25,6 +25,7 @@ public struct Configuration: Codable, Equatable {
     case lineLength
     case tabWidth
     case indentation
+    case whitespaceOnly
     case respectsExistingLineBreaks
     case lineBreakBeforeControlFlowKeywords
     case lineBreakBeforeEachArgument
@@ -60,6 +61,10 @@ public struct Configuration: Codable, Equatable {
   ///
   /// All indentation will be conducted in multiples of this configuration.
   public var indentation: Indent = .spaces(2)
+
+  /// When true, only whitespace (e.g. spaces, newlines) are modified. Text changes (e.g. add/remove
+  /// trailing commas) are not performed.
+  public var whitespaceOnly = false
 
   /// Indicates that the formatter should try to respect users' discretionary line breaks when
   /// possible.
@@ -157,6 +162,8 @@ public struct Configuration: Codable, Equatable {
     self.tabWidth = try container.decodeIfPresent(Int.self, forKey: .tabWidth) ?? 8
     self.indentation
       = try container.decodeIfPresent(Indent.self, forKey: .indentation) ?? .spaces(2)
+    self.whitespaceOnly
+      = try container.decodeIfPresent(Bool.self, forKey: .whitespaceOnly) ?? false
     self.respectsExistingLineBreaks
       = try container.decodeIfPresent(Bool.self, forKey: .respectsExistingLineBreaks) ?? true
     self.lineBreakBeforeControlFlowKeywords
@@ -193,6 +200,7 @@ public struct Configuration: Codable, Equatable {
     try container.encode(lineLength, forKey: .lineLength)
     try container.encode(tabWidth, forKey: .tabWidth)
     try container.encode(indentation, forKey: .indentation)
+    try container.encode(whitespaceOnly, forKey: .whitespaceOnly)
     try container.encode(respectsExistingLineBreaks, forKey: .respectsExistingLineBreaks)
     try container.encode(lineBreakBeforeControlFlowKeywords, forKey: .lineBreakBeforeControlFlowKeywords)
     try container.encode(lineBreakBeforeEachArgument, forKey: .lineBreakBeforeEachArgument)

--- a/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
@@ -546,14 +546,15 @@ public class PrettyPrinter {
         fatalError("Found trailing comma end with no corresponding start.")
       }
 
-      let shouldHaveTrailingComma = startLineNumber != openCloseBreakCompensatingLineNumber
-      if shouldHaveTrailingComma && !hasTrailingComma {
+      let shouldWriteComma = whitespaceOnly ? hasTrailingComma :
+        startLineNumber != openCloseBreakCompensatingLineNumber
+
+      if shouldWriteComma && !hasTrailingComma {
         diagnose(.addTrailingComma)
-      } else if !shouldHaveTrailingComma && hasTrailingComma {
+      } else if !shouldWriteComma && hasTrailingComma {
         diagnose(.removeTrailingComma)
       }
 
-      let shouldWriteComma = whitespaceOnly ? hasTrailingComma : shouldHaveTrailingComma
       if shouldWriteComma {
         write(",")
         spaceRemaining -= 1


### PR DESCRIPTION
Allows configuring whether formatter should add or remove trailing commas in lists.