### PR TITLE
Revert "Fix for newly optional return type of `withDigits`."

### DIFF
--- a/Sources/SwiftFormatRules/GroupNumericLiterals.swift
+++ b/Sources/SwiftFormatRules/GroupNumericLiterals.swift
@@ -59,15 +59,11 @@ public final class GroupNumericLiterals: SyntaxFormatRule {
     }
 
     newDigits = isNegative ? "-" + newDigits : newDigits
-    guard
-      let result = node.withDigits(
-        SyntaxFactory.makeIntegerLiteral(
-          newDigits,
-          leadingTrivia: node.digits.leadingTrivia,
-          trailingTrivia: node.digits.trailingTrivia))
-    else {
-      return ExprSyntax(node)
-    }
+    let result = node.withDigits(
+      SyntaxFactory.makeIntegerLiteral(
+        newDigits,
+        leadingTrivia: node.digits.leadingTrivia,
+        trailingTrivia: node.digits.trailingTrivia))
     return ExprSyntax(result)
   }
 


### PR DESCRIPTION
Reverts apple/swift-format#237

The change that made `makeIntegerLiteralExpr` return an optional was reverted, so this needs to be reverted to build swift-format.