### PR TITLE
Fix invalid location references in some diagnostics.

### DIFF
--- a/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
@@ -58,8 +58,10 @@ public final class ValidateDocumentationComments: SyntaxLintRule {
       $0.trimmingCharacters(in: .whitespaces).starts(with: "- Parameters")
     }
 
-    validateThrows(throwsOrRethrowsKeyword, name: name, throwsDesc: commentInfo.throwsDescription)
-    validateReturn(returnClause, name: name, returnDesc: commentInfo.returnsDescription)
+    validateThrows(
+      throwsOrRethrowsKeyword, name: name, throwsDesc: commentInfo.throwsDescription, node: node)
+    validateReturn(
+      returnClause, name: name, returnDesc: commentInfo.returnsDescription, node: node)
     let funcParameters = funcParametersIdentifiers(in: parameters)
 
     // If the documentation of the parameters is wrong 'docCommentInfo' won't
@@ -89,10 +91,11 @@ public final class ValidateDocumentationComments: SyntaxLintRule {
   private func validateReturn(
     _ returnClause: ReturnClauseSyntax?,
     name: String,
-    returnDesc: String?
+    returnDesc: String?,
+    node: DeclSyntax
   ) {
     if returnClause == nil && returnDesc != nil {
-      diagnose(.removeReturnComment(funcName: name), on: returnClause)
+      diagnose(.removeReturnComment(funcName: name), on: node)
     } else if returnClause != nil && returnDesc == nil {
       diagnose(.documentReturnValue(funcName: name), on: returnClause)
     }
@@ -103,7 +106,8 @@ public final class ValidateDocumentationComments: SyntaxLintRule {
   private func validateThrows(
     _ throwsOrRethrowsKeyword: TokenSyntax?,
     name: String,
-    throwsDesc: String?
+    throwsDesc: String?,
+    node: DeclSyntax
   ) {
     // If a function is marked as `rethrows`, it doesn't have any errors of its
     // own that should be documented. So only require documentation for
@@ -111,7 +115,7 @@ public final class ValidateDocumentationComments: SyntaxLintRule {
     let needsThrowsDesc = throwsOrRethrowsKeyword?.tokenKind == .throwsKeyword
 
     if !needsThrowsDesc && throwsDesc != nil {
-      diagnose(.removeThrowsComment(funcName: name), on: throwsOrRethrowsKeyword)
+      diagnose(.removeThrowsComment(funcName: name), on: throwsOrRethrowsKeyword ?? node.firstToken)
     } else if needsThrowsDesc && throwsDesc == nil {
       diagnose(.documentErrorsThrown(funcName: name), on: throwsOrRethrowsKeyword)
     }

--- a/Tests/SwiftFormatRulesTests/ValidateDocumentationCommentsTests.swift
+++ b/Tests/SwiftFormatRulesTests/ValidateDocumentationCommentsTests.swift
@@ -1,6 +1,11 @@
 import SwiftFormatRules
 
 final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
+  override func setUp() {
+    super.setUp()
+    shouldCheckForUnassertedDiagnostics = true
+  }
+
   func testParameterDocumentation() {
     let input =
     """
@@ -32,9 +37,9 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
     func testInvalidParameterDesc(command: String, stdin: String) -> String {}
     """
     performLint(ValidateDocumentationComments.self, input: input)
-    XCTAssertDiagnosed(.useSingularParameter)
-    XCTAssertDiagnosed(.usePluralParameters)
-    XCTAssertDiagnosed(.usePluralParameters)
+    XCTAssertDiagnosed(.useSingularParameter, line: 6, column: 1)
+    XCTAssertDiagnosed(.usePluralParameters, line: 15, column: 1)
+    XCTAssertDiagnosed(.usePluralParameters, line: 26, column: 1)
   }
 
   func testParametersName() {
@@ -57,8 +62,8 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
     func foo(p1: Int, p2: Int, p3: Int) -> Int {}
     """
     performLint(ValidateDocumentationComments.self, input: input)
-    XCTAssertDiagnosed(.parametersDontMatch(funcName: "sum"))
-    XCTAssertDiagnosed(.parametersDontMatch(funcName: "foo"))
+    XCTAssertDiagnosed(.parametersDontMatch(funcName: "sum"), line: 7, column: 1)
+    XCTAssertDiagnosed(.parametersDontMatch(funcName: "foo"), line: 15, column: 1)
   }
 
   func testThrowsDocumentation() {
@@ -88,9 +93,9 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
     func doesRethrow(p1: (() throws -> ())) rethrows {}
     """
     performLint(ValidateDocumentationComments.self, input: input)
-    XCTAssertDiagnosed(.removeThrowsComment(funcName: "doesNotThrow"))
-    XCTAssertDiagnosed(.documentErrorsThrown(funcName: "doesThrow"))
-    XCTAssertDiagnosed(.removeThrowsComment(funcName: "doesRethrow"))
+    XCTAssertDiagnosed(.removeThrowsComment(funcName: "doesNotThrow"), line: 8, column: 1)
+    XCTAssertDiagnosed(.documentErrorsThrown(funcName: "doesThrow"), line: 16, column: 43)
+    XCTAssertDiagnosed(.removeThrowsComment(funcName: "doesRethrow"), line: 22, column: 41)
   }
 
   func testReturnDocumentation() {
@@ -114,8 +119,8 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
     func foo(p1: Int, p2: Int, p3: Int) -> Int {}
     """
     performLint(ValidateDocumentationComments.self, input: input)
-    XCTAssertDiagnosed(.removeReturnComment(funcName: "noReturn"))
-    XCTAssertDiagnosed(.documentReturnValue(funcName: "foo"))
+    XCTAssertDiagnosed(.removeReturnComment(funcName: "noReturn"), line: 8, column: 1)
+    XCTAssertDiagnosed(.documentReturnValue(funcName: "foo"), line: 16, column: 37)
   }
 
   func testValidDocumentation() {
@@ -214,7 +219,7 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
     XCTAssertNotDiagnosed(.useSingularParameter)
     XCTAssertNotDiagnosed(.usePluralParameters)
 
-    XCTAssertDiagnosed(.parametersDontMatch(funcName: "incorrectParam"))
+    XCTAssertDiagnosed(.parametersDontMatch(funcName: "incorrectParam"), line: 6, column: 1)
 
     XCTAssertNotDiagnosed(.documentReturnValue(funcName: "singularParam"))
     XCTAssertNotDiagnosed(.removeReturnComment(funcName: "singularParam"))
@@ -268,8 +273,8 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
     XCTAssertNotDiagnosed(.useSingularParameter)
     XCTAssertNotDiagnosed(.usePluralParameters)
 
-    XCTAssertDiagnosed(.parametersDontMatch(funcName: "init"))
-    XCTAssertDiagnosed(.removeReturnComment(funcName: "init"))
+    XCTAssertDiagnosed(.parametersDontMatch(funcName: "init"), line: 6, column: 3)
+    XCTAssertDiagnosed(.removeReturnComment(funcName: "init"), line: 6, column: 3)
 
     XCTAssertNotDiagnosed(.documentReturnValue(funcName: "init"))
     XCTAssertNotDiagnosed(.removeReturnComment(funcName: "init"))


### PR DESCRIPTION
These diagnostics were using a nil node to for the diagnostic's location, which results in a bogus location (e.g. <unknown>:0:0). Now the diagnostics reference a relevant node, and the tests are updated to verify the diagnostics have reasonable locations.