### PR TITLE
Add strict flag

### DIFF
--- a/Sources/swift-format/Subcommands/Lint.swift
+++ b/Sources/swift-format/Subcommands/Lint.swift
@@ -21,11 +21,22 @@ extension SwiftFormatCommand {
 
     @OptionGroup()
     var lintOptions: LintFormatOptions
+    
+    @Flag(
+      name: .shortAndLong,
+      help: "Fail on warnings."
+    )
+    var strict: Bool = false
 
     func run() throws {
       let frontend = LintFrontend(lintFormatOptions: lintOptions)
       frontend.run()
       if frontend.errorsWereEmitted { throw ExitCode.failure }
+      if strict,
+         frontend.diagnosticEngine.diagnostics
+            .contains(where: { $0.message.severity == .warning }) {
+        throw ExitCode.failure
+      }
     }
   }
 }


### PR DESCRIPTION
Hi!

I'd find it quite useful to be able to promote warnings to be errors when running `swift-format lint`.

My use-case is that I'd like to validate on CI that no formatting is needed but we want to leave it up to the developer to fix it - this is very similar to what eg. `swiftlint` offers (and `swiftformat` offers a similar functionality as well, for that matter).
The solution is quite simple and more-or-less copies `if frontend.errorsWereEmitted { throw ExitCode.failure }`.

This PR is only a draft to validate whether such feature would be welcome, so there are no tests (I have validated this only by running it locally).

Sorry if this is already possible and I have missed it 🙇 (I have tried to see if there's any mention of this in the repo and in the previous PRs, but have not found any)