### PR TITLE
Actually cache rule names.

### DIFF
--- a/Sources/SwiftFormatCore/Rule.swift
+++ b/Sources/SwiftFormatCore/Rule.swift
@@ -27,9 +27,12 @@ fileprivate var nameCache = [ObjectIdentifier: String]()
 extension Rule {
   /// By default, the `ruleName` is just the name of the implementing rule class.
   public static var ruleName: String {
-    return nameCache[
-      ObjectIdentifier(self),
-      default: String("\(self)".split(separator: ".").last!)
-    ]
+    let identifier = ObjectIdentifier(self)
+    if let cachedName = nameCache[identifier] {
+      return cachedName
+    }
+    let name = String("\(self)".split(separator: ".").last!)
+    nameCache[identifier] = name
+    return name
   }
 }


### PR DESCRIPTION
The `nameCache` for rule names wasn't actually ever storing any rule names, so the cache hit rate was pretty low. Now rule names are stored in the cache and the hit rate is much better.

I tested this by formatting the swift-protobuf library.
- Before: average 56.7 seconds
- After: average 24.3 seconds