### PR TITLE
Add portable Darwin build

### DIFF
--- a/Scripts/package-darwin.sh
+++ b/Scripts/package-darwin.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+BUILD_PATH=.build/release
+LIB_PATH=$BUILD_PATH/lib
+BIN_PATH=$BUILD_PATH/bin/swift-format
+SWIFT_PATH=$(xcrun --find swift)
+
+swift build --configuration release --disable-sandbox
+rm -rf $LIB_PATH
+rm -rf $BIN_PATH
+mkdir -p $LIB_PATH
+mkdir -p $BUILD_PATH/bin
+cp .build/release/swift-format $BIN_PATH
+cp "$(dirname $SWIFT_PATH)/../lib/swift/macosx/lib_InternalSwiftSyntaxParser.dylib" $LIB_PATH/lib_InternalSwiftSyntaxParser.dylib
+install_name_tool -add_rpath @executable_path/../lib $BIN_PATH
+tar -C $BUILD_PATH -czf swift-format.tar.gz bin lib
+mv swift-format.tar.gz .build


### PR DESCRIPTION
I use this script for distributing [DrString][], which also depends on `lib_InternalSwiftSyntaxParser.dylib`.

Summary of approach: 

1. distribute a copy of `lib_InternalSwiftSyntaxParser.dylib`
2. modify the main executable's rpath to include the copy's relative path. 

This ensures the .dylib is always compatible with the executable. The resulting .tar.gz can be unpacked into, say, the Homebrew installation folders. And users no longer need the "right" Xcode release to run `swift-format`.

[DrString]: https://github.com/dduan/DrString/blob/master/Scripts/package-darwin.sh