### PR TITLE
Fix some tests that are broken against the latest toolchains.

### DIFF
--- a/Tests/SwiftFormatRulesTests/ReturnVoidInsteadOfEmptyTupleTests.swift
+++ b/Tests/SwiftFormatRulesTests/ReturnVoidInsteadOfEmptyTupleTests.swift
@@ -90,18 +90,18 @@ final class ReturnVoidInsteadOfEmptyTupleTests: LintOrFormatRuleTestCase {
       input:
         """
         let callback: () -> /*foo*/()/*bar*/
-        let callback: (Int ->   /*foo*/   ()   /*bar*/) -> ()
+        let callback: ((Int) ->   /*foo*/   ()   /*bar*/) -> ()
         """,
       expected:
         """
         let callback: () -> /*foo*/Void/*bar*/
-        let callback: (Int ->   /*foo*/   Void   /*bar*/) -> Void
+        let callback: ((Int) ->   /*foo*/   Void   /*bar*/) -> Void
         """,
       checkForUnassertedDiagnostics: true
     )
     XCTAssertDiagnosed(.returnVoid, line: 1, column: 28)
-    XCTAssertDiagnosed(.returnVoid, line: 2, column: 35)
-    XCTAssertDiagnosed(.returnVoid, line: 2, column: 52)
+    XCTAssertDiagnosed(.returnVoid, line: 2, column: 37)
+    XCTAssertDiagnosed(.returnVoid, line: 2, column: 54)
   }
 
   func testEmptyTupleWithInternalCommentsIsDiagnosedButNotReplaced() {

--- a/Tests/SwiftFormatTests/SyntaxValidatingVisitorTests.swift
+++ b/Tests/SwiftFormatTests/SyntaxValidatingVisitorTests.swift
@@ -32,15 +32,8 @@ final class SyntaxValidatingVisitorTests: XCTestCase {
     input =
       """
       switch a {
-      case b, c, d: break
       @unknown what_is_this default: break
       }
-      """
-    assertInvalidSyntax(in: input, atLine: 3, column: 1)
-
-    input =
-      """
-      @unknown c class Foo {}
       """
     assertInvalidSyntax(in: input, atLine: 1, column: 1)
   }


### PR DESCRIPTION
These are broken either because of parser crashes (due to malformed
input, which we can change easily enough) or due to potential
behavioral changes.

See SR-14552 and SR-14553.