### PR TITLE
Add support for Throws doc comments

### DIFF
--- a/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
@@ -24,12 +24,12 @@ public final class ValidateDocumentationComments: SyntaxLintRule {
 
   public override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
     return checkFunctionLikeDocumentation(
-      DeclSyntax(node), name: "init", parameters: node.parameters.parameterList)
+      DeclSyntax(node), name: "init", parameters: node.parameters.parameterList, throwsOrRethrowsKeyword: node.throwsOrRethrowsKeyword)
   }
 
   public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
     return checkFunctionLikeDocumentation(
-      DeclSyntax(node), name: node.identifier.text, parameters: node.signature.input.parameterList,
+      DeclSyntax(node), name: node.identifier.text, parameters: node.signature.input.parameterList, throwsOrRethrowsKeyword: node.signature.throwsOrRethrowsKeyword,
       returnClause: node.signature.output)
   }
 
@@ -37,6 +37,7 @@ public final class ValidateDocumentationComments: SyntaxLintRule {
     _ node: DeclSyntax,
     name: String,
     parameters: FunctionParameterListSyntax,
+    throwsOrRethrowsKeyword: TokenSyntax?,
     returnClause: ReturnClauseSyntax? = nil
   ) -> SyntaxVisitorContinueKind {
     guard let declComment = node.docComment else { return .skipChildren }
@@ -57,6 +58,7 @@ public final class ValidateDocumentationComments: SyntaxLintRule {
       $0.trimmingCharacters(in: .whitespaces).starts(with: "- Parameters")
     }
 
+    validateThrows(throwsOrRethrowsKeyword, name: name, throwsDesc: commentInfo.throwsDescription)
     validateReturn(returnClause, name: name, returnDesc: commentInfo.returnsDescription)
     let funcParameters = funcParametersIdentifiers(in: parameters)
 
@@ -95,6 +97,21 @@ public final class ValidateDocumentationComments: SyntaxLintRule {
       diagnose(.documentReturnValue(funcName: name), on: returnClause)
     }
   }
+
+  /// Ensures the function has throws documentation if it may actually throw
+  /// an error.
+  private func validateThrows(
+    _ throwsOrRethrowsKeyword: TokenSyntax?,
+    name: String,
+    throwsDesc: String?
+  ) {
+    if throwsOrRethrowsKeyword == nil && throwsDesc != nil {
+      diagnose(.removeThrowsComment(funcName: name), on: throwsOrRethrowsKeyword)
+    } else if throwsOrRethrowsKeyword != nil && throwsDesc == nil {
+      diagnose(.documentErrorsThrown(funcName: name), on: throwsOrRethrowsKeyword)
+    }
+  }
+
 }
 
 /// Iterates through every parameter of paramList and returns a list of the
@@ -153,4 +170,15 @@ extension Diagnostic.Message {
     "replace the singular inline form of 'Parameter' tag with a plural 'Parameters' tag "
       + "and group each parameter as a nested list"
   )
+
+  public static func removeThrowsComment(funcName: String) -> Diagnostic.Message {
+    return Diagnostic.Message(
+      .warning,
+      "remove the throws comment of \(funcName), it doesn't throw an error"
+    )
+  }
+
+  public static func documentErrorsThrown(funcName: String) -> Diagnostic.Message {
+    return Diagnostic.Message(.warning, "document the errors thrown by \(funcName)")
+  }
 }

