### PR TITLE
Fix for newly optional return type of `withDigits`.

### DIFF
--- a/Sources/SwiftFormatRules/GroupNumericLiterals.swift
+++ b/Sources/SwiftFormatRules/GroupNumericLiterals.swift
@@ -59,11 +59,15 @@ public final class GroupNumericLiterals: SyntaxFormatRule {
     }
 
     newDigits = isNegative ? "-" + newDigits : newDigits
-    let result = node.withDigits(
-      SyntaxFactory.makeIntegerLiteral(
-        newDigits,
-        leadingTrivia: node.digits.leadingTrivia,
-        trailingTrivia: node.digits.trailingTrivia))
+    guard
+      let result = node.withDigits(
+        SyntaxFactory.makeIntegerLiteral(
+          newDigits,
+          leadingTrivia: node.digits.leadingTrivia,
+          trailingTrivia: node.digits.trailingTrivia))
+    else {
+      return ExprSyntax(node)
+    }
     return ExprSyntax(result)
   }
 


### PR DESCRIPTION
The `withDigits` method was updated to return an optional, which causes this to fail to build. I think a nil value here would indicate an error in swift-format's numeric grouping that resulted in an invalid numeric literal.

`withDigits` was udpated in a recent swift-syntax change:
https://github.com/apple/swift-syntax/commit/94fc5ae3f34fac87380756b9c17ea7c6752a227b#diff-8c79a56bd4eb3d1313169ca412f5e11eL2387