### PR TITLE
Visit child nodes in NoParensAroundConditions rule.

### DIFF
--- a/Tests/SwiftFormatRulesTests/NoParensAroundConditionsTests.swift
+++ b/Tests/SwiftFormatRulesTests/NoParensAroundConditionsTests.swift
@@ -21,4 +21,118 @@ final class NoParensAroundConditionsTests: LintOrFormatRuleTestCase {
                 switch 4 { default: break }
                 """)
   }
+
+  func testParensAroundNestedParenthesizedStatements() {
+    XCTAssertFormatting(
+      NoParensAroundConditions.self,
+      input: """
+             switch (a) {
+               case 1:
+                 switch (b) {
+                   default: break
+                 }
+             }
+             if (x) {
+               if (y) {
+               } else if (z) {
+               } else {
+               }
+             } else if (w) {
+             }
+             while (x) {
+               while (y) {}
+             }
+             guard (x), (y), (x == 3) else {
+               guard (a), (b), (c == x) else {
+                 return
+               }
+               return
+             }
+             repeat {
+               repeat {
+               } while (y)
+             } while(x)
+             if (foo.someCall({ if (x) {} })) {}
+             """,
+      expected: """
+                switch a {
+                  case 1:
+                    switch b {
+                      default: break
+                    }
+                }
+                if x {
+                  if y {
+                  } else if z {
+                  } else {
+                  }
+                } else if w {
+                }
+                while x {
+                  while y {}
+                }
+                guard x, y, x == 3 else {
+                  guard a, b, c == x else {
+                    return
+                  }
+                  return
+                }
+                repeat {
+                  repeat {
+                  } while y
+                } while x
+                if foo.someCall({ if x {} }) {}
+                """)
+  }
+
+  func testParensAroundNestedUnparenthesizedStatements() {
+    XCTAssertFormatting(
+      NoParensAroundConditions.self,
+      input: """
+             switch b {
+               case 2:
+                 switch (d) {
+                   default: break
+                 }
+             }
+             if x {
+               if (y) {
+               } else if (z) {
+               } else {
+               }
+             } else if (w) {
+             }
+             while x {
+               while (y) {}
+             }
+             repeat {
+               repeat {
+               } while (y)
+             } while x
+             if foo.someCall({ if (x) {} }) {}
+             """,
+      expected: """
+                switch b {
+                  case 2:
+                    switch d {
+                      default: break
+                    }
+                }
+                if x {
+                  if y {
+                  } else if z {
+                  } else {
+                  }
+                } else if w {
+                }
+                while x {
+                  while y {}
+                }
+                repeat {
+                  repeat {
+                  } while y
+                } while x
+                if foo.someCall({ if x {} }) {}
+                """)
+  }
 }


### PR DESCRIPTION
Without visiting the child nodes, the rule wasn't applied to nested nodes meaning parens wouldn't be removed.