### PR TITLE
Correct version string for `--version` flag (swift-5.2-branch)

### DIFF
--- a/Sources/swift-format/VersionOptions.swift
+++ b/Sources/swift-format/VersionOptions.swift
@@ -19,8 +19,8 @@ struct VersionOptions: ParsableArguments {
 
   func validate() throws {
     if version {
-      // TODO: Use a real version number here.
-      print("0.0.1")
+      // TODO: Automate updates to this somehow.
+      print("0.50200.1")
       throw ExitCode.success
     }
   }


### PR DESCRIPTION
This is going to be a pain to keep bumping for every release, but this change at least gets the correct version in for now.