### PR TITLE
Allow empty paths to imply reading from stdin.

### DIFF
--- a/Sources/swift-format/Subcommands/LintFormatOptions.swift
+++ b/Sources/swift-format/Subcommands/LintFormatOptions.swift
@@ -51,7 +51,7 @@ struct LintFormatOptions: ParsableArguments {
 
   /// The list of paths to Swift source files that should be formatted or linted.
   @Argument(help: "Zero or more input filenames.")
-  var paths: [String]
+  var paths: [String] = []
 
   @Flag(help: .hidden) var debugDisablePrettyPrint: Bool
   @Flag(help: .hidden) var debugDumpTokenStream: Bool


### PR DESCRIPTION
This has been supported for a long time, but a recent change in swift-argument-parser 0.3.0 changed the behavior for non-nullable array types as arguments. Previously, the argument parser defaulted them to empty arrays. The suggested migration is to specify a default empty array for optional array arguments.

Reference: https://github.com/apple/swift-argument-parser/releases/tag/0.3.0