### PR TITLE
Correct version string for `--version` flag (swift-5.1-branch)

### DIFF
--- a/Sources/swift-format/main.swift
+++ b/Sources/swift-format/main.swift
@@ -56,7 +56,7 @@ fileprivate func main(_ arguments: [String]) -> Int32 {
     dumpDefaultConfiguration()
     return 0
   case .version:
-    print("0.0.1")  // TODO: Automate updates to this somehow.
+    print("0.50100.0")  // TODO: Automate updates to this somehow.
     return 0
   }
 }


### PR DESCRIPTION
This is going to be a pain to keep bumping for every release, but this change at least gets the correct version in for now.

I'm guessing at a version here based on the 5.2-related versioning scheme, but I feel like it's important to have something beyond `0.0.1` to indicate what version it is for testing purposes. Feel free to close though if you think this isn't necessary.