### PR TITLE
Convert some rules to be opt-in because they are noisy for non-strict…

### DIFF
--- a/Sources/SwiftFormat/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Pipelines+Generated.swift
@@ -42,6 +42,7 @@ class LintPipeline: SyntaxVisitor {
 
   override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, in: context, for: node)
+    visitIfEnabled(AlwaysUseLowerCamelCase.visit, in: context, for: node)
     visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, in: context, for: node)
     visitIfEnabled(DontRepeatTypeInStaticProperties.visit, in: context, for: node)
     visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
@@ -205,6 +206,7 @@ class LintPipeline: SyntaxVisitor {
   }
 
   override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
+    visitIfEnabled(AlwaysUseLowerCamelCase.visit, in: context, for: node)
     visitIfEnabled(AmbiguousTrailingClosureOverload.visit, in: context, for: node)
     visitIfEnabled(FileScopedDeclarationPrivacy.visit, in: context, for: node)
     visitIfEnabled(NeverForceUnwrap.visit, in: context, for: node)

--- a/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
+++ b/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
@@ -14,7 +14,7 @@
 
 enum RuleRegistry {
   static let rules: [String: Bool] = [
-    "AllPublicDeclarationsHaveDocumentation": true,
+    "AllPublicDeclarationsHaveDocumentation": false,
     "AlwaysUseLowerCamelCase": true,
     "AmbiguousTrailingClosureOverload": true,
     "BeginDocumentationCommentWithOneLineSummary": true,
@@ -24,9 +24,9 @@ enum RuleRegistry {
     "FullyIndirectEnum": true,
     "GroupNumericLiterals": true,
     "IdentifiersMustBeASCII": true,
-    "NeverForceUnwrap": true,
-    "NeverUseForceTry": true,
-    "NeverUseImplicitlyUnwrappedOptionals": true,
+    "NeverForceUnwrap": false,
+    "NeverUseForceTry": false,
+    "NeverUseImplicitlyUnwrappedOptionals": false,
     "NoAccessLevelOnExtensionDeclaration": true,
     "NoBlockComments": true,
     "NoCasesWithOnlyFallthrough": true,

--- a/Sources/SwiftFormatRules/AllPublicDeclarationsHaveDocumentation.swift
+++ b/Sources/SwiftFormatRules/AllPublicDeclarationsHaveDocumentation.swift
@@ -18,6 +18,12 @@ import SwiftSyntax
 /// Lint: If a public declaration is missing a documentation comment, a lint error is raised.
 public final class AllPublicDeclarationsHaveDocumentation: SyntaxLintRule {
 
+  /// Identifies this rule was being opt-in. While docs on most public declarations are beneficial,
+  /// there are a number of public decls where docs are either redundant or superfluous. This rule
+  /// can't differentiate those situations and will make a lot of noise for projects that are
+  /// intentionally avoiding docs on some decls.
+  public override class var isOptIn: Bool { return true }
+
   public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseMissingDocComment(DeclSyntax(node), name: node.fullDeclName, modifiers: node.modifiers)
     return .skipChildren

--- a/Sources/SwiftFormatRules/NeverForceUnwrap.swift
+++ b/Sources/SwiftFormatRules/NeverForceUnwrap.swift
@@ -18,6 +18,11 @@ import SwiftSyntax
 /// Lint: If a force unwrap is used, a lint warning is raised.
 public final class NeverForceUnwrap: SyntaxLintRule {
 
+  /// Identifies this rule was being opt-in. While force unwrap is an unsafe pattern (i.e. it can
+  /// crash), there are valid contexts for force unwrap where it won't crash. This rule can't
+  /// evaluate the context around the force unwrap to make that determination.
+  public override class var isOptIn: Bool { return true }
+
   public override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
     // Tracks whether "XCTest" is imported in the source file before processing individual nodes.
     setImportsXCTest(context: context, sourceFile: node)

--- a/Sources/SwiftFormatRules/NeverUseForceTry.swift
+++ b/Sources/SwiftFormatRules/NeverUseForceTry.swift
@@ -23,6 +23,11 @@ import SwiftSyntax
 /// TODO: Create exception for NSRegularExpression
 public final class NeverUseForceTry: SyntaxLintRule {
 
+  /// Identifies this rule was being opt-in. While force try is an unsafe pattern (i.e. it can
+  /// crash), there are valid contexts for force try where it won't crash. This rule can't
+  /// evaluate the context around the force try to make that determination.
+  public override class var isOptIn: Bool { return true }
+
   public override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
     setImportsXCTest(context: context, sourceFile: node)
     return .visitChildren

--- a/Sources/SwiftFormatRules/NeverUseImplicitlyUnwrappedOptionals.swift
+++ b/Sources/SwiftFormatRules/NeverUseImplicitlyUnwrappedOptionals.swift
@@ -25,6 +25,12 @@ import SwiftSyntax
 /// Lint: Declaring a property with an implicitly unwrapped type yields a lint error.
 public final class NeverUseImplicitlyUnwrappedOptionals: SyntaxLintRule {
 
+  /// Identifies this rule was being opt-in. While accessing implicitly unwrapped optionals is an
+  /// unsafe pattern (i.e. it can crash), there are valid contexts for using implicitly unwrapped
+  /// optionals where it won't crash. This rule can't evaluate the context around the usage to make
+  /// that determination.
+  public override class var isOptIn: Bool { return true }
+
   // Checks if "XCTest" is an import statement
   public override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
     setImportsXCTest(context: context, sourceFile: node)


### PR DESCRIPTION
… projects.

The rules that are now opt-in are:
- AllPublicDeclarationsHaveDocumentation
- NeverForceUnwrap
- NeverUseForceTry
- NeverUseImplicitlyUnwrappedOptionals

The rules that identify unsafe patterns (force unwrap, force try, implicitly unwrapped optionals) aren't able to understand the context of the usage, which means the use might be safe and the rule can't tell.

Projects that wish to be more strict can turn on these rules in their configuration, to get back to the original behavior. There is also no change for projects that are already using a configuration file.