--- a/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
@@ -105,9 +105,11 @@ public final class ValidateDocumentationComments: SyntaxLintRule {
     name: String,
     throwsDesc: String?
   ) {
-    if throwsOrRethrowsKeyword == nil && throwsDesc != nil {
+    let needsThrowsDesc = throwsOrRethrowsKeyword != nil && throwsOrRethrowsKeyword!.tokenKind == .throwsKeyword
+
+    if !needsThrowsDesc && throwsDesc != nil {
       diagnose(.removeThrowsComment(funcName: name), on: throwsOrRethrowsKeyword)
-    } else if throwsOrRethrowsKeyword != nil && throwsDesc == nil {
+    } else if needsThrowsDesc && throwsDesc == nil {
       diagnose(.documentErrorsThrown(funcName: name), on: throwsOrRethrowsKeyword)
     }
   }

--- a/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
@@ -105,7 +105,10 @@ public final class ValidateDocumentationComments: SyntaxLintRule {
     name: String,
     throwsDesc: String?
   ) {
-    let needsThrowsDesc = throwsOrRethrowsKeyword != nil && throwsOrRethrowsKeyword!.tokenKind == .throwsKeyword
+    // If a function is marked as `rethrows`, it doesn't have any errors of its
+    // own that should be documented. So only require documentation for
+    // functions marked `throws`.
+    let needsThrowsDesc = throwsOrRethrowsKeyword?.tokenKind == .throwsKeyword
 
     if !needsThrowsDesc && throwsDesc != nil {
       diagnose(.removeThrowsComment(funcName: name), on: throwsOrRethrowsKeyword)
@@ -175,11 +178,14 @@ extension Diagnostic.Message {
   public static func removeThrowsComment(funcName: String) -> Diagnostic.Message {
     return Diagnostic.Message(
       .warning,
-      "remove the throws comment of \(funcName), it doesn't throw an error"
+      "remove the 'Throws' tag for non-throwing function \(funcName)"
     )
   }
 
   public static func documentErrorsThrown(funcName: String) -> Diagnostic.Message {
-    return Diagnostic.Message(.warning, "document the errors thrown by \(funcName)")
+    return Diagnostic.Message(
+      .warning,
+      "add a 'Throws' tag describing the errors thrown by \(funcName)"
+    )
   }
 }

--- a/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
@@ -111,7 +111,6 @@ public final class ValidateDocumentationComments: SyntaxLintRule {
       diagnose(.documentErrorsThrown(funcName: name), on: throwsOrRethrowsKeyword)
     }
   }
-
 }
 
 /// Iterates through every parameter of paramList and returns a list of the

--- a/Tests/SwiftFormatRulesTests/ValidateDocumentationCommentsTests.swift
+++ b/Tests/SwiftFormatRulesTests/ValidateDocumentationCommentsTests.swift
@@ -61,6 +61,31 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
     XCTAssertDiagnosed(.parametersDontMatch(funcName: "foo"))
   }
 
+  func testThrowsDocumentation() {
+    let input =
+    """
+    /// One sentence summary.
+    ///
+    /// - Parameters:
+    ///   - p1: Parameter 1.
+    ///   - p2: Parameter 2.
+    ///   - p3: Parameter 3.
+    /// - Throws: an error.
+    func noThrows(p1: Int, p2: Int, p3: Int) {}
+
+    /// One sentence summary.
+    ///
+    /// - Parameters:
+    ///   - p1: Parameter 1.
+    ///   - p2: Parameter 2.
+    ///   - p3: Parameter 3.
+    func foo(p1: Int, p2: Int, p3: Int) throws {}
+    """
+    performLint(ValidateDocumentationComments.self, input: input)
+    XCTAssertDiagnosed(.removeThrowsComment(funcName: "noThrows"))
+    XCTAssertDiagnosed(.documentErrorsThrown(funcName: "foo"))
+  }
+
   func testReturnDocumentation() {
     let input =
     """

--- a/Tests/SwiftFormatRulesTests/ValidateDocumentationCommentsTests.swift
+++ b/Tests/SwiftFormatRulesTests/ValidateDocumentationCommentsTests.swift
@@ -129,9 +129,10 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
     /// - Parameters:
     ///   - command: The command to execute in the shell environment.
     ///   - stdin: The string to use as standard input.
+    /// - Throws: An error, possibly.
     /// - Returns: A string containing the contents of the invoked process's
     ///   standard output.
-    func pluralParam(command: String, stdin: String) -> String {
+    func pluralParam(command: String, stdin: String) throws -> String {
     // ...
     }
 
@@ -151,6 +152,8 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
     XCTAssertNotDiagnosed(.documentReturnValue(funcName: "pluralParam"))
     XCTAssertNotDiagnosed(.removeReturnComment(funcName: "pluralParam"))
     XCTAssertNotDiagnosed(.parametersDontMatch(funcName: "pluralParam"))
+    XCTAssertNotDiagnosed(.documentErrorsThrown(funcName: "pluralParam"))
+    XCTAssertNotDiagnosed(.removeThrowsComment(funcName: "pluralParam"))
 
     XCTAssertNotDiagnosed(.documentReturnValue(funcName: "ommitedFunc"))
     XCTAssertNotDiagnosed(.removeReturnComment(funcName: "ommitedFunc"))
@@ -232,6 +235,16 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
       init(label command: String, label2 stdin: String) {
       // ...
       }
+
+      /// Brief summary.
+      ///
+      /// - Parameters:
+      ///   - command: The command to execute in the shell environment.
+      ///   - stdin: The string to use as standard input.
+      /// - Throws: An error.
+      init(label command: String, label2 stdin: String) throws {
+      // ...
+      }
     }
     """
     performLint(ValidateDocumentationComments.self, input: input)
@@ -248,5 +261,11 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
     XCTAssertNotDiagnosed(.documentReturnValue(funcName: "init"))
     XCTAssertNotDiagnosed(.removeReturnComment(funcName: "init"))
     XCTAssertNotDiagnosed(.parametersDontMatch(funcName: "init"))
+
+    XCTAssertNotDiagnosed(.documentReturnValue(funcName: "init"))
+    XCTAssertNotDiagnosed(.removeReturnComment(funcName: "init"))
+    XCTAssertNotDiagnosed(.parametersDontMatch(funcName: "init"))
+    XCTAssertNotDiagnosed(.documentErrorsThrown(funcName: "init"))
+    XCTAssertNotDiagnosed(.removeThrowsComment(funcName: "init"))
   }
 }

