### PR TITLE
Refresh generated code by running generate-pipeline.

### DIFF
--- a/Sources/SwiftFormat/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Pipelines+Generated.swift
@@ -49,19 +49,19 @@ class LintPipeline: SyntaxVisitor {
     return .visitChildren
   }
 
-  override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(OneVariableDeclarationPerLine.visit, in: context, for: node)
+  override func visit(_ node: ClosureSignatureSyntax) -> SyntaxVisitorContinueKind {
+    visitIfEnabled(ReturnVoidInsteadOfEmptyTuple.visit, in: context, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: CodeBlockItemListSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(DoNotUseSemicolons.visit, in: context, for: node)
+    visitIfEnabled(OneVariableDeclarationPerLine.visit, in: context, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: CodeBlockSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(AmbiguousTrailingClosureOverload.visit, in: context, for: node)
-    visitIfEnabled(OneVariableDeclarationPerLine.visit, in: context, for: node)
     return .visitChildren
   }
 
@@ -210,7 +210,6 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(NeverForceUnwrap.visit, in: context, for: node)
     visitIfEnabled(NeverUseForceTry.visit, in: context, for: node)
     visitIfEnabled(NeverUseImplicitlyUnwrappedOptionals.visit, in: context, for: node)
-    visitIfEnabled(OneVariableDeclarationPerLine.visit, in: context, for: node)
     visitIfEnabled(OrderedImports.visit, in: context, for: node)
     return .visitChildren
   }

--- a/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
+++ b/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
@@ -20,7 +20,7 @@ enum RuleRegistry {
     "BeginDocumentationCommentWithOneLineSummary": true,
     "DoNotUseSemicolons": true,
     "DontRepeatTypeInStaticProperties": true,
-    "FileprivateAtFileScope": true,
+    "FileScopedDeclarationPrivacy": true,
     "FullyIndirectEnum": true,
     "GroupNumericLiterals": true,
     "IdentifiersMustBeASCII": true,


### PR DESCRIPTION
It looks like the generate-pipeline step was skipped recently, and the generated code was out of date.