### PR TITLE
[SR-13194] DoNotUseSemicolons should not strip semicolons which separate a 'do' blocks from 'while' blocks.

### DIFF
--- a/Tests/SwiftFormatRulesTests/DoNotUseSemicolonsTests.swift
+++ b/Tests/SwiftFormatRulesTests/DoNotUseSemicolonsTests.swift
@@ -89,4 +89,41 @@ final class DoNotUseSemicolonsTests: LintOrFormatRuleTestCase {
                 print("7")
                 """)
   }
+  
+  func testSemicolonsSeparatingDoWhile() {
+    XCTAssertFormatting(
+      DoNotUseSemicolons.self,
+      input: """
+             do { f() };
+             while someCondition { g() }
+
+             do {
+               f()
+             };
+
+             // Comment and whitespace separating blocks.
+             while someCondition {
+               g()
+             }
+
+             do { f() };
+             for _ in 0..<10 { g() }
+             """,
+      expected: """
+                do { f() };
+                while someCondition { g() }
+
+                do {
+                  f()
+                };
+
+                // Comment and whitespace separating blocks.
+                while someCondition {
+                  g()
+                }
+
+                do { f() }
+                for _ in 0..<10 { g() }
+                """)
+  }
 }


### PR DESCRIPTION
This semi-colon is required, and removing it breaks code.

I've never used the syntax APIs before, so not sure if this is the right way to do it, but it works.

Fixes SR-13194.