### PR TITLE
Use regular property initialization for argument defaults.

### DIFF
--- a/Sources/swift-format/Subcommands/Format.swift
+++ b/Sources/swift-format/Subcommands/Format.swift
@@ -25,7 +25,7 @@ extension SwiftFormatCommand {
     @Flag(
       name: .shortAndLong,
       help: "Overwrite the current file when formatting.")
-    var inPlace: Bool
+    var inPlace: Bool = false
 
     @OptionGroup()
     var formatOptions: LintFormatOptions

--- a/Sources/swift-format/Subcommands/LegacyMain.swift
+++ b/Sources/swift-format/Subcommands/LegacyMain.swift
@@ -28,9 +28,8 @@ extension SwiftFormatCommand {
     /// If not specified, the tool will be run in format mode.
     @Option(
       name: .shortAndLong,
-      default: .format,
       help: "The mode to run swift-format in. Either 'format', 'lint', or 'dump-configuration'.")
-    var mode: ToolMode
+    var mode: ToolMode = .format
 
     @OptionGroup()
     var lintFormatOptions: LintFormatOptions
@@ -41,7 +40,7 @@ extension SwiftFormatCommand {
     @Flag(
       name: .shortAndLong,
       help: "Overwrite the current file when formatting ('format' mode only).")
-    var inPlace: Bool
+    var inPlace: Bool = false
 
     mutating func validate() throws {
       if inPlace && (mode != .format || lintFormatOptions.paths.isEmpty) {

--- a/Sources/swift-format/Subcommands/LintFormatOptions.swift
+++ b/Sources/swift-format/Subcommands/LintFormatOptions.swift
@@ -37,7 +37,7 @@ struct LintFormatOptions: ParsableArguments {
   @Flag(
     name: .shortAndLong,
     help: "Recursively run on '.swift' files in any provided directories.")
-  var recursive: Bool
+  var recursive: Bool = false
 
   /// Whether unparsable files, due to syntax errors or unrecognized syntax, should be ignored or
   /// treated as containing an error. When ignored, unparsable files are output verbatim in format
@@ -47,14 +47,14 @@ struct LintFormatOptions: ParsableArguments {
     Ignores unparsable files, disabling all diagnostics and formatting for files that contain \
     invalid syntax.
     """)
-  var ignoreUnparsableFiles: Bool
+  var ignoreUnparsableFiles: Bool = false
 
   /// The list of paths to Swift source files that should be formatted or linted.
   @Argument(help: "Zero or more input filenames.")
   var paths: [String] = []
 
-  @Flag(help: .hidden) var debugDisablePrettyPrint: Bool
-  @Flag(help: .hidden) var debugDumpTokenStream: Bool
+  @Flag(help: .hidden) var debugDisablePrettyPrint: Bool = false
+  @Flag(help: .hidden) var debugDumpTokenStream: Bool = false
 
   mutating func validate() throws {
     if recursive && paths.isEmpty {

--- a/Sources/swift-format/VersionOptions.swift
+++ b/Sources/swift-format/VersionOptions.swift
@@ -15,7 +15,7 @@ import ArgumentParser
 /// Encapsulates `--version` flag behavior.
 struct VersionOptions: ParsableArguments {
   @Flag(name: .shortAndLong, help: "Print the version and exit")
-  var version: Bool
+  var version: Bool = false
 
   func validate() throws {
     if version {


### PR DESCRIPTION
This gets rid of warnings from deprecated swift-argument-parser APIs.