### PR TITLE
Use string based SourceLocationConverter init because it's faster.

### DIFF
--- a/Sources/SwiftFormatCore/Context.swift
+++ b/Sources/SwiftFormatCore/Context.swift
@@ -57,14 +57,16 @@ public class Context {
     configuration: Configuration,
     diagnosticEngine: DiagnosticEngine?,
     fileURL: URL,
-    sourceFileSyntax: SourceFileSyntax
+    sourceFileSyntax: SourceFileSyntax,
+    source: String? = nil
   ) {
     self.configuration = configuration
     self.diagnosticEngine = diagnosticEngine
     self.fileURL = fileURL
     self.importsXCTest = .notDetermined
-    self.sourceLocationConverter = SourceLocationConverter(
-      file: fileURL.path, tree: sourceFileSyntax)
+    self.sourceLocationConverter =
+      source.map { SourceLocationConverter(file: fileURL.path, source: $0) }
+      ?? SourceLocationConverter(file: fileURL.path, tree: sourceFileSyntax)
     self.ruleMask = RuleMask(
       syntaxNode: Syntax(sourceFileSyntax),
       sourceLocationConverter: sourceLocationConverter


### PR DESCRIPTION
I'm not sure why, but the string based initializer for `SourceLocationConverter` is substantially faster than the syntax tree based initializer.

The impact is a few hundred ms per file, so it is substantial when formatting many files.

Results:
- swift-protobuf 21.4 seconds before, 17.9 seconds after
- 10k LOC file - 2.5 seconds before, 2.2 seconds after