### PR TITLE
Multithread processing source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ as well as the following command line options:
 * `-i/--in-place`: Overwrites the input files when formatting instead of
   printing the results to standard output.
 
+* `-p/--parallel`: Process files in parallel, simultaneously across
+  multiple cores.
+
 * `-r/--recursive`: If specified, then the tool will process `.swift` source
   files in any directories listed on the command line and their descendants.
   Without this flag, it is an error to list a directory on the command line.

--- a/Sources/swift-format/Subcommands/LintFormatOptions.swift
+++ b/Sources/swift-format/Subcommands/LintFormatOptions.swift
@@ -49,6 +49,12 @@ struct LintFormatOptions: ParsableArguments {
     """)
   var ignoreUnparsableFiles: Bool = false
 
+  /// Whether or not to run the formatter/linter in parallel.
+  @Flag(
+    name: .shortAndLong,
+    help: "Process files in parallel, simultaneously across multiple cores.")
+  var parallel: Bool = false
+
   /// The list of paths to Swift source files that should be formatted or linted.
   @Argument(help: "Zero or more input filenames.")
   var paths: [String] = []


### PR DESCRIPTION
Previously every source file was formatted / linted one by one. On our
codebase this took a full project format from ~17 minutes to ~5 minutes.

This is an updated version of https://github.com/apple/swift-format/pull/117

Depends on:

- https://github.com/apple/swift-format/pull/242
- https://github.com/apple/swift-syntax/pull/243