### PR TITLE
Correct version string for `--version` flag (master)

### DIFF
--- a/Sources/swift-format/VersionOptions.swift
+++ b/Sources/swift-format/VersionOptions.swift
@@ -19,8 +19,8 @@ struct VersionOptions: ParsableArguments {
 
   func validate() throws {
     if version {
-      // TODO: Use a real version number here.
-      print("0.0.1")
+      // TODO: Automate updates to this somehow.
+      print("0.50200.1")
       throw ExitCode.success
     }
   }


### PR DESCRIPTION
This is going to be a pain to keep bumping for every release, but this change at least gets the correct version in for now.

Feel free to close this or #201 if you don't feel both are necessary, but since it seems like you'd cherry pick this commit anyway between the branches, I figured I'd save you some time and make them separate PRs.