### PR TITLE
Use non-discretionary newlines in the break after `try` keyword.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1420,7 +1420,9 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: TryExprSyntax) -> SyntaxVisitorContinueKind {
-    before(node.expression.firstToken, tokens: .break)
+    before(
+      node.expression.firstToken,
+      tokens: .break(.continue, newlines: .elective(ignoresDiscretionary: true)))
 
     // Check for an anchor token inside of the expression to group with the try keyword.
     if let anchorToken = findTryExprConnectingToken(inExpr: node.expression) {

--- a/Tests/SwiftFormatPrettyPrintTests/TryCatchTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/TryCatchTests.swift
@@ -236,6 +236,8 @@ final class TryCatchTests: PrettyPrintTestCase {
     let input =
       """
       let aVeryLongArgumentName = try foo.bar()
+      let aVeryLongArgumentName = try
+        foo.bar()
       let aVeryLongArgumentName = try? foo.bar()
       let abc = try foo.baz().quxxe(a, b, c).bar()
       let abc = try foo
@@ -246,10 +248,15 @@ final class TryCatchTests: PrettyPrintTestCase {
       let abc = try foo.baz().quxxe(a, b, c).bar[0]
       let abc = try foo
         .baz().quxxe(a, b, c).bar[0]
+      let abc = try
+        foo
+        .baz().quxxe(a, b, c).bar[0]
       """
 
     let expected =
       """
+      let aVeryLongArgumentName =
+        try foo.bar()
       let aVeryLongArgumentName =
         try foo.bar()
       let aVeryLongArgumentName =
@@ -265,6 +272,9 @@ final class TryCatchTests: PrettyPrintTestCase {
         .baz().quxxe(a, b, c).bar()
       let abc = try foo.baz().quxxe(a, b, c)
         .bar[0]
+      let abc =
+        try foo
+        .baz().quxxe(a, b, c).bar[0]
       let abc =
         try foo
         .baz().quxxe(a, b, c).bar[0]


### PR DESCRIPTION
This reflects the fact that the `try` keyword should almost never be separated from the start of the expr that may throw.