### PR TITLE
Group the try keyword with a relevant portion of its expression.

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/TryCatchTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/TryCatchTests.swift
@@ -231,4 +231,46 @@ final class TryCatchTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 25)
   }
+
+  func testTryKeywordBreaking() {
+    let input =
+      """
+      let aVeryLongArgumentName = try foo.bar()
+      let aVeryLongArgumentName = try? foo.bar()
+      let abc = try foo.baz().quxxe(a, b, c).bar()
+      let abc = try foo
+        .baz().quxxe(a, b, c).bar()
+      let abc = try [1, 2, 3, 4, 5, 6, 7].baz().quxxe(a, b, c).bar()
+      let abc = try [1, 2, 3, 4, 5, 6, 7]
+        .baz().quxxe(a, b, c).bar()
+      let abc = try foo.baz().quxxe(a, b, c).bar[0]
+      let abc = try foo
+        .baz().quxxe(a, b, c).bar[0]
+      """
+
+    let expected =
+      """
+      let aVeryLongArgumentName =
+        try foo.bar()
+      let aVeryLongArgumentName =
+        try? foo.bar()
+      let abc = try foo.baz().quxxe(a, b, c)
+        .bar()
+      let abc =
+        try foo
+        .baz().quxxe(a, b, c).bar()
+      let abc = try [1, 2, 3, 4, 5, 6, 7]
+        .baz().quxxe(a, b, c).bar()
+      let abc = try [1, 2, 3, 4, 5, 6, 7]
+        .baz().quxxe(a, b, c).bar()
+      let abc = try foo.baz().quxxe(a, b, c)
+        .bar[0]
+      let abc =
+        try foo
+        .baz().quxxe(a, b, c).bar[0]
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
+  }
 }


### PR DESCRIPTION
This keeps the try keyword and a portion of the expression that may throw on the same line, when possible. Previously, the group around certain member access exprs would result in frequently breaking after the keyword. That group is replaced by a group that starts at the try keyword now instead.

There is some preexisting inconsistency between breaking before `MemberAccessExpr` where the base is an `IdentifierExpr` vs other types of expressions. I'm hesitant to make changes to that behavior as part of this fix for try expressions, but it might be worth visiting.