### PR TITLE
Add build-only support for the `async` keyword.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1401,6 +1401,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   override func visit(_ node: FunctionTypeSyntax) -> SyntaxVisitorContinueKind {
     after(node.leftParen, tokens: .break(.open, size: 0), .open)
     before(node.rightParen, tokens: .break(.close, size: 0), .close)
+    before(node.asyncKeyword, tokens: .break)
     before(node.throwsOrRethrowsKeyword, tokens: .break)
     before(node.arrow, tokens: .break)
     before(node.returnType.firstToken, tokens: .break)
@@ -1603,6 +1604,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: FunctionSignatureSyntax) -> SyntaxVisitorContinueKind {
+    before(node.asyncKeyword, tokens: .break)
     before(node.throwsOrRethrowsKeyword, tokens: .break)
     before(node.output?.firstToken, tokens: .break)
     return .visitChildren

--- a/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
+++ b/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
@@ -414,6 +414,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
         leftParen: functionType.leftParen,
         argumentTypes: functionType.arguments,
         rightParen: functionType.rightParen,
+        asyncKeyword: functionType.asyncKeyword,
         throwsOrRethrowsKeyword: functionType.throwsOrRethrowsKeyword,
         arrow: functionType.arrow,
         returnType: functionType.returnType
@@ -455,6 +456,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
     leftParen: TokenSyntax,
     argumentTypes: TupleTypeElementListSyntax,
     rightParen: TokenSyntax,
+    asyncKeyword: TokenSyntax?,
     throwsOrRethrowsKeyword: TokenSyntax?,
     arrow: TokenSyntax,
     returnType: TypeSyntax
@@ -471,6 +473,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
       elementList: argumentTypeExprs,
       rightParen: rightParen)
     let arrowExpr = SyntaxFactory.makeArrowExpr(
+      asyncKeyword: asyncKeyword,
       throwsToken: throwsOrRethrowsKeyword,
       arrowToken: arrow)
 


### PR DESCRIPTION
Since the parser's behavior is gated on the `-enable-experimental-concurrency`
compiler flag, we unfortunately can't write any tests for this yet as the
in-memory parser will not have the concurrency support enabled. This change
only adds minimal support for `async` in the pretty printer and fixes a
build breakage in `master` caused by the addition of the new keyword.