### PR TITLE
Remove trailing spaces from comments and keep spaces after block comments.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -2730,10 +2730,15 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       case .blockComment(let text):
         if index > 0 || isStartOfFile {
           appendToken(.comment(Comment(kind: .block, text: text), wasEndOfLine: false))
-          // We place a size-0 break after the comment to allow a discretionary newline after the
-          // comment if the user places one here but the comment is otherwise adjacent to a text
-          // token.
-          appendToken(.break(.same, size: 0))
+          // There is always a break after the comment to allow a discretionary newline after it.
+          var breakSize = 0
+          if index + 1 < trivia.endIndex {
+            let nextPiece = trivia[index + 1]
+            // The original number of spaces is intentionally discarded, but 1 space is allowed in
+            // case the comment is followed by another token instead of a newline.
+            if case .spaces = nextPiece { breakSize = 1 }
+          }
+          appendToken(.break(.same, size: breakSize))
           isStartOfFile = false
         }
         requiresNextNewline = false

--- a/Tests/SwiftFormatPrettyPrintTests/CommentTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/CommentTests.swift
@@ -639,5 +639,47 @@ final class CommentTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 100)
   }
 
+  func testTrailingSpacesInComments() {
+    // Xcode has a commonly enabled setting to delete trailing spaces, which also applies to
+    // multi-line strings. The trailing spaces are intentionally written using a unicode escape
+    // sequence to ensure they aren't deleted.
+    let input = """
+      /// This is a trailing space documentation comment.\u{0020}\u{0020}\u{0020}\u{0020}\u{0020}
+      ///        This is a leading space documentation comment.
+      func foo() {
+        //       leading spaces are fine
+        // trailing spaces should go\u{0020}\u{0020}\u{0020}\u{0020}\u{0020}
+        let out = "123"
+      }
 
+      /**
+       *    This is a leading space doc block comment
+       * This is a trailing space doc block comment\u{0020}\u{0020}\u{0020}\u{0020}\u{0020}
+       */
+      func foo() {
+        /*    block comment    */ let out = "123"
+      }
+      """
+
+    let expected = """
+      /// This is a trailing space documentation comment.
+      ///        This is a leading space documentation comment.
+      func foo() {
+        //       leading spaces are fine
+        // trailing spaces should go
+        let out = "123"
+      }
+
+      /**
+       *    This is a leading space doc block comment
+       * This is a trailing space doc block comment
+       */
+      func foo() {
+        /*    block comment    */ let out = "123"
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 60)
+  }
 }


### PR DESCRIPTION
This has 2 fixes for comments:
1. Removes trailing spaces at the end of each line in all types of comments. Note that spaces before the `*/` to end a block comment aren't removed.
2. Keeps spaces after `*/` of a block comment if it is inline with another token (e.g. `/* blah */ foo = bar`).