### PR TITLE
Handle `ignore-unparsable-files` option in LintFrontend.

### DIFF
--- a/Sources/swift-format/Frontend/LintFrontend.swift
+++ b/Sources/swift-format/Frontend/LintFrontend.swift
@@ -39,6 +39,10 @@ class LintFrontend: Frontend {
           .error, "Unable to lint \(path): file is not readable or does not exist."))
       return
     } catch SwiftFormatError.fileContainsInvalidSyntax(let position) {
+      guard !lintFormatOptions.ignoreUnparsableFiles else {
+        // The caller wants to silently ignore this error.
+        return
+      }
       let location = SourceLocationConverter(file: path, source: source).location(for: position)
       diagnosticEngine.diagnose(
         Diagnostic.Message(.error, "file contains invalid or unrecognized Swift syntax."),


### PR DESCRIPTION
The LintFrontend was ignoring the option to ignore unparsable files and reporting a diagnostic. This option is meant to prevent diagnostics and formatting changes to occur in files with unparsable syntax. The LintFrontend now silently ignores unparsable files, not raising any diagnostics.