### PR TITLE
Support opt-in rules using an `isOptIn` class property.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -61,7 +61,14 @@ let package = Package(
         "SwiftSyntax",
       ]
     ),
-    .target(name: "generate-pipeline", dependencies: ["SwiftSyntax"]),
+    .target(
+      name: "generate-pipeline",
+      dependencies: [
+        "SwiftFormatCore",
+        "SwiftFormatRules",
+        "SwiftSyntax",
+      ]
+    ),
     .target(
       name: "swift-format",
       dependencies: [

--- a/Sources/SwiftFormatCore/Rule.swift
+++ b/Sources/SwiftFormatCore/Rule.swift
@@ -18,6 +18,9 @@ public protocol Rule {
   /// The human-readable name of the rule. This defaults to the class name.
   static var ruleName: String { get }
 
+  /// Whether this rule is opt-in, meaning it is disabled by default.
+  static var isOptIn: Bool { get }
+
   /// Creates a new Rule in a given context.
   init(context: Context)
 }

--- a/Sources/SwiftFormatCore/SyntaxFormatRule.swift
+++ b/Sources/SwiftFormatCore/SyntaxFormatRule.swift
@@ -14,6 +14,12 @@ import SwiftSyntax
 
 /// A rule that both formats and lints a given file.
 open class SyntaxFormatRule: SyntaxRewriter, Rule {
+  /// Whether this rule is opt-in, meaning it's disabled by default. Rules are opt-out unless they
+  /// override this property.
+  open class var isOptIn: Bool {
+    return false
+  }
+
   /// The context in which the rule is executed.
   public let context: Context
 

--- a/Sources/SwiftFormatCore/SyntaxLintRule.swift
+++ b/Sources/SwiftFormatCore/SyntaxLintRule.swift
@@ -15,6 +15,11 @@ import SwiftSyntax
 
 /// A rule that lints a given file.
 open class SyntaxLintRule: SyntaxVisitor, Rule {
+  /// Whether this rule is opt-in, meaning it's disabled by default. Rules are opt-out unless they
+  /// override this property.
+  open class var isOptIn: Bool {
+    return false
+  }
 
   /// The context in which the rule is executed.
   public let context: Context

--- a/Sources/generate-pipeline/PipelineGenerator.swift
+++ b/Sources/generate-pipeline/PipelineGenerator.swift
@@ -96,7 +96,7 @@ final class PipelineGenerator: FileGenerator {
       """
     )
 
-    for ruleName in ruleCollector.allFormatters.sorted() {
+    for ruleName in ruleCollector.allFormatters.map({ $0.typeName }).sorted() {
       handle.write(
         """
             node = \(ruleName)(context: context).visit(node)

--- a/Sources/generate-pipeline/RuleRegistryGenerator.swift
+++ b/Sources/generate-pipeline/RuleRegistryGenerator.swift
@@ -46,8 +46,8 @@ final class RuleRegistryGenerator: FileGenerator {
       """
     )
 
-    for ruleName in ruleCollector.allLinters.sorted() {
-      handle.write("    \"\(ruleName)\": true,\n")
+    for detectedRule in ruleCollector.allLinters.sorted(by: { $0.typeName < $1.typeName }) {
+      handle.write("    \"\(detectedRule.typeName)\": \(!detectedRule.isOptIn),\n")
     }
     handle.write("  ]\n}\n")
   }


### PR DESCRIPTION
The codegen pipeline evaluates the new property for rule types that are discovered and uses it to write the correct default value into `RuleRegistry`. No rules are converted to opt-in status as part of this change.

The new property needs to be support overriding in subclasses, so I had to define it as an open class property in the 2 superclasses for rules (`SyntaxFormatRule` and `SyntaxLintRule`).