### PR TITLE
Convert another doc comment rule to opt-in and fix some typos.

### DIFF
--- a/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
+++ b/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
@@ -17,7 +17,7 @@ enum RuleRegistry {
     "AllPublicDeclarationsHaveDocumentation": false,
     "AlwaysUseLowerCamelCase": true,
     "AmbiguousTrailingClosureOverload": true,
-    "BeginDocumentationCommentWithOneLineSummary": true,
+    "BeginDocumentationCommentWithOneLineSummary": false,
     "DoNotUseSemicolons": true,
     "DontRepeatTypeInStaticProperties": true,
     "FileScopedDeclarationPrivacy": true,

--- a/Sources/SwiftFormatRules/AllPublicDeclarationsHaveDocumentation.swift
+++ b/Sources/SwiftFormatRules/AllPublicDeclarationsHaveDocumentation.swift
@@ -18,7 +18,7 @@ import SwiftSyntax
 /// Lint: If a public declaration is missing a documentation comment, a lint error is raised.
 public final class AllPublicDeclarationsHaveDocumentation: SyntaxLintRule {
 
-  /// Identifies this rule was being opt-in. While docs on most public declarations are beneficial,
+  /// Identifies this rule as being opt-in. While docs on most public declarations are beneficial,
   /// there are a number of public decls where docs are either redundant or superfluous. This rule
   /// can't differentiate those situations and will make a lot of noise for projects that are
   /// intentionally avoiding docs on some decls.

--- a/Sources/SwiftFormatRules/BeginDocumentationCommentWithOneLineSummary.swift
+++ b/Sources/SwiftFormatRules/BeginDocumentationCommentWithOneLineSummary.swift
@@ -26,6 +26,10 @@ public final class BeginDocumentationCommentWithOneLineSummary: SyntaxLintRule {
   /// This allows test runs on those platforms to test both implementations.
   public static var _forcesFallbackModeForTesting = false
 
+  /// Identifies this rule as being opt-in. Well written docs on declarations are important, but
+  /// this rule isn't linguistically advanced enough on all platforms to be applied universally.
+  public override class var isOptIn: Bool { return true }
+
   public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseDocComments(in: DeclSyntax(node))
     return .skipChildren

--- a/Sources/SwiftFormatRules/NeverForceUnwrap.swift
+++ b/Sources/SwiftFormatRules/NeverForceUnwrap.swift
@@ -18,7 +18,7 @@ import SwiftSyntax
 /// Lint: If a force unwrap is used, a lint warning is raised.
 public final class NeverForceUnwrap: SyntaxLintRule {
 
-  /// Identifies this rule was being opt-in. While force unwrap is an unsafe pattern (i.e. it can
+  /// Identifies this rule as being opt-in. While force unwrap is an unsafe pattern (i.e. it can
   /// crash), there are valid contexts for force unwrap where it won't crash. This rule can't
   /// evaluate the context around the force unwrap to make that determination.
   public override class var isOptIn: Bool { return true }

--- a/Sources/SwiftFormatRules/NeverUseForceTry.swift
+++ b/Sources/SwiftFormatRules/NeverUseForceTry.swift
@@ -23,7 +23,7 @@ import SwiftSyntax
 /// TODO: Create exception for NSRegularExpression
 public final class NeverUseForceTry: SyntaxLintRule {
 
-  /// Identifies this rule was being opt-in. While force try is an unsafe pattern (i.e. it can
+  /// Identifies this rule as being opt-in. While force try is an unsafe pattern (i.e. it can
   /// crash), there are valid contexts for force try where it won't crash. This rule can't
   /// evaluate the context around the force try to make that determination.
   public override class var isOptIn: Bool { return true }

--- a/Sources/SwiftFormatRules/NeverUseImplicitlyUnwrappedOptionals.swift
+++ b/Sources/SwiftFormatRules/NeverUseImplicitlyUnwrappedOptionals.swift
@@ -25,7 +25,7 @@ import SwiftSyntax
 /// Lint: Declaring a property with an implicitly unwrapped type yields a lint error.
 public final class NeverUseImplicitlyUnwrappedOptionals: SyntaxLintRule {
 
-  /// Identifies this rule was being opt-in. While accessing implicitly unwrapped optionals is an
+  /// Identifies this rule as being opt-in. While accessing implicitly unwrapped optionals is an
   /// unsafe pattern (i.e. it can crash), there are valid contexts for using implicitly unwrapped
   /// optionals where it won't crash. This rule can't evaluate the context around the usage to make
   /// that determination.


### PR DESCRIPTION
This converts the rule `BeginDocumentationCommentWithOneLineSummary` to opt-in status. The linguistic APIs for sentence detection aren't available on Linux, and the rule creates a lot of noise and is inconsistent across platforms.

This also fixes a few typos from doc comments explaining the opt-in status of some other rules.