### PR TITLE
[5.3] Cherry-pick Swift 5.3 compatible changes since 7/29.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -144,8 +144,8 @@ let package = Package(
 if getenv("SWIFTCI_USE_LOCAL_DEPS") == nil {
   // Building standalone.
   package.dependencies += [
-    .package(url: "https://github.com/apple/swift-syntax", .branch("master")),
-    .package(url: "https://github.com/apple/swift-argument-parser.git", .branch("master")),
+    .package(url: "https://github.com/apple/swift-syntax", .revision("swift-5.3-RELEASE")),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.3.1")),
   ]
 } else {
   package.dependencies += [

--- a/Package.swift
+++ b/Package.swift
@@ -61,7 +61,14 @@ let package = Package(
         "SwiftSyntax",
       ]
     ),
-    .target(name: "generate-pipeline", dependencies: ["SwiftSyntax"]),
+    .target(
+      name: "generate-pipeline",
+      dependencies: [
+        "SwiftFormatCore",
+        "SwiftFormatRules",
+        "SwiftSyntax",
+      ]
+    ),
     .target(
       name: "swift-format",
       dependencies: [

--- a/Sources/SwiftFormat/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Pipelines+Generated.swift
@@ -42,6 +42,7 @@ class LintPipeline: SyntaxVisitor {
 
   override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, in: context, for: node)
+    visitIfEnabled(AlwaysUseLowerCamelCase.visit, in: context, for: node)
     visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, in: context, for: node)
     visitIfEnabled(DontRepeatTypeInStaticProperties.visit, in: context, for: node)
     visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
@@ -205,6 +206,7 @@ class LintPipeline: SyntaxVisitor {
   }
 
   override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
+    visitIfEnabled(AlwaysUseLowerCamelCase.visit, in: context, for: node)
     visitIfEnabled(AmbiguousTrailingClosureOverload.visit, in: context, for: node)
     visitIfEnabled(FileScopedDeclarationPrivacy.visit, in: context, for: node)
     visitIfEnabled(NeverForceUnwrap.visit, in: context, for: node)

--- a/Sources/SwiftFormat/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Pipelines+Generated.swift
@@ -24,266 +24,270 @@ class LintPipeline: SyntaxVisitor {
   /// The formatter context.
   let context: Context
 
+  /// Stores lint and format rule instances, indexed by the `ObjectIdentifier` of a rule's
+  /// class type.
+  var ruleCache = [ObjectIdentifier: Rule]()
+
   /// Creates a new lint pipeline.
   init(context: Context) {
     self.context = context
   }
 
   override func visit(_ node: AsExprSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(NeverForceUnwrap.visit, in: context, for: node)
+    visitIfEnabled(NeverForceUnwrap.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: AssociatedtypeDeclSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, in: context, for: node)
-    visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
+    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
+    visitIfEnabled(NoLeadingUnderscores.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, in: context, for: node)
-    visitIfEnabled(AlwaysUseLowerCamelCase.visit, in: context, for: node)
-    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, in: context, for: node)
-    visitIfEnabled(DontRepeatTypeInStaticProperties.visit, in: context, for: node)
-    visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
-    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, in: context, for: node)
+    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, for: node)
+    visitIfEnabled(AlwaysUseLowerCamelCase.visit, for: node)
+    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
+    visitIfEnabled(DontRepeatTypeInStaticProperties.visit, for: node)
+    visitIfEnabled(NoLeadingUnderscores.visit, for: node)
+    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: ClosureSignatureSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(AlwaysUseLowerCamelCase.visit, in: context, for: node)
-    visitIfEnabled(ReturnVoidInsteadOfEmptyTuple.visit, in: context, for: node)
+    visitIfEnabled(AlwaysUseLowerCamelCase.visit, for: node)
+    visitIfEnabled(ReturnVoidInsteadOfEmptyTuple.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: CodeBlockItemListSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(DoNotUseSemicolons.visit, in: context, for: node)
-    visitIfEnabled(OneVariableDeclarationPerLine.visit, in: context, for: node)
+    visitIfEnabled(DoNotUseSemicolons.visit, for: node)
+    visitIfEnabled(OneVariableDeclarationPerLine.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: CodeBlockSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(AmbiguousTrailingClosureOverload.visit, in: context, for: node)
+    visitIfEnabled(AmbiguousTrailingClosureOverload.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: ConditionElementSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(NoParensAroundConditions.visit, in: context, for: node)
+    visitIfEnabled(NoParensAroundConditions.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: DeinitializerDeclSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, in: context, for: node)
-    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, in: context, for: node)
-    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, in: context, for: node)
+    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, for: node)
+    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
+    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: EnumCaseElementSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(AlwaysUseLowerCamelCase.visit, in: context, for: node)
-    visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
+    visitIfEnabled(AlwaysUseLowerCamelCase.visit, for: node)
+    visitIfEnabled(NoLeadingUnderscores.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, in: context, for: node)
-    visitIfEnabled(DontRepeatTypeInStaticProperties.visit, in: context, for: node)
-    visitIfEnabled(FullyIndirectEnum.visit, in: context, for: node)
-    visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
-    visitIfEnabled(OneCasePerLine.visit, in: context, for: node)
-    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, in: context, for: node)
+    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
+    visitIfEnabled(DontRepeatTypeInStaticProperties.visit, for: node)
+    visitIfEnabled(FullyIndirectEnum.visit, for: node)
+    visitIfEnabled(NoLeadingUnderscores.visit, for: node)
+    visitIfEnabled(OneCasePerLine.visit, for: node)
+    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(DontRepeatTypeInStaticProperties.visit, in: context, for: node)
-    visitIfEnabled(NoAccessLevelOnExtensionDeclaration.visit, in: context, for: node)
-    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, in: context, for: node)
+    visitIfEnabled(DontRepeatTypeInStaticProperties.visit, for: node)
+    visitIfEnabled(NoAccessLevelOnExtensionDeclaration.visit, for: node)
+    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: ForcedValueExprSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(NeverForceUnwrap.visit, in: context, for: node)
+    visitIfEnabled(NeverForceUnwrap.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(NoEmptyTrailingClosureParentheses.visit, in: context, for: node)
-    visitIfEnabled(OnlyOneTrailingClosureArgument.visit, in: context, for: node)
+    visitIfEnabled(NoEmptyTrailingClosureParentheses.visit, for: node)
+    visitIfEnabled(OnlyOneTrailingClosureArgument.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, in: context, for: node)
-    visitIfEnabled(AlwaysUseLowerCamelCase.visit, in: context, for: node)
-    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, in: context, for: node)
-    visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
-    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, in: context, for: node)
-    visitIfEnabled(ValidateDocumentationComments.visit, in: context, for: node)
+    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, for: node)
+    visitIfEnabled(AlwaysUseLowerCamelCase.visit, for: node)
+    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
+    visitIfEnabled(NoLeadingUnderscores.visit, for: node)
+    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
+    visitIfEnabled(ValidateDocumentationComments.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: FunctionParameterSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
+    visitIfEnabled(NoLeadingUnderscores.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: FunctionSignatureSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(NoVoidReturnOnFunctionSignature.visit, in: context, for: node)
+    visitIfEnabled(NoVoidReturnOnFunctionSignature.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: FunctionTypeSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(ReturnVoidInsteadOfEmptyTuple.visit, in: context, for: node)
+    visitIfEnabled(ReturnVoidInsteadOfEmptyTuple.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: GenericParameterSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
+    visitIfEnabled(NoLeadingUnderscores.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: IdentifierPatternSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(IdentifiersMustBeASCII.visit, in: context, for: node)
-    visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
+    visitIfEnabled(IdentifiersMustBeASCII.visit, for: node)
+    visitIfEnabled(NoLeadingUnderscores.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: IfStmtSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(NoParensAroundConditions.visit, in: context, for: node)
+    visitIfEnabled(NoParensAroundConditions.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, in: context, for: node)
-    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, in: context, for: node)
-    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, in: context, for: node)
-    visitIfEnabled(ValidateDocumentationComments.visit, in: context, for: node)
+    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, for: node)
+    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
+    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
+    visitIfEnabled(ValidateDocumentationComments.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: IntegerLiteralExprSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(GroupNumericLiterals.visit, in: context, for: node)
+    visitIfEnabled(GroupNumericLiterals.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: MemberDeclBlockSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(AmbiguousTrailingClosureOverload.visit, in: context, for: node)
+    visitIfEnabled(AmbiguousTrailingClosureOverload.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: MemberDeclListSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(DoNotUseSemicolons.visit, in: context, for: node)
+    visitIfEnabled(DoNotUseSemicolons.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: OptionalBindingConditionSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(AlwaysUseLowerCamelCase.visit, in: context, for: node)
+    visitIfEnabled(AlwaysUseLowerCamelCase.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: PatternBindingSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(UseSingleLinePropertyGetter.visit, in: context, for: node)
+    visitIfEnabled(UseSingleLinePropertyGetter.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: PrecedenceGroupDeclSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
+    visitIfEnabled(NoLeadingUnderscores.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, in: context, for: node)
-    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, in: context, for: node)
-    visitIfEnabled(DontRepeatTypeInStaticProperties.visit, in: context, for: node)
-    visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
-    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, in: context, for: node)
+    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, for: node)
+    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
+    visitIfEnabled(DontRepeatTypeInStaticProperties.visit, for: node)
+    visitIfEnabled(NoLeadingUnderscores.visit, for: node)
+    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: RepeatWhileStmtSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(NoParensAroundConditions.visit, in: context, for: node)
+    visitIfEnabled(NoParensAroundConditions.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: SimpleTypeIdentifierSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(UseShorthandTypeNames.visit, in: context, for: node)
+    visitIfEnabled(UseShorthandTypeNames.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(AlwaysUseLowerCamelCase.visit, in: context, for: node)
-    visitIfEnabled(AmbiguousTrailingClosureOverload.visit, in: context, for: node)
-    visitIfEnabled(FileScopedDeclarationPrivacy.visit, in: context, for: node)
-    visitIfEnabled(NeverForceUnwrap.visit, in: context, for: node)
-    visitIfEnabled(NeverUseForceTry.visit, in: context, for: node)
-    visitIfEnabled(NeverUseImplicitlyUnwrappedOptionals.visit, in: context, for: node)
-    visitIfEnabled(OrderedImports.visit, in: context, for: node)
+    visitIfEnabled(AlwaysUseLowerCamelCase.visit, for: node)
+    visitIfEnabled(AmbiguousTrailingClosureOverload.visit, for: node)
+    visitIfEnabled(FileScopedDeclarationPrivacy.visit, for: node)
+    visitIfEnabled(NeverForceUnwrap.visit, for: node)
+    visitIfEnabled(NeverUseForceTry.visit, for: node)
+    visitIfEnabled(NeverUseImplicitlyUnwrappedOptionals.visit, for: node)
+    visitIfEnabled(OrderedImports.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: SpecializeExprSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(UseShorthandTypeNames.visit, in: context, for: node)
+    visitIfEnabled(UseShorthandTypeNames.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, in: context, for: node)
-    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, in: context, for: node)
-    visitIfEnabled(DontRepeatTypeInStaticProperties.visit, in: context, for: node)
-    visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
-    visitIfEnabled(UseSynthesizedInitializer.visit, in: context, for: node)
-    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, in: context, for: node)
+    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, for: node)
+    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
+    visitIfEnabled(DontRepeatTypeInStaticProperties.visit, for: node)
+    visitIfEnabled(NoLeadingUnderscores.visit, for: node)
+    visitIfEnabled(UseSynthesizedInitializer.visit, for: node)
+    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: SubscriptDeclSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, in: context, for: node)
-    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, in: context, for: node)
-    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, in: context, for: node)
+    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, for: node)
+    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
+    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: SwitchCaseLabelSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(NoLabelsInCasePatterns.visit, in: context, for: node)
-    visitIfEnabled(UseLetInEveryBoundCaseVariable.visit, in: context, for: node)
+    visitIfEnabled(NoLabelsInCasePatterns.visit, for: node)
+    visitIfEnabled(UseLetInEveryBoundCaseVariable.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: SwitchCaseListSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(NoCasesWithOnlyFallthrough.visit, in: context, for: node)
+    visitIfEnabled(NoCasesWithOnlyFallthrough.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: SwitchStmtSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(NoParensAroundConditions.visit, in: context, for: node)
+    visitIfEnabled(NoParensAroundConditions.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: TokenSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(NoBlockComments.visit, in: context, for: node)
+    visitIfEnabled(NoBlockComments.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: TryExprSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(NeverUseForceTry.visit, in: context, for: node)
+    visitIfEnabled(NeverUseForceTry.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, in: context, for: node)
-    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, in: context, for: node)
-    visitIfEnabled(NoLeadingUnderscores.visit, in: context, for: node)
-    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, in: context, for: node)
+    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, for: node)
+    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
+    visitIfEnabled(NoLeadingUnderscores.visit, for: node)
+    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, in: context, for: node)
-    visitIfEnabled(AlwaysUseLowerCamelCase.visit, in: context, for: node)
-    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, in: context, for: node)
-    visitIfEnabled(NeverUseImplicitlyUnwrappedOptionals.visit, in: context, for: node)
-    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, in: context, for: node)
+    visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, for: node)
+    visitIfEnabled(AlwaysUseLowerCamelCase.visit, for: node)
+    visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
+    visitIfEnabled(NeverUseImplicitlyUnwrappedOptionals.visit, for: node)
+    visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }
 }

