### PR TITLE
Trim trivia from node descriptions used in diagnostics.

### DIFF
--- a/Sources/SwiftFormatRules/NeverForceUnwrap.swift
+++ b/Sources/SwiftFormatRules/NeverForceUnwrap.swift
@@ -26,7 +26,7 @@ public final class NeverForceUnwrap: SyntaxLintRule {
 
   public override func visit(_ node: ForcedValueExprSyntax) -> SyntaxVisitorContinueKind {
     guard context.importsXCTest == .doesNotImportXCTest else { return .skipChildren }
-    diagnose(.doNotForceUnwrap(name: node.expression.description), on: node)
+    diagnose(.doNotForceUnwrap(name: node.expression.withoutTrivia().description), on: node)
     return .skipChildren
   }
 
@@ -36,7 +36,7 @@ public final class NeverForceUnwrap: SyntaxLintRule {
     guard context.importsXCTest == .doesNotImportXCTest else { return .skipChildren }
     guard let questionOrExclamation = node.questionOrExclamationMark else { return .skipChildren }
     guard questionOrExclamation.tokenKind == .exclamationMark else { return .skipChildren }
-    diagnose(.doNotForceCast(name: node.typeName.description), on: node)
+    diagnose(.doNotForceCast(name: node.typeName.withoutTrivia().description), on: node)
     return .skipChildren
   }
 }

--- a/Sources/SwiftFormatRules/NeverUseImplicitlyUnwrappedOptionals.swift
+++ b/Sources/SwiftFormatRules/NeverUseImplicitlyUnwrappedOptionals.swift
@@ -51,7 +51,9 @@ public final class NeverUseImplicitlyUnwrappedOptionals: SyntaxLintRule {
 
   private func diagnoseImplicitWrapViolation(_ type: TypeSyntax) {
     guard let violation = type.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) else { return }
-    diagnose(.doNotUseImplicitUnwrapping(identifier: "\(violation.wrappedType)"), on: type)
+    diagnose(
+      .doNotUseImplicitUnwrapping(
+        identifier: violation.wrappedType.withoutTrivia().description), on: type)
   }
 }
 