--- a/Tests/SwiftFormatRulesTests/ValidateDocumentationCommentsTests.swift
+++ b/Tests/SwiftFormatRulesTests/ValidateDocumentationCommentsTests.swift
@@ -71,7 +71,7 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
     ///   - p2: Parameter 2.
     ///   - p3: Parameter 3.
     /// - Throws: an error.
-    func noThrows(p1: Int, p2: Int, p3: Int) {}
+    func doesNotThrow(p1: Int, p2: Int, p3: Int) {}
 
     /// One sentence summary.
     ///
@@ -79,11 +79,18 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
     ///   - p1: Parameter 1.
     ///   - p2: Parameter 2.
     ///   - p3: Parameter 3.
-    func foo(p1: Int, p2: Int, p3: Int) throws {}
+    func doesThrow(p1: Int, p2: Int, p3: Int) throws {}
+
+    /// One sentence summary.
+    ///
+    /// - Parameter p1: Parameter 1.
+    /// - Throws: doesn't really throw, just rethrows
+    func doesRethrow(p1: (() throws -> ())) rethrows {}
     """
     performLint(ValidateDocumentationComments.self, input: input)
-    XCTAssertDiagnosed(.removeThrowsComment(funcName: "noThrows"))
-    XCTAssertDiagnosed(.documentErrorsThrown(funcName: "foo"))
+    XCTAssertDiagnosed(.removeThrowsComment(funcName: "doesNotThrow"))
+    XCTAssertDiagnosed(.documentErrorsThrown(funcName: "doesThrow"))
+    XCTAssertDiagnosed(.removeThrowsComment(funcName: "doesRethrow"))
   }
 
   func testReturnDocumentation() {
@@ -136,6 +143,13 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
     // ...
     }
 
+    /// One sentence summary.
+    ///
+    /// - Parameter p1: Parameter 1.
+    func rethrower(p1: (() throws -> ())) rethrows {
+    // ...
+    }
+
     /// Parameter(s) and Returns tags may be omitted only if the single-sentence
     /// brief summary fully describes the meaning of those items and including the
     /// tags would only repeat what has already been said
@@ -152,6 +166,9 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
     XCTAssertNotDiagnosed(.documentReturnValue(funcName: "pluralParam"))
     XCTAssertNotDiagnosed(.removeReturnComment(funcName: "pluralParam"))
     XCTAssertNotDiagnosed(.parametersDontMatch(funcName: "pluralParam"))
+    XCTAssertNotDiagnosed(.documentErrorsThrown(funcName: "pluralParam"))
+    XCTAssertNotDiagnosed(.removeThrowsComment(funcName: "pluralParam"))
+
     XCTAssertNotDiagnosed(.documentErrorsThrown(funcName: "pluralParam"))
     XCTAssertNotDiagnosed(.removeThrowsComment(funcName: "pluralParam"))
 

--- a/Tests/SwiftFormatRulesTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatRulesTests/XCTestManifests.swift
@@ -398,6 +398,7 @@ extension ValidateDocumentationCommentsTests {
         ("testInitializer", testInitializer),
         ("testParameterDocumentation", testParameterDocumentation),
         ("testParametersName", testParametersName),
+        ("testThrowsDocumentation", testThrowsDocumentation),
         ("testReturnDocumentation", testReturnDocumentation),
         ("testSeparateLabelAndIdentifier", testSeparateLabelAndIdentifier),
         ("testValidDocumentation", testValidDocumentation),


### PR DESCRIPTION
Adding a `- Throws:` declaration to a doc comment on a method with multiple parameters is causing a linting error. 

This PR adds support to parse throws documentation and will ensure that it is present on throwing functions/initializers and absent on non-throwing or rethrowing ones. 

I'm a little unsure of the comment declaration parsing code so some extra scrutiny is especially welcome there. 