--- a/Sources/SwiftFormat/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Pipelines+Generated.swift
@@ -51,6 +51,7 @@ class LintPipeline: SyntaxVisitor {
   }
 
   override func visit(_ node: ClosureSignatureSyntax) -> SyntaxVisitorContinueKind {
+    visitIfEnabled(AlwaysUseLowerCamelCase.visit, in: context, for: node)
     visitIfEnabled(ReturnVoidInsteadOfEmptyTuple.visit, in: context, for: node)
     return .visitChildren
   }
@@ -173,6 +174,11 @@ class LintPipeline: SyntaxVisitor {
 
   override func visit(_ node: MemberDeclListSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(DoNotUseSemicolons.visit, in: context, for: node)
+    return .visitChildren
+  }
+
+  override func visit(_ node: OptionalBindingConditionSyntax) -> SyntaxVisitorContinueKind {
+    visitIfEnabled(AlwaysUseLowerCamelCase.visit, in: context, for: node)
     return .visitChildren
   }
 

--- a/Sources/SwiftFormat/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Pipelines+Generated.swift
@@ -49,19 +49,19 @@ class LintPipeline: SyntaxVisitor {
     return .visitChildren
   }
 
-  override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(OneVariableDeclarationPerLine.visit, in: context, for: node)
+  override func visit(_ node: ClosureSignatureSyntax) -> SyntaxVisitorContinueKind {
+    visitIfEnabled(ReturnVoidInsteadOfEmptyTuple.visit, in: context, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: CodeBlockItemListSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(DoNotUseSemicolons.visit, in: context, for: node)
+    visitIfEnabled(OneVariableDeclarationPerLine.visit, in: context, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: CodeBlockSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(AmbiguousTrailingClosureOverload.visit, in: context, for: node)
-    visitIfEnabled(OneVariableDeclarationPerLine.visit, in: context, for: node)
     return .visitChildren
   }
 
@@ -210,7 +210,6 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(NeverForceUnwrap.visit, in: context, for: node)
     visitIfEnabled(NeverUseForceTry.visit, in: context, for: node)
     visitIfEnabled(NeverUseImplicitlyUnwrappedOptionals.visit, in: context, for: node)
-    visitIfEnabled(OneVariableDeclarationPerLine.visit, in: context, for: node)
     visitIfEnabled(OrderedImports.visit, in: context, for: node)
     return .visitChildren
   }

--- a/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
+++ b/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
@@ -20,7 +20,7 @@ enum RuleRegistry {
     "BeginDocumentationCommentWithOneLineSummary": true,
     "DoNotUseSemicolons": true,
     "DontRepeatTypeInStaticProperties": true,
-    "FileprivateAtFileScope": true,
+    "FileScopedDeclarationPrivacy": true,
     "FullyIndirectEnum": true,
     "GroupNumericLiterals": true,
     "IdentifiersMustBeASCII": true,

--- a/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
+++ b/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
@@ -32,7 +32,7 @@ enum RuleRegistry {
     "NoCasesWithOnlyFallthrough": true,
     "NoEmptyTrailingClosureParentheses": true,
     "NoLabelsInCasePatterns": true,
-    "NoLeadingUnderscores": true,
+    "NoLeadingUnderscores": false,
     "NoParensAroundConditions": true,
     "NoVoidReturnOnFunctionSignature": true,
     "OneCasePerLine": true,
@@ -45,6 +45,6 @@ enum RuleRegistry {
     "UseSingleLinePropertyGetter": true,
     "UseSynthesizedInitializer": true,
     "UseTripleSlashForDocumentationComments": true,
-    "ValidateDocumentationComments": true,
+    "ValidateDocumentationComments": false,
   ]
 }

--- a/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
+++ b/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
@@ -14,7 +14,7 @@
 
 enum RuleRegistry {
   static let rules: [String: Bool] = [
-    "AllPublicDeclarationsHaveDocumentation": true,
+    "AllPublicDeclarationsHaveDocumentation": false,
     "AlwaysUseLowerCamelCase": true,
     "AmbiguousTrailingClosureOverload": true,
     "BeginDocumentationCommentWithOneLineSummary": true,
@@ -24,9 +24,9 @@ enum RuleRegistry {
     "FullyIndirectEnum": true,
     "GroupNumericLiterals": true,
     "IdentifiersMustBeASCII": true,
-    "NeverForceUnwrap": true,
-    "NeverUseForceTry": true,
-    "NeverUseImplicitlyUnwrappedOptionals": true,
+    "NeverForceUnwrap": false,
+    "NeverUseForceTry": false,
+    "NeverUseImplicitlyUnwrappedOptionals": false,
     "NoAccessLevelOnExtensionDeclaration": true,
     "NoBlockComments": true,
     "NoCasesWithOnlyFallthrough": true,

--- a/Sources/SwiftFormatCore/Rule.swift
+++ b/Sources/SwiftFormatCore/Rule.swift
@@ -18,6 +18,9 @@ public protocol Rule {
   /// The human-readable name of the rule. This defaults to the class name.
   static var ruleName: String { get }
 
+  /// Whether this rule is opt-in, meaning it is disabled by default.
+  static var isOptIn: Bool { get }
+
   /// Creates a new Rule in a given context.
   init(context: Context)
 }

--- a/Sources/SwiftFormatCore/SyntaxFormatRule.swift
+++ b/Sources/SwiftFormatCore/SyntaxFormatRule.swift
@@ -14,6 +14,12 @@ import SwiftSyntax
 
 /// A rule that both formats and lints a given file.
 open class SyntaxFormatRule: SyntaxRewriter, Rule {
+  /// Whether this rule is opt-in, meaning it's disabled by default. Rules are opt-out unless they
+  /// override this property.
+  open class var isOptIn: Bool {
+    return false
+  }
+
   /// The context in which the rule is executed.
   public let context: Context
 

--- a/Sources/SwiftFormatCore/SyntaxLintRule.swift
+++ b/Sources/SwiftFormatCore/SyntaxLintRule.swift
@@ -15,6 +15,11 @@ import SwiftSyntax
 
 /// A rule that lints a given file.
 open class SyntaxLintRule: SyntaxVisitor, Rule {
+  /// Whether this rule is opt-in, meaning it's disabled by default. Rules are opt-out unless they
+  /// override this property.
+  open class var isOptIn: Bool {
+    return false
+  }
 
   /// The context in which the rule is executed.
   public let context: Context

--- a/Sources/SwiftFormatPrettyPrint/Token.swift
+++ b/Sources/SwiftFormatPrettyPrint/Token.swift
@@ -185,8 +185,8 @@ enum Token {
   case commaDelimitedRegionStart
 
   /// Marks the end of a comma delimited collection, where a trailing comma should be inserted
-  /// if and only if the collection spans multiple lines.
-  case commaDelimitedRegionEnd(hasTrailingComma: Bool)
+  /// if and only if the collection spans multiple lines and has multiple elements.
+  case commaDelimitedRegionEnd(hasTrailingComma: Bool, isSingleElement: Bool)
 
   /// Starts a scope where `contextual` breaks have consistent behavior.
   case contextualBreakingStart

--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -795,16 +795,12 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       if let trailingComma = lastElement.trailingComma {
         ignoredTokens.insert(trailingComma)
       }
-      // The syntax library can't distinguish an array initializer (where the elements are types)
-      // from an array literal (where the elements are the contents of the array). We never want to
-      // add a trailing comma in the initializer case and there's always exactly 1 element, so we
-      // never add a trailing comma to 1 element arrays.
-      if let firstElement = node.first, firstElement != lastElement {
-        before(firstElement.firstToken, tokens: .commaDelimitedRegionStart)
-        let endToken =
-          Token.commaDelimitedRegionEnd(hasTrailingComma: lastElement.trailingComma != nil)
-        after(lastElement.expression.lastToken, tokens: [endToken])
-      }
+      before(node.first?.firstToken, tokens: .commaDelimitedRegionStart)
+      let endToken =
+        Token.commaDelimitedRegionEnd(
+          hasTrailingComma: lastElement.trailingComma != nil,
+          isSingleElement: node.first == lastElement)
+      after(lastElement.expression.lastToken, tokens: [endToken])
     }
     return .visitChildren
   }
@@ -842,16 +838,12 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       if let trailingComma = lastElement.trailingComma {
         ignoredTokens.insert(trailingComma)
       }
-      // The syntax library can't distinguish a dictionary initializer (where the elements are
-      // types) from a dictionary literal (where the elements are the contents of the dictionary).
-      // We never want to add a trailing comma in the initializer case and there's always exactly 1
-      //  element, so we never add a trailing comma to 1 element dictionaries.
-      if let firstElement = node.first, let lastElement = node.last, firstElement != lastElement {
-        before(firstElement.firstToken, tokens: .commaDelimitedRegionStart)
-        let endToken =
-          Token.commaDelimitedRegionEnd(hasTrailingComma: lastElement.trailingComma != nil)
-        after(lastElement.lastToken, tokens: endToken)
-      }
+      before(node.first?.firstToken, tokens: .commaDelimitedRegionStart)
+      let endToken =
+        Token.commaDelimitedRegionEnd(
+          hasTrailingComma: lastElement.trailingComma != nil,
+          isSingleElement: node.first == node.last)
+      after(lastElement.lastToken, tokens: endToken)
     }
     return .visitChildren
   }

--- a/Sources/SwiftFormatRules/AllPublicDeclarationsHaveDocumentation.swift
+++ b/Sources/SwiftFormatRules/AllPublicDeclarationsHaveDocumentation.swift
@@ -18,6 +18,12 @@ import SwiftSyntax
 /// Lint: If a public declaration is missing a documentation comment, a lint error is raised.
 public final class AllPublicDeclarationsHaveDocumentation: SyntaxLintRule {
 
+  /// Identifies this rule was being opt-in. While docs on most public declarations are beneficial,
+  /// there are a number of public decls where docs are either redundant or superfluous. This rule
+  /// can't differentiate those situations and will make a lot of noise for projects that are
+  /// intentionally avoiding docs on some decls.
+  public override class var isOptIn: Bool { return true }
+
   public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseMissingDocComment(DeclSyntax(node), name: node.fullDeclName, modifiers: node.modifiers)
     return .skipChildren

--- a/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
+++ b/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
@@ -19,35 +19,81 @@ import SwiftSyntax
 /// Lint: If an identifier contains underscores or begins with a capital letter, a lint error is
 ///       raised.
 public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
+  /// Stores function decls that are test cases.
+  private var testCaseFuncs = Set<FunctionDeclSyntax>()
+
+  public override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
+    // Tracks whether "XCTest" is imported in the source file before processing individual nodes.
+    setImportsXCTest(context: context, sourceFile: node)
+    return .visitChildren
+  }
+
+  public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+    // Check if this class is an `XCTestCase`, otherwise it cannot contain any test cases.
+    guard context.importsXCTest == .importsXCTest else { return .visitChildren }
+
+    // Identify and store all of the function decls that are test cases.
+    let testCases = node.members.members.compactMap {
+      $0.decl.as(FunctionDeclSyntax.self)
+    }.filter {
+      // Filter out non-test methods using the same heuristics as XCTest to identify tests.
+      // Test methods are methods that start with "test", have no arguments, and void return type.
+      $0.identifier.text.starts(with: "test")
+        && $0.signature.input.parameterList.isEmpty
+        && $0.signature.output.map { $0.isVoid } ?? true
+    }
+    testCaseFuncs.formUnion(testCases)
+    return .visitChildren
+  }
+
+  public override func visitPost(_ node: ClassDeclSyntax) {
+    testCaseFuncs.removeAll()
+  }
 
   public override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
     for binding in node.bindings {
       guard let pat = binding.pattern.as(IdentifierPatternSyntax.self) else {
         continue
       }
-      diagnoseLowerCamelCaseViolations(pat.identifier)
+      diagnoseLowerCamelCaseViolations(pat.identifier, allowUnderscores: false)
     }
     return .skipChildren
   }
 
   public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseLowerCamelCaseViolations(node.identifier)
+    // We allow underscores in test names, because there's an existing convention of using
+    // underscores to separate phrases in very detailed test names.
+    let allowUnderscores = testCaseFuncs.contains(node)
+    diagnoseLowerCamelCaseViolations(node.identifier, allowUnderscores: allowUnderscores)
     return .skipChildren
   }
 
   public override func visit(_ node: EnumCaseElementSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseLowerCamelCaseViolations(node.identifier)
+    diagnoseLowerCamelCaseViolations(node.identifier, allowUnderscores: false)
     return .skipChildren
   }
 
-  private func diagnoseLowerCamelCaseViolations(_ identifier: TokenSyntax) {
+  private func diagnoseLowerCamelCaseViolations(_ identifier: TokenSyntax, allowUnderscores: Bool) {
     guard case .identifier(let text) = identifier.tokenKind else { return }
     if text.isEmpty { return }
-    if text.dropFirst().contains("_") || ("A"..."Z").contains(text.first!) {
+    if (text.dropFirst().contains("_") && !allowUnderscores) || ("A"..."Z").contains(text.first!) {
       diagnose(.variableNameMustBeLowerCamelCase(text), on: identifier) {
         $0.highlight(identifier.sourceRange(converter: self.context.sourceLocationConverter))
       }
     }
+  }
+}
+
+extension ReturnClauseSyntax {
+  /// Whether this return clause specifies an explicit `Void` return type.
+  fileprivate var isVoid: Bool {
+    if let returnTypeIdentifier = returnType.as(SimpleTypeIdentifierSyntax.self) {
+      return returnTypeIdentifier.name.text == "Void"
+    }
+    if let returnTypeTuple = returnType.as(TupleTypeSyntax.self) {
+      return returnTypeTuple.elements.isEmpty
+    }
+    return false
   }
 }
 

--- a/Sources/SwiftFormatRules/DeclSyntaxProtocol+Comments.swift
+++ b/Sources/SwiftFormatRules/DeclSyntaxProtocol+Comments.swift
@@ -83,9 +83,9 @@ extension DeclSyntaxProtocol {
     let comments = docComment.components(separatedBy: .newlines)
     var params = [ParseComment.Parameter]()
     var commentParagraphs = [String]()
-    var hasFoundParameterList = false
-    var hasFoundReturn = false
+    var currentSection: DocCommentSection = .commentParagraphs
     var returnsDescription: String?
+    var throwsDescription: String?
     // Takes the first sentence of the comment, and counts the number of lines it uses.
     let oneSenteceSummary = docComment.components(separatedBy: ".").first
     let numOfOneSentenceLines = oneSenteceSummary!.components(separatedBy: .newlines).count
@@ -96,40 +96,62 @@ extension DeclSyntaxProtocol {
       let trimmedLine = line.trimmingCharacters(in: .whitespaces)
 
       if trimmedLine.starts(with: "- Parameters") {
-        hasFoundParameterList = true
+        currentSection = .parameters
       } else if trimmedLine.starts(with: "- Parameter") {
-        // If it's only a parameter it's information is inline eith the parameter
+        // If it's only a parameter it's information is inline with the parameter
         // tag, just after the ':'.
         guard let index = trimmedLine.firstIndex(of: ":") else { continue }
         let name = trimmedLine.dropFirst("- Parameter".count)[..<index]
           .trimmingCharacters(in: .init(charactersIn: " -:"))
         let summary = trimmedLine[index...].trimmingCharacters(in: .init(charactersIn: " -:"))
         params.append(ParseComment.Parameter(name: name, summary: summary))
+      } else if trimmedLine.starts(with: "- Throws:") {
+        currentSection = .throwsDescription
+        throwsDescription = String(trimmedLine.dropFirst("- Throws:".count))
       } else if trimmedLine.starts(with: "- Returns:") {
-        hasFoundParameterList = false
-        hasFoundReturn = true
+        currentSection = .returnsDescription
         returnsDescription = String(trimmedLine.dropFirst("- Returns:".count))
-      } else if hasFoundParameterList {
-        // After the paramters tag is found the following lines should be the parameters
-        // description.
-        guard let index = trimmedLine.firstIndex(of: ":") else { continue }
-        let name = trimmedLine[..<index].trimmingCharacters(in: .init(charactersIn: " -:"))
-        let summary = trimmedLine[index...].trimmingCharacters(in: .init(charactersIn: " -:"))
-        params.append(ParseComment.Parameter(name: name, summary: summary))
-      } else if hasFoundReturn {
-        // Appends the return description that is not inline with the return tag.
-        returnsDescription!.append(trimmedLine)
-      } else if trimmedLine != "" {
-        commentParagraphs.append(" " + trimmedLine)
+      } else {
+        switch currentSection {
+        case .parameters:
+          // After the paramters tag is found the following lines should be the parameters
+          // description.
+          guard let index = trimmedLine.firstIndex(of: ":") else { continue }
+          let name = trimmedLine[..<index].trimmingCharacters(in: .init(charactersIn: " -:"))
+          let summary = trimmedLine[index...].trimmingCharacters(in: .init(charactersIn: " -:"))
+          params.append(ParseComment.Parameter(name: name, summary: summary))
+
+        case .returnsDescription:
+          // Appends the return description that is not inline with the return tag.
+          returnsDescription!.append(trimmedLine)
+
+        case .throwsDescription:
+          // Appends the throws description that is not inline with the throws tag.
+          throwsDescription!.append(trimmedLine)
+
+        case .commentParagraphs:
+          if trimmedLine != "" {
+            commentParagraphs.append(" " + trimmedLine)
+          }
+        }
       }
     }
+
     return ParseComment(
       oneSentenceSummary: oneSenteceSummary,
       commentParagraphs: commentParagraphs,
       parameters: params,
+      throwsDescription: throwsDescription,
       returnsDescription: returnsDescription
     )
   }
+}
+
+private enum DocCommentSection {
+    case commentParagraphs
+    case parameters
+    case throwsDescription
+    case returnsDescription
 }
 
 struct ParseComment {
@@ -141,5 +163,6 @@ struct ParseComment {
   var oneSentenceSummary: String?
   var commentParagraphs: [String]?
   var parameters: [Parameter]?
+  var throwsDescription: String?
   var returnsDescription: String?
 }

--- a/Sources/SwiftFormatRules/NeverForceUnwrap.swift
+++ b/Sources/SwiftFormatRules/NeverForceUnwrap.swift
@@ -19,7 +19,7 @@ import SwiftSyntax
 public final class NeverForceUnwrap: SyntaxLintRule {
 
   public override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
-    // Tracks whether "XCTest" is imported in the source file before processing the individual
+    // Tracks whether "XCTest" is imported in the source file before processing individual nodes.
     setImportsXCTest(context: context, sourceFile: node)
     return .visitChildren
   }

--- a/Sources/SwiftFormatRules/NeverForceUnwrap.swift
+++ b/Sources/SwiftFormatRules/NeverForceUnwrap.swift
@@ -18,6 +18,11 @@ import SwiftSyntax
 /// Lint: If a force unwrap is used, a lint warning is raised.
 public final class NeverForceUnwrap: SyntaxLintRule {
 
+  /// Identifies this rule was being opt-in. While force unwrap is an unsafe pattern (i.e. it can
+  /// crash), there are valid contexts for force unwrap where it won't crash. This rule can't
+  /// evaluate the context around the force unwrap to make that determination.
+  public override class var isOptIn: Bool { return true }
+
   public override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
     // Tracks whether "XCTest" is imported in the source file before processing individual nodes.
     setImportsXCTest(context: context, sourceFile: node)

--- a/Sources/SwiftFormatRules/NeverUseForceTry.swift
+++ b/Sources/SwiftFormatRules/NeverUseForceTry.swift
@@ -23,6 +23,11 @@ import SwiftSyntax
 /// TODO: Create exception for NSRegularExpression
 public final class NeverUseForceTry: SyntaxLintRule {
 
+  /// Identifies this rule was being opt-in. While force try is an unsafe pattern (i.e. it can
+  /// crash), there are valid contexts for force try where it won't crash. This rule can't
+  /// evaluate the context around the force try to make that determination.
+  public override class var isOptIn: Bool { return true }
+
   public override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
     setImportsXCTest(context: context, sourceFile: node)
     return .visitChildren

--- a/Sources/SwiftFormatRules/NeverUseImplicitlyUnwrappedOptionals.swift
+++ b/Sources/SwiftFormatRules/NeverUseImplicitlyUnwrappedOptionals.swift
@@ -25,6 +25,12 @@ import SwiftSyntax
 /// Lint: Declaring a property with an implicitly unwrapped type yields a lint error.
 public final class NeverUseImplicitlyUnwrappedOptionals: SyntaxLintRule {
 
+  /// Identifies this rule was being opt-in. While accessing implicitly unwrapped optionals is an
+  /// unsafe pattern (i.e. it can crash), there are valid contexts for using implicitly unwrapped
+  /// optionals where it won't crash. This rule can't evaluate the context around the usage to make
+  /// that determination.
+  public override class var isOptIn: Bool { return true }
+
   // Checks if "XCTest" is an import statement
   public override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
     setImportsXCTest(context: context, sourceFile: node)

--- a/Sources/SwiftFormatRules/NoLeadingUnderscores.swift
+++ b/Sources/SwiftFormatRules/NoLeadingUnderscores.swift
@@ -25,6 +25,12 @@ import SwiftSyntax
 /// Lint: Declaring an identifier with a leading underscore yields a lint error.
 public final class NoLeadingUnderscores: SyntaxLintRule {
 
+  /// Identifies this rule as being opt-in. While leading underscores aren't meant to be used in
+  /// normal circumstances, there are situations where they can be used to hint which APIs should be
+  /// avoided by general users. In particular when APIs must be exported publicly, but the author
+  /// doesn't intend for arbitrary usage.
+  public override class var isOptIn: Bool { return true }
+
   public override func visit(_ node: AssociatedtypeDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseIfNameStartsWithUnderscore(node.identifier)
     return .visitChildren

--- a/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
@@ -58,8 +58,10 @@ public final class ValidateDocumentationComments: SyntaxLintRule {
       $0.trimmingCharacters(in: .whitespaces).starts(with: "- Parameters")
     }
 
-    validateThrows(throwsOrRethrowsKeyword, name: name, throwsDesc: commentInfo.throwsDescription)
-    validateReturn(returnClause, name: name, returnDesc: commentInfo.returnsDescription)
+    validateThrows(
+      throwsOrRethrowsKeyword, name: name, throwsDesc: commentInfo.throwsDescription, node: node)
+    validateReturn(
+      returnClause, name: name, returnDesc: commentInfo.returnsDescription, node: node)
     let funcParameters = funcParametersIdentifiers(in: parameters)
 
     // If the documentation of the parameters is wrong 'docCommentInfo' won't
@@ -89,10 +91,11 @@ public final class ValidateDocumentationComments: SyntaxLintRule {
   private func validateReturn(
     _ returnClause: ReturnClauseSyntax?,
     name: String,
-    returnDesc: String?
+    returnDesc: String?,
+    node: DeclSyntax
   ) {
     if returnClause == nil && returnDesc != nil {
-      diagnose(.removeReturnComment(funcName: name), on: returnClause)
+      diagnose(.removeReturnComment(funcName: name), on: node)
     } else if returnClause != nil && returnDesc == nil {
       diagnose(.documentReturnValue(funcName: name), on: returnClause)
     }
@@ -103,7 +106,8 @@ public final class ValidateDocumentationComments: SyntaxLintRule {
   private func validateThrows(
     _ throwsOrRethrowsKeyword: TokenSyntax?,
     name: String,
-    throwsDesc: String?
+    throwsDesc: String?,
+    node: DeclSyntax
   ) {
     // If a function is marked as `rethrows`, it doesn't have any errors of its
     // own that should be documented. So only require documentation for
@@ -111,7 +115,7 @@ public final class ValidateDocumentationComments: SyntaxLintRule {
     let needsThrowsDesc = throwsOrRethrowsKeyword?.tokenKind == .throwsKeyword
 
     if !needsThrowsDesc && throwsDesc != nil {
-      diagnose(.removeThrowsComment(funcName: name), on: throwsOrRethrowsKeyword)
+      diagnose(.removeThrowsComment(funcName: name), on: throwsOrRethrowsKeyword ?? node.firstToken)
     } else if needsThrowsDesc && throwsDesc == nil {
       diagnose(.documentErrorsThrown(funcName: name), on: throwsOrRethrowsKeyword)
     }

--- a/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
@@ -96,7 +96,12 @@ public final class ValidateDocumentationComments: SyntaxLintRule {
   ) {
     if returnClause == nil && returnDesc != nil {
       diagnose(.removeReturnComment(funcName: name), on: node)
-    } else if returnClause != nil && returnDesc == nil {
+    } else if let returnClause = returnClause, returnDesc == nil {
+      if let returnTypeIdentifier = returnClause.returnType.as(SimpleTypeIdentifierSyntax.self),
+         returnTypeIdentifier.name.text == "Never"
+      {
+        return
+      }
       diagnose(.documentReturnValue(funcName: name), on: returnClause)
     }
   }

--- a/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
@@ -22,6 +22,11 @@ import SwiftSyntax
 ///       invalid (uses `Parameters` when there is only one parameter) will yield a lint error.
 public final class ValidateDocumentationComments: SyntaxLintRule {
 
+  /// Identifies this rule as being opt-in. Accurate and complete documentation comments are
+  /// important, but this rule isn't able to handle situations where portions of documentation are
+  /// redundant. For example when the returns clause is redundant for a simple declaration.
+  public override class var isOptIn: Bool { return true }
+
   public override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
     return checkFunctionLikeDocumentation(
       DeclSyntax(node), name: "init", parameters: node.parameters.parameterList, throwsOrRethrowsKeyword: node.throwsOrRethrowsKeyword)

--- a/Sources/generate-pipeline/PipelineGenerator.swift
+++ b/Sources/generate-pipeline/PipelineGenerator.swift
@@ -96,7 +96,7 @@ final class PipelineGenerator: FileGenerator {
       """
     )
 
-    for ruleName in ruleCollector.allFormatters.sorted() {
+    for ruleName in ruleCollector.allFormatters.map({ $0.typeName }).sorted() {
       handle.write(
         """
             node = \(ruleName)(context: context).visit(node)

--- a/Sources/generate-pipeline/PipelineGenerator.swift
+++ b/Sources/generate-pipeline/PipelineGenerator.swift
@@ -52,6 +52,10 @@ final class PipelineGenerator: FileGenerator {
         /// The formatter context.
         let context: Context
 
+        /// Stores lint and format rule instances, indexed by the `ObjectIdentifier` of a rule's
+        /// class type.
+        var ruleCache = [ObjectIdentifier: Rule]()
+
         /// Creates a new lint pipeline.
         init(context: Context) {
           self.context = context
@@ -71,7 +75,7 @@ final class PipelineGenerator: FileGenerator {
       for ruleName in lintRules.sorted() {
         handle.write(
           """
-              visitIfEnabled(\(ruleName).visit, in: context, for: node)
+              visitIfEnabled(\(ruleName).visit, for: node)
 
           """)
       }

--- a/Sources/generate-pipeline/RuleRegistryGenerator.swift
+++ b/Sources/generate-pipeline/RuleRegistryGenerator.swift
@@ -46,8 +46,8 @@ final class RuleRegistryGenerator: FileGenerator {
       """
     )
 
-    for ruleName in ruleCollector.allLinters.sorted() {
-      handle.write("    \"\(ruleName)\": true,\n")
+    for detectedRule in ruleCollector.allLinters.sorted(by: { $0.typeName < $1.typeName }) {
+      handle.write("    \"\(detectedRule.typeName)\": \(!detectedRule.isOptIn),\n")
     }
     handle.write("  ]\n}\n")
   }

--- a/Sources/swift-format/Subcommands/Format.swift
+++ b/Sources/swift-format/Subcommands/Format.swift
@@ -25,7 +25,7 @@ extension SwiftFormatCommand {
     @Flag(
       name: .shortAndLong,
       help: "Overwrite the current file when formatting.")
-    var inPlace: Bool
+    var inPlace: Bool = false
 
     @OptionGroup()
     var formatOptions: LintFormatOptions

--- a/Sources/swift-format/Subcommands/LegacyMain.swift
+++ b/Sources/swift-format/Subcommands/LegacyMain.swift
@@ -28,9 +28,8 @@ extension SwiftFormatCommand {
     /// If not specified, the tool will be run in format mode.
     @Option(
       name: .shortAndLong,
-      default: .format,
       help: "The mode to run swift-format in. Either 'format', 'lint', or 'dump-configuration'.")
-    var mode: ToolMode
+    var mode: ToolMode = .format
 
     @OptionGroup()
     var lintFormatOptions: LintFormatOptions
@@ -41,7 +40,7 @@ extension SwiftFormatCommand {
     @Flag(
       name: .shortAndLong,
       help: "Overwrite the current file when formatting ('format' mode only).")
-    var inPlace: Bool
+    var inPlace: Bool = false
 
     mutating func validate() throws {
       if inPlace && (mode != .format || lintFormatOptions.paths.isEmpty) {

--- a/Sources/swift-format/Subcommands/LintFormatOptions.swift
+++ b/Sources/swift-format/Subcommands/LintFormatOptions.swift
@@ -51,7 +51,7 @@ struct LintFormatOptions: ParsableArguments {
 
   /// The list of paths to Swift source files that should be formatted or linted.
   @Argument(help: "Zero or more input filenames.")
-  var paths: [String]
+  var paths: [String] = []
 
   @Flag(help: .hidden) var debugDisablePrettyPrint: Bool
   @Flag(help: .hidden) var debugDumpTokenStream: Bool

--- a/Sources/swift-format/Subcommands/LintFormatOptions.swift
+++ b/Sources/swift-format/Subcommands/LintFormatOptions.swift
@@ -37,7 +37,7 @@ struct LintFormatOptions: ParsableArguments {
   @Flag(
     name: .shortAndLong,
     help: "Recursively run on '.swift' files in any provided directories.")
-  var recursive: Bool
+  var recursive: Bool = false
 
   /// Whether unparsable files, due to syntax errors or unrecognized syntax, should be ignored or
   /// treated as containing an error. When ignored, unparsable files are output verbatim in format
@@ -47,14 +47,14 @@ struct LintFormatOptions: ParsableArguments {
     Ignores unparsable files, disabling all diagnostics and formatting for files that contain \
     invalid syntax.
     """)
-  var ignoreUnparsableFiles: Bool
+  var ignoreUnparsableFiles: Bool = false
 
   /// The list of paths to Swift source files that should be formatted or linted.
   @Argument(help: "Zero or more input filenames.")
   var paths: [String] = []
 
-  @Flag(help: .hidden) var debugDisablePrettyPrint: Bool
-  @Flag(help: .hidden) var debugDumpTokenStream: Bool
+  @Flag(help: .hidden) var debugDisablePrettyPrint: Bool = false
+  @Flag(help: .hidden) var debugDumpTokenStream: Bool = false
 
   mutating func validate() throws {
     if recursive && paths.isEmpty {

--- a/Sources/swift-format/VersionOptions.swift
+++ b/Sources/swift-format/VersionOptions.swift
@@ -15,7 +15,7 @@ import ArgumentParser
 /// Encapsulates `--version` flag behavior.
 struct VersionOptions: ParsableArguments {
   @Flag(name: .shortAndLong, help: "Print the version and exit")
-  var version: Bool
+  var version: Bool = false
 
   func validate() throws {
     if version {

--- a/Tests/SwiftFormatPrettyPrintTests/ArrayDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ArrayDeclTests.swift
@@ -103,6 +103,9 @@ final class ArrayDeclTests: PrettyPrintTestCase {
   func testWhitespaceOnlyDoesNotChangeTrailingComma() {
     let input =
       """
+      let a = [
+        "String",
+      ]
       let a = [1, 2, 3,]
       let a: [String] = [
         "One", "Two", "Three", "Four", "Five",

--- a/Tests/SwiftFormatPrettyPrintTests/DictionaryDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/DictionaryDeclTests.swift
@@ -92,6 +92,9 @@ final class DictionaryDeclTests: PrettyPrintTestCase {
   func testWhitespaceOnlyDoesNotChangeTrailingComma() {
     let input =
       """
+      let a = [
+        1: "a",
+      ]
       let a = [1: "a", 2: "b", 3: "c",]
       let a: [Int: String] = [
         1: "a", 2: "b", 3: "c", 4: "d", 5: "e", 6: "f",

--- a/Tests/SwiftFormatRulesTests/AlwaysUseLowerCamelCaseTests.swift
+++ b/Tests/SwiftFormatRulesTests/AlwaysUseLowerCamelCaseTests.swift
@@ -23,6 +23,19 @@ final class AlwaysUseLowerCamelCaseTests: LintOrFormatRuleTestCase {
         case UpperCamelCase
         case lowerCamelCase
       }
+      if let Baz = foo { }
+      guard let foo = [1, 2, 3, 4].first(where: { BadName -> Bool in
+        let TerribleName = BadName
+        return TerribleName != 0
+      }) else { return }
+      var fooVar = [1, 2, 3, 4].first(where: { BadNameInFooVar -> Bool in
+        let TerribleNameInFooVar = BadName
+        return TerribleName != 0
+      })
+      var abc = array.first(where: { (CParam1, _ CParam2: Type, cparam3) -> Bool in return true })
+      func wellNamedFunc(_ BadFuncArg1: Int, BadFuncArgLabel goodFuncArg: String) {
+        var PoorlyNamedVar = 0
+      }
       """
     performLint(AlwaysUseLowerCamelCase.self, input: input)
     XCTAssertDiagnosed(
@@ -39,6 +52,30 @@ final class AlwaysUseLowerCamelCaseTests: LintOrFormatRuleTestCase {
       line: 9, column: 8)
     XCTAssertDiagnosed(
       .nameMustBeLowerCamelCase("UpperCamelCase", description: "enum case"), line: 12, column: 8)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("Baz", description: "constant"), line: 15, column: 8)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("BadName", description: "closure parameter"), line: 16, column: 45)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("TerribleName", description: "constant"), line: 17, column: 7)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("BadNameInFooVar", description: "closure parameter"),
+      line: 20, column: 42)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("TerribleNameInFooVar", description: "constant"),
+      line: 21, column: 7)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("CParam1", description: "closure parameter"), line: 24, column: 33)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("CParam2", description: "closure parameter"), line: 24, column: 44)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("BadFuncArg1", description: "function parameter"),
+      line: 25, column: 22)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("BadFuncArgLabel", description: "argument label"),
+      line: 25, column: 40)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("PoorlyNamedVar", description: "variable"), line: 26, column: 7)
   }
 
   func testIgnoresUnderscoresInTestNames() {

--- a/Tests/SwiftFormatRulesTests/AlwaysUseLowerCamelCaseTests.swift
+++ b/Tests/SwiftFormatRulesTests/AlwaysUseLowerCamelCaseTests.swift
@@ -19,16 +19,26 @@ final class AlwaysUseLowerCamelCaseTests: LintOrFormatRuleTestCase {
       class UnitTests: XCTestCase {
         func test_HappyPath_Through_GoodCode() {}
       }
+      enum FooBarCases {
+        case UpperCamelCase
+        case lowerCamelCase
+      }
       """
     performLint(AlwaysUseLowerCamelCase.self, input: input)
-    XCTAssertDiagnosed(.variableNameMustBeLowerCamelCase("Test"), line: 1, column: 5)
-    XCTAssertNotDiagnosed(.variableNameMustBeLowerCamelCase("foo"))
-    XCTAssertDiagnosed(.variableNameMustBeLowerCamelCase("bad_name"), line: 3, column: 5)
-    XCTAssertNotDiagnosed(.variableNameMustBeLowerCamelCase("_okayName"))
-    XCTAssertNotDiagnosed(.variableNameMustBeLowerCamelCase("Foo"))
-    XCTAssertDiagnosed(.variableNameMustBeLowerCamelCase("FooFunc"), line: 6, column: 8)
     XCTAssertDiagnosed(
-      .variableNameMustBeLowerCamelCase("test_HappyPath_Through_GoodCode"), line: 9, column: 8)
+      .nameMustBeLowerCamelCase("Test", description: "constant"), line: 1, column: 5)
+    XCTAssertNotDiagnosed(.nameMustBeLowerCamelCase("foo", description: "variable"))
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("bad_name", description: "variable"), line: 3, column: 5)
+    XCTAssertNotDiagnosed(.nameMustBeLowerCamelCase("_okayName", description: "variable"))
+    XCTAssertNotDiagnosed(.nameMustBeLowerCamelCase("Foo", description: "struct"))
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("FooFunc", description: "function"), line: 6, column: 8)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("test_HappyPath_Through_GoodCode", description: "function"),
+      line: 9, column: 8)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("UpperCamelCase", description: "enum case"), line: 12, column: 8)
   }
 
   func testIgnoresUnderscoresInTestNames() {
@@ -50,21 +60,30 @@ final class AlwaysUseLowerCamelCaseTests: LintOrFormatRuleTestCase {
       }
       """
     performLint(AlwaysUseLowerCamelCase.self, input: input)
-    XCTAssertDiagnosed(.variableNameMustBeLowerCamelCase("Test"), line: 3, column: 5)
-    XCTAssertDiagnosed(.variableNameMustBeLowerCamelCase("My_Constant_Value"), line: 5, column: 14)
-    XCTAssertNotDiagnosed(.variableNameMustBeLowerCamelCase("test_HappyPath_Through_GoodCode"))
-    XCTAssertDiagnosed(.variableNameMustBeLowerCamelCase("FooFunc"), line: 7, column: 16)
     XCTAssertDiagnosed(
-      .variableNameMustBeLowerCamelCase("helperFunc_For_HappyPath_Setup"), line: 8, column: 16)
+      .nameMustBeLowerCamelCase("Test", description: "constant"), line: 3, column: 5)
     XCTAssertDiagnosed(
-      .variableNameMustBeLowerCamelCase("testLikeMethod_With_Underscores"), line: 9, column: 16)
+      .nameMustBeLowerCamelCase("My_Constant_Value", description: "constant"), line: 5, column: 14)
+    XCTAssertNotDiagnosed(
+      .nameMustBeLowerCamelCase("test_HappyPath_Through_GoodCode", description: "function"))
     XCTAssertDiagnosed(
-      .variableNameMustBeLowerCamelCase("testLikeMethod_With_Underscores2"), line: 10, column: 16)
+      .nameMustBeLowerCamelCase("FooFunc", description: "function"), line: 7, column: 16)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("helperFunc_For_HappyPath_Setup", description: "function"),
+      line: 8, column: 16)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("testLikeMethod_With_Underscores", description: "function"),
+      line: 9, column: 16)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("testLikeMethod_With_Underscores2", description: "function"),
+      line: 10, column: 16)
     XCTAssertNotDiagnosed(
-      .variableNameMustBeLowerCamelCase("test_HappyPath_Through_GoodCode_ReturnsVoid"))
+      .nameMustBeLowerCamelCase(
+        "test_HappyPath_Through_GoodCode_ReturnsVoid", description: "function"))
     XCTAssertNotDiagnosed(
-      .variableNameMustBeLowerCamelCase("test_HappyPath_Through_GoodCode_ReturnsShortVoid"))
+      .nameMustBeLowerCamelCase(
+        "test_HappyPath_Through_GoodCode_ReturnsShortVoid", description: "function"))
     XCTAssertNotDiagnosed(
-      .variableNameMustBeLowerCamelCase("test_HappyPath_Through_GoodCode_Throws"))
+      .nameMustBeLowerCamelCase("test_HappyPath_Through_GoodCode_Throws", description: "function"))
   }
 }

--- a/Tests/SwiftFormatRulesTests/AlwaysUseLowerCamelCaseTests.swift
+++ b/Tests/SwiftFormatRulesTests/AlwaysUseLowerCamelCaseTests.swift
@@ -1,6 +1,11 @@
 import SwiftFormatRules
 
 final class AlwaysUseLowerCamelCaseTests: LintOrFormatRuleTestCase {
+  override func setUp() {
+    super.setUp()
+    shouldCheckForUnassertedDiagnostics = true
+  }
+
   func testInvalidVariableCasing() {
     let input =
       """
@@ -11,13 +16,55 @@ final class AlwaysUseLowerCamelCaseTests: LintOrFormatRuleTestCase {
       struct Foo {
         func FooFunc() {}
       }
+      class UnitTests: XCTestCase {
+        func test_HappyPath_Through_GoodCode() {}
+      }
       """
     performLint(AlwaysUseLowerCamelCase.self, input: input)
-    XCTAssertDiagnosed(.variableNameMustBeLowerCamelCase("Test"))
+    XCTAssertDiagnosed(.variableNameMustBeLowerCamelCase("Test"), line: 1, column: 5)
     XCTAssertNotDiagnosed(.variableNameMustBeLowerCamelCase("foo"))
-    XCTAssertDiagnosed(.variableNameMustBeLowerCamelCase("bad_name"))
+    XCTAssertDiagnosed(.variableNameMustBeLowerCamelCase("bad_name"), line: 3, column: 5)
     XCTAssertNotDiagnosed(.variableNameMustBeLowerCamelCase("_okayName"))
     XCTAssertNotDiagnosed(.variableNameMustBeLowerCamelCase("Foo"))
-    XCTAssertDiagnosed(.variableNameMustBeLowerCamelCase("FooFunc"))
+    XCTAssertDiagnosed(.variableNameMustBeLowerCamelCase("FooFunc"), line: 6, column: 8)
+    XCTAssertDiagnosed(
+      .variableNameMustBeLowerCamelCase("test_HappyPath_Through_GoodCode"), line: 9, column: 8)
+  }
+
+  func testIgnoresUnderscoresInTestNames() {
+    let input =
+      """
+      import XCTest
+
+      let Test = 1
+      class UnitTests: XCTestCase {
+        static let My_Constant_Value = 0
+        func test_HappyPath_Through_GoodCode() {}
+        private func FooFunc() {}
+        private func helperFunc_For_HappyPath_Setup() {}
+        private func testLikeMethod_With_Underscores(_ arg1: ParamType) {}
+        private func testLikeMethod_With_Underscores2() -> ReturnType {}
+        func test_HappyPath_Through_GoodCode_ReturnsVoid() -> Void {}
+        func test_HappyPath_Through_GoodCode_ReturnsShortVoid() -> () {}
+        func test_HappyPath_Through_GoodCode_Throws() throws {}
+      }
+      """
+    performLint(AlwaysUseLowerCamelCase.self, input: input)
+    XCTAssertDiagnosed(.variableNameMustBeLowerCamelCase("Test"), line: 3, column: 5)
+    XCTAssertDiagnosed(.variableNameMustBeLowerCamelCase("My_Constant_Value"), line: 5, column: 14)
+    XCTAssertNotDiagnosed(.variableNameMustBeLowerCamelCase("test_HappyPath_Through_GoodCode"))
+    XCTAssertDiagnosed(.variableNameMustBeLowerCamelCase("FooFunc"), line: 7, column: 16)
+    XCTAssertDiagnosed(
+      .variableNameMustBeLowerCamelCase("helperFunc_For_HappyPath_Setup"), line: 8, column: 16)
+    XCTAssertDiagnosed(
+      .variableNameMustBeLowerCamelCase("testLikeMethod_With_Underscores"), line: 9, column: 16)
+    XCTAssertDiagnosed(
+      .variableNameMustBeLowerCamelCase("testLikeMethod_With_Underscores2"), line: 10, column: 16)
+    XCTAssertNotDiagnosed(
+      .variableNameMustBeLowerCamelCase("test_HappyPath_Through_GoodCode_ReturnsVoid"))
+    XCTAssertNotDiagnosed(
+      .variableNameMustBeLowerCamelCase("test_HappyPath_Through_GoodCode_ReturnsShortVoid"))
+    XCTAssertNotDiagnosed(
+      .variableNameMustBeLowerCamelCase("test_HappyPath_Through_GoodCode_Throws"))
   }
 }

--- a/Tests/SwiftFormatRulesTests/ValidateDocumentationCommentsTests.swift
+++ b/Tests/SwiftFormatRulesTests/ValidateDocumentationCommentsTests.swift
@@ -117,10 +117,29 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
     ///   - p2: Parameter 2.
     ///   - p3: Parameter 3.
     func foo(p1: Int, p2: Int, p3: Int) -> Int {}
+
+    /// One sentence summary.
+    ///
+    /// - Parameters:
+    ///   - p1: Parameter 1.
+    ///   - p2: Parameter 2.
+    ///   - p3: Parameter 3.
+    func neverReturns(p1: Int, p2: Int, p3: Int) -> Never {}
+
+    /// One sentence summary.
+    ///
+    /// - Parameters:
+    ///   - p1: Parameter 1.
+    ///   - p2: Parameter 2.
+    ///   - p3: Parameter 3.
+    /// - Returns: Never returns.
+    func documentedNeverReturns(p1: Int, p2: Int, p3: Int) -> Never {}
     """
     performLint(ValidateDocumentationComments.self, input: input)
     XCTAssertDiagnosed(.removeReturnComment(funcName: "noReturn"), line: 8, column: 1)
     XCTAssertDiagnosed(.documentReturnValue(funcName: "foo"), line: 16, column: 37)
+    XCTAssertNotDiagnosed(.documentReturnValue(funcName: "neverReturns"))
+    XCTAssertNotDiagnosed(.removeReturnComment(funcName: "documentedNeverReturns"))
   }
 
   func testValidDocumentation() {

--- a/Tests/SwiftFormatRulesTests/ValidateDocumentationCommentsTests.swift
+++ b/Tests/SwiftFormatRulesTests/ValidateDocumentationCommentsTests.swift
@@ -1,6 +1,11 @@
 import SwiftFormatRules
 
 final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
+  override func setUp() {
+    super.setUp()
+    shouldCheckForUnassertedDiagnostics = true
+  }
+
   func testParameterDocumentation() {
     let input =
     """
@@ -32,9 +37,9 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
     func testInvalidParameterDesc(command: String, stdin: String) -> String {}
     """
     performLint(ValidateDocumentationComments.self, input: input)
-    XCTAssertDiagnosed(.useSingularParameter)
-    XCTAssertDiagnosed(.usePluralParameters)
-    XCTAssertDiagnosed(.usePluralParameters)
+    XCTAssertDiagnosed(.useSingularParameter, line: 6, column: 1)
+    XCTAssertDiagnosed(.usePluralParameters, line: 15, column: 1)
+    XCTAssertDiagnosed(.usePluralParameters, line: 26, column: 1)
   }
 
   func testParametersName() {
@@ -57,8 +62,8 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
     func foo(p1: Int, p2: Int, p3: Int) -> Int {}
     """
     performLint(ValidateDocumentationComments.self, input: input)
-    XCTAssertDiagnosed(.parametersDontMatch(funcName: "sum"))
-    XCTAssertDiagnosed(.parametersDontMatch(funcName: "foo"))
+    XCTAssertDiagnosed(.parametersDontMatch(funcName: "sum"), line: 7, column: 1)
+    XCTAssertDiagnosed(.parametersDontMatch(funcName: "foo"), line: 15, column: 1)
   }
 
   func testThrowsDocumentation() {
@@ -88,9 +93,9 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
     func doesRethrow(p1: (() throws -> ())) rethrows {}
     """
     performLint(ValidateDocumentationComments.self, input: input)
-    XCTAssertDiagnosed(.removeThrowsComment(funcName: "doesNotThrow"))
-    XCTAssertDiagnosed(.documentErrorsThrown(funcName: "doesThrow"))
-    XCTAssertDiagnosed(.removeThrowsComment(funcName: "doesRethrow"))
+    XCTAssertDiagnosed(.removeThrowsComment(funcName: "doesNotThrow"), line: 8, column: 1)
+    XCTAssertDiagnosed(.documentErrorsThrown(funcName: "doesThrow"), line: 16, column: 43)
+    XCTAssertDiagnosed(.removeThrowsComment(funcName: "doesRethrow"), line: 22, column: 41)
   }
 
   func testReturnDocumentation() {
@@ -114,8 +119,8 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
     func foo(p1: Int, p2: Int, p3: Int) -> Int {}
     """
     performLint(ValidateDocumentationComments.self, input: input)
-    XCTAssertDiagnosed(.removeReturnComment(funcName: "noReturn"))
-    XCTAssertDiagnosed(.documentReturnValue(funcName: "foo"))
+    XCTAssertDiagnosed(.removeReturnComment(funcName: "noReturn"), line: 8, column: 1)
+    XCTAssertDiagnosed(.documentReturnValue(funcName: "foo"), line: 16, column: 37)
   }
 
   func testValidDocumentation() {
@@ -214,7 +219,7 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
     XCTAssertNotDiagnosed(.useSingularParameter)
     XCTAssertNotDiagnosed(.usePluralParameters)
 
-    XCTAssertDiagnosed(.parametersDontMatch(funcName: "incorrectParam"))
+    XCTAssertDiagnosed(.parametersDontMatch(funcName: "incorrectParam"), line: 6, column: 1)
 
     XCTAssertNotDiagnosed(.documentReturnValue(funcName: "singularParam"))
     XCTAssertNotDiagnosed(.removeReturnComment(funcName: "singularParam"))
@@ -268,8 +273,8 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
     XCTAssertNotDiagnosed(.useSingularParameter)
     XCTAssertNotDiagnosed(.usePluralParameters)
 
-    XCTAssertDiagnosed(.parametersDontMatch(funcName: "init"))
-    XCTAssertDiagnosed(.removeReturnComment(funcName: "init"))
+    XCTAssertDiagnosed(.parametersDontMatch(funcName: "init"), line: 6, column: 3)
+    XCTAssertDiagnosed(.removeReturnComment(funcName: "init"), line: 6, column: 3)
 
     XCTAssertNotDiagnosed(.documentReturnValue(funcName: "init"))
     XCTAssertNotDiagnosed(.removeReturnComment(funcName: "init"))

--- a/Tests/SwiftFormatRulesTests/ValidateDocumentationCommentsTests.swift
+++ b/Tests/SwiftFormatRulesTests/ValidateDocumentationCommentsTests.swift
@@ -61,6 +61,38 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
     XCTAssertDiagnosed(.parametersDontMatch(funcName: "foo"))
   }
 
+  func testThrowsDocumentation() {
+    let input =
+    """
+    /// One sentence summary.
+    ///
+    /// - Parameters:
+    ///   - p1: Parameter 1.
+    ///   - p2: Parameter 2.
+    ///   - p3: Parameter 3.
+    /// - Throws: an error.
+    func doesNotThrow(p1: Int, p2: Int, p3: Int) {}
+
+    /// One sentence summary.
+    ///
+    /// - Parameters:
+    ///   - p1: Parameter 1.
+    ///   - p2: Parameter 2.
+    ///   - p3: Parameter 3.
+    func doesThrow(p1: Int, p2: Int, p3: Int) throws {}
+
+    /// One sentence summary.
+    ///
+    /// - Parameter p1: Parameter 1.
+    /// - Throws: doesn't really throw, just rethrows
+    func doesRethrow(p1: (() throws -> ())) rethrows {}
+    """
+    performLint(ValidateDocumentationComments.self, input: input)
+    XCTAssertDiagnosed(.removeThrowsComment(funcName: "doesNotThrow"))
+    XCTAssertDiagnosed(.documentErrorsThrown(funcName: "doesThrow"))
+    XCTAssertDiagnosed(.removeThrowsComment(funcName: "doesRethrow"))
+  }
+
   func testReturnDocumentation() {
     let input =
     """
@@ -104,9 +136,17 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
     /// - Parameters:
     ///   - command: The command to execute in the shell environment.
     ///   - stdin: The string to use as standard input.
+    /// - Throws: An error, possibly.
     /// - Returns: A string containing the contents of the invoked process's
     ///   standard output.
-    func pluralParam(command: String, stdin: String) -> String {
+    func pluralParam(command: String, stdin: String) throws -> String {
+    // ...
+    }
+
+    /// One sentence summary.
+    ///
+    /// - Parameter p1: Parameter 1.
+    func rethrower(p1: (() throws -> ())) rethrows {
     // ...
     }
 
@@ -126,6 +166,11 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
     XCTAssertNotDiagnosed(.documentReturnValue(funcName: "pluralParam"))
     XCTAssertNotDiagnosed(.removeReturnComment(funcName: "pluralParam"))
     XCTAssertNotDiagnosed(.parametersDontMatch(funcName: "pluralParam"))
+    XCTAssertNotDiagnosed(.documentErrorsThrown(funcName: "pluralParam"))
+    XCTAssertNotDiagnosed(.removeThrowsComment(funcName: "pluralParam"))
+
+    XCTAssertNotDiagnosed(.documentErrorsThrown(funcName: "pluralParam"))
+    XCTAssertNotDiagnosed(.removeThrowsComment(funcName: "pluralParam"))
 
     XCTAssertNotDiagnosed(.documentReturnValue(funcName: "ommitedFunc"))
     XCTAssertNotDiagnosed(.removeReturnComment(funcName: "ommitedFunc"))
@@ -207,6 +252,16 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
       init(label command: String, label2 stdin: String) {
       // ...
       }
+
+      /// Brief summary.
+      ///
+      /// - Parameters:
+      ///   - command: The command to execute in the shell environment.
+      ///   - stdin: The string to use as standard input.
+      /// - Throws: An error.
+      init(label command: String, label2 stdin: String) throws {
+      // ...
+      }
     }
     """
     performLint(ValidateDocumentationComments.self, input: input)
@@ -223,5 +278,11 @@ final class ValidateDocumentationCommentsTests: LintOrFormatRuleTestCase {
     XCTAssertNotDiagnosed(.documentReturnValue(funcName: "init"))
     XCTAssertNotDiagnosed(.removeReturnComment(funcName: "init"))
     XCTAssertNotDiagnosed(.parametersDontMatch(funcName: "init"))
+
+    XCTAssertNotDiagnosed(.documentReturnValue(funcName: "init"))
+    XCTAssertNotDiagnosed(.removeReturnComment(funcName: "init"))
+    XCTAssertNotDiagnosed(.parametersDontMatch(funcName: "init"))
+    XCTAssertNotDiagnosed(.documentErrorsThrown(funcName: "init"))
+    XCTAssertNotDiagnosed(.removeThrowsComment(funcName: "init"))
   }
 }

--- a/Tests/SwiftFormatRulesTests/XCTestManifests.swift
+++ b/Tests/SwiftFormatRulesTests/XCTestManifests.swift
@@ -398,6 +398,7 @@ extension ValidateDocumentationCommentsTests {
         ("testInitializer", testInitializer),
         ("testParameterDocumentation", testParameterDocumentation),
         ("testParametersName", testParametersName),
+        ("testThrowsDocumentation", testThrowsDocumentation),
         ("testReturnDocumentation", testReturnDocumentation),
         ("testSeparateLabelAndIdentifier", testSeparateLabelAndIdentifier),
         ("testValidDocumentation", testValidDocumentation),


### PR DESCRIPTION
All changes since fa84e116f909f487b3886f498ac19df8cb43fc60 have been Swift 5.3 compatible. The only omission is 33f0b37f607d90a6da7d445140b798a09a57f778, which addressed a breaking API change from the addition of the `async` keyword in `master`.