--- a/Sources/SwiftFormatRules/NoCasesWithOnlyFallthrough.swift
+++ b/Sources/SwiftFormatRules/NoCasesWithOnlyFallthrough.swift
@@ -45,7 +45,8 @@ public final class NoCasesWithOnlyFallthrough: SyntaxFormatRule {
 
       if isFallthroughOnly(switchCase), let label = switchCase.label.as(SwitchCaseLabelSyntax.self) {
         // If the case is fallthrough-only, store it as a violation that we will merge later.
-        diagnose(.collapseCase(name: "\(label)"), on: switchCase)
+        diagnose(
+          .collapseCase(name: label.caseItems.withoutTrivia().description), on: switchCase)
         fallthroughOnlyCases.append(switchCase)
       } else {
         guard !fallthroughOnlyCases.isEmpty else {

--- a/Sources/SwiftFormatRules/NoLabelsInCasePatterns.swift
+++ b/Sources/SwiftFormatRules/NoLabelsInCasePatterns.swift
@@ -50,7 +50,7 @@ public final class NoLabelsInCasePatterns: SyntaxFormatRule {
         }
 
         // Remove label if it's the same as the value identifier
-        let name = valueBinding.valuePattern.description.trimmingCharacters(in: .whitespaces)
+        let name = valueBinding.valuePattern.withoutTrivia().description
         guard name == label.text else {
           newArgs.append(argument)
           continue

--- a/Tests/SwiftFormatRulesTests/NeverForceUnwrapTests.swift
+++ b/Tests/SwiftFormatRulesTests/NeverForceUnwrapTests.swift
@@ -10,6 +10,8 @@ final class NeverForceUnwrapTests: LintOrFormatRuleTestCase {
       let c = (someValue())!
       let d = String(a)!
       let regex = try! NSRegularExpression(pattern: "a*b+c?")
+      let e = /*comment about stuff*/ [1: a, 2: b, 3: c][4]!
+      var f = a as! /*comment about this type*/ FooBarType
       return a!
     }
     """
@@ -20,6 +22,8 @@ final class NeverForceUnwrapTests: LintOrFormatRuleTestCase {
     XCTAssertNotDiagnosed(.doNotForceCast(name: "try"))
     XCTAssertNotDiagnosed(.doNotForceUnwrap(name: "try"))
     XCTAssertDiagnosed(.doNotForceUnwrap(name: "a"))
+    XCTAssertDiagnosed(.doNotForceUnwrap(name: "[1: a, 2: b, 3: c][4]"))
+    XCTAssertDiagnosed(.doNotForceCast(name: "FooBarType"))
   }
 
   func testIgnoreTestCode() {

--- a/Tests/SwiftFormatRulesTests/NeverUseImplicitlyUnwrappedOptionalsTests.swift
+++ b/Tests/SwiftFormatRulesTests/NeverUseImplicitlyUnwrappedOptionalsTests.swift
@@ -10,12 +10,14 @@ final class NeverUseImplicitlyUnwrappedOptionalsTests: LintOrFormatRuleTestCase 
 
       var foo: Int?
       var s: String!
+      var f: /*this is a Foo*/Foo!
       var c, d, e: Float
       @IBOutlet var button: UIButton!
       """
     performLint(NeverUseImplicitlyUnwrappedOptionals.self, input: input)
     XCTAssertNotDiagnosed(.doNotUseImplicitUnwrapping(identifier: "Int"))
     XCTAssertDiagnosed(.doNotUseImplicitUnwrapping(identifier: "String"))
+    XCTAssertDiagnosed(.doNotUseImplicitUnwrapping(identifier: "Foo"))
     XCTAssertNotDiagnosed(.doNotUseImplicitUnwrapping(identifier: "Float"))
     XCTAssertNotDiagnosed(.doNotUseImplicitUnwrapping(identifier: "UIButton"))
   }

--- a/Tests/SwiftFormatRulesTests/NoCasesWithOnlyFallthroughTests.swift
+++ b/Tests/SwiftFormatRulesTests/NoCasesWithOnlyFallthroughTests.swift
@@ -53,7 +53,18 @@ final class NoCasesWithOnlyFallthroughTests: LintOrFormatRuleTestCase {
         case .empty: fallthrough
         default: break
         }
-        """)
+        """,
+      checkForUnassertedDiagnostics: true)
+
+    XCTAssertDiagnosed(.collapseCase(name: "2"), line: 3, column: 1)
+    XCTAssertDiagnosed(.collapseCase(name: "3"), line: 4, column: 1)
+    XCTAssertDiagnosed(.collapseCase(name: "5"), line: 6, column: 1)
+    XCTAssertDiagnosed(.collapseCase(name: "\"a\""), line: 11, column: 1)
+    XCTAssertDiagnosed(.collapseCase(name: "\"b\", \"c\""), line: 12, column: 1)
+    XCTAssertDiagnosed(.collapseCase(name: "\"f\""), line: 15, column: 1)
+    XCTAssertDiagnosed(.collapseCase(name: ".rightBrace"), line: 21, column: 1)
+    XCTAssertDiagnosed(.collapseCase(name: ".leftBrace"), line: 22, column: 1)
+    XCTAssertDiagnosed(.collapseCase(name: ".empty"), line: 25, column: 1)
   }
 
   func testFallthroughCasesWithCommentsAreNotCombined() {

--- a/Tests/SwiftFormatRulesTests/NoLabelsInCasePatternsTests.swift
+++ b/Tests/SwiftFormatRulesTests/NoLabelsInCasePatternsTests.swift
@@ -8,7 +8,7 @@ final class NoLabelsInCasePatternsTests: LintOrFormatRuleTestCase {
              switch treeNode {
              case .root(let data):
                break
-             case .subtree(left: let left, right: let right):
+             case .subtree(left: let /*hello*/left, right: let right):
                break
              case .leaf(element: let element):
                break
@@ -18,7 +18,7 @@ final class NoLabelsInCasePatternsTests: LintOrFormatRuleTestCase {
                 switch treeNode {
                 case .root(let data):
                   break
-                case .subtree(let left, let right):
+                case .subtree(let /*hello*/left, let right):
                   break
                 case .leaf(let element):
                   break


### PR DESCRIPTION
Trivia such as comments and whitespace were being included in diagnostics which was distracting and potentially confusing.