### PR TITLE
Support Swift 5.5 concurrency syntax.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1068,6 +1068,8 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   override func visit(_ node: ClosureSignatureSyntax) -> SyntaxVisitorContinueKind {
     before(node.firstToken, tokens: .open)
 
+    arrangeAttributeList(node.attributes, suppressFinalBreak: node.input == nil)
+
     if let input = node.input {
       // We unconditionally put a break before the `in` keyword below, so we should only put a break
       // after the capture list's right bracket if there are arguments following it or we'll end up
@@ -2531,11 +2533,18 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   // MARK: - Various other helper methods
 
   /// Applies formatting tokens around and between the attributes in an attribute list.
-  private func arrangeAttributeList(_ attributes: AttributeListSyntax?) {
+  private func arrangeAttributeList(
+    _ attributes: AttributeListSyntax?,
+    suppressFinalBreak: Bool = false
+  ) {
     if let attributes = attributes {
       before(attributes.firstToken, tokens: .open)
       insertTokens(.break(.same), betweenElementsOf: attributes)
-      after(attributes.lastToken, tokens: .close, .break(.same))
+      var afterAttributeTokens = [Token.close]
+      if !suppressFinalBreak {
+        afterAttributeTokens.append(.break(.same))
+      }
+      after(attributes.lastToken, tokens: afterAttributeTokens)
     }
   }
 

--- a/Tests/SwiftFormatPrettyPrintTests/AwaitExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/AwaitExprTests.swift
@@ -1,0 +1,127 @@
+import SwiftFormatConfiguration
+
+final class AwaitExprTests: PrettyPrintTestCase {
+  func testBasicAwaits() {
+    let input =
+      """
+      let a = await asynchronousFunction()
+      let b = await longerAsynchronousFunction()
+      let c = await evenLongerAndLongerAsynchronousFunction()
+      """
+
+    let expected =
+      """
+      let a = await asynchronousFunction()
+      let b =
+        await longerAsynchronousFunction()
+      let c =
+        await
+        evenLongerAndLongerAsynchronousFunction()
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 36)
+  }
+
+  func testAwaitKeywordBreaking() {
+    let input =
+      """
+      let aVeryLongArgumentName = await foo.bar()
+      let aVeryLongArgumentName = await
+        foo.bar()
+      let abc = await foo.baz().quxxe(a, b, c).bar()
+      let abc = await foo
+        .baz().quxxe(a, b, c).bar()
+      let abc = await [1, 2, 3, 4, 5, 6, 7].baz().quxxe(a, b, c).bar()
+      let abc = await [1, 2, 3, 4, 5, 6, 7]
+        .baz().quxxe(a, b, c).bar()
+      let abc = await foo.baz().quxxe(a, b, c).bar[0]
+      let abc = await foo
+        .baz().quxxe(a, b, c).bar[0]
+      let abc = await
+        foo
+        .baz().quxxe(a, b, c).bar[0]
+      """
+
+    let expected =
+      """
+      let aVeryLongArgumentName =
+        await foo.bar()
+      let aVeryLongArgumentName =
+        await foo.bar()
+      let abc = await foo.baz().quxxe(a, b, c)
+        .bar()
+      let abc =
+        await foo
+        .baz().quxxe(a, b, c).bar()
+      let abc = await [1, 2, 3, 4, 5, 6, 7]
+        .baz().quxxe(a, b, c).bar()
+      let abc = await [1, 2, 3, 4, 5, 6, 7]
+        .baz().quxxe(a, b, c).bar()
+      let abc = await foo.baz().quxxe(a, b, c)
+        .bar[0]
+      let abc =
+        await foo
+        .baz().quxxe(a, b, c).bar[0]
+      let abc =
+        await foo
+        .baz().quxxe(a, b, c).bar[0]
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 42)
+  }
+
+  func testTryAwaitKeywordBreaking() {
+    let input =
+      """
+      let aVeryLongArgumentName = try await foo.bar()
+      let aVeryLongArgumentName = try await
+        foo.bar()
+      let abc = try await foo.baz().quxxe(a, b, c).bar()
+      let abc = try await foo
+        .baz().quxxe(a, b, c).bar()
+      let abc = try await [1, 2, 3, 4, 5, 6, 7].baz().quxxe(a, b, c).bar()
+      let abc = try await [1, 2, 3, 4, 5, 6, 7]
+        .baz().quxxe(a, b, c).bar()
+      let abc = try await foo.baz().quxxe(a, b, c).bar[0]
+      let abc = try await foo
+        .baz().quxxe(a, b, c).bar[0]
+      let abc = try await
+        foo
+        .baz().quxxe(a, b, c).bar[0]
+      let abc = try await thisIsASuperblyExtremelyVeryLongFunctionName()
+      """
+
+    let expected =
+      """
+      let aVeryLongArgumentName =
+        try await foo.bar()
+      let aVeryLongArgumentName =
+        try await foo.bar()
+      let abc = try await foo.baz().quxxe(a, b, c)
+        .bar()
+      let abc =
+        try await foo
+        .baz().quxxe(a, b, c).bar()
+      let abc = try await [1, 2, 3, 4, 5, 6, 7]
+        .baz().quxxe(a, b, c).bar()
+      let abc = try await [1, 2, 3, 4, 5, 6, 7]
+        .baz().quxxe(a, b, c).bar()
+      let abc = try await foo.baz().quxxe(a, b, c)
+        .bar[0]
+      let abc =
+        try await foo
+        .baz().quxxe(a, b, c).bar[0]
+      let abc =
+        try await foo
+        .baz().quxxe(a, b, c).bar[0]
+      let abc =
+        try await
+        thisIsASuperblyExtremelyVeryLongFunctionName()
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 46)
+  }
+}

--- a/Tests/SwiftFormatPrettyPrintTests/ClassDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ClassDeclTests.swift
@@ -489,4 +489,43 @@ final class ClassDeclTests: PrettyPrintTestCase {
     let input = "class Foo { var bar: Int }"
     assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 50)
   }
+
+  func testBasicActorDeclarations() {
+    let input =
+      """
+      actor MyActor {
+        let A: Int
+        let B: Bool
+      }
+      public actor MyActor {
+        let A: Int
+        let B: Bool
+      }
+      public actor MyLongerActor {
+        let A: Int
+        let B: Bool
+      }
+      """
+
+    let expected =
+      """
+      actor MyActor {
+        let A: Int
+        let B: Bool
+      }
+      public actor MyActor {
+        let A: Int
+        let B: Bool
+      }
+      public actor
+        MyLongerActor
+      {
+        let A: Int
+        let B: Bool
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 25)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/ClosureExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ClosureExprTests.swift
@@ -379,10 +379,19 @@ final class ClosureExprTests: PrettyPrintTestCase {
       (s1: String, s2: String, s3: String) throws -> AVeryLongReturnTypeThatOverflowsFiftyColumns in return s1 > s2
       })
       funcCall(closure: {
+      (s1: String, s2: String, n: Int) async throws -> AVeryLongReturnTypeThatOverflowsFiftyColumns in return s1 > s2
+      })
+      funcCall(closure: {
+      (s1: String, s2: String, s3: String) async throws -> AVeryLongReturnTypeThatOverflowsFiftyColumns in return s1 > s2
+      })
+      funcCall(closure: {
       () throws -> Bool in return s1 > s2
       })
       funcCall(closure: {
       () throws -> AVeryLongReturnTypeThatOverflowsFiftyColumns in return s1 > s2
+      })
+      funcCall(closure: {
+      () async throws -> AVeryLongReturnTypeThatOverflowsFiftyColumns in return s1 > s2
       })
       """
 
@@ -398,10 +407,26 @@ final class ClosureExprTests: PrettyPrintTestCase {
         in return s1 > s2
       })
       funcCall(closure: {
+        (s1: String, s2: String, n: Int) async throws
+          -> AVeryLongReturnTypeThatOverflowsFiftyColumns
+        in return s1 > s2
+      })
+      funcCall(closure: {
+        (s1: String, s2: String, s3: String)
+          async throws
+          -> AVeryLongReturnTypeThatOverflowsFiftyColumns
+        in return s1 > s2
+      })
+      funcCall(closure: {
         () throws -> Bool in return s1 > s2
       })
       funcCall(closure: {
         () throws
+          -> AVeryLongReturnTypeThatOverflowsFiftyColumns
+        in return s1 > s2
+      })
+      funcCall(closure: {
+        () async throws
           -> AVeryLongReturnTypeThatOverflowsFiftyColumns
         in return s1 > s2
       })
@@ -425,10 +450,29 @@ final class ClosureExprTests: PrettyPrintTestCase {
         in return s1 > s2
       })
       funcCall(closure: {
+        (
+          s1: String, s2: String, n: Int
+        ) async throws
+          -> AVeryLongReturnTypeThatOverflowsFiftyColumns
+        in return s1 > s2
+      })
+      funcCall(closure: {
+        (
+          s1: String, s2: String, s3: String
+        ) async throws
+          -> AVeryLongReturnTypeThatOverflowsFiftyColumns
+        in return s1 > s2
+      })
+      funcCall(closure: {
         () throws -> Bool in return s1 > s2
       })
       funcCall(closure: {
         () throws
+          -> AVeryLongReturnTypeThatOverflowsFiftyColumns
+        in return s1 > s2
+      })
+      funcCall(closure: {
+        () async throws
           -> AVeryLongReturnTypeThatOverflowsFiftyColumns
         in return s1 > s2
       })

--- a/Tests/SwiftFormatPrettyPrintTests/ClosureExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ClosureExprTests.swift
@@ -484,4 +484,32 @@ final class ClosureExprTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(
       input: input, expected: expectedKeepingOutputTogether, linelength: 50, configuration: config)
   }
+
+  func testClosureSignatureAttributes() {
+    let input =
+      """
+      let a = { @MainActor in print("hi") }
+      let b = { @MainActor in print("hello world") }
+      let c = { @MainActor param in print("hi") }
+      let d = { @MainActor (a: Int) async -> Int in print("hi") }
+      """
+
+    let expected =
+      """
+      let a = { @MainActor in print("hi") }
+      let b = { @MainActor in
+        print("hello world")
+      }
+      let c = { @MainActor param in
+        print("hi")
+      }
+      let d = {
+        @MainActor (a: Int) async -> Int in
+        print("hi")
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/ForInStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ForInStmtTests.swift
@@ -329,4 +329,53 @@ final class ForInStmtTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 80)
   }
+
+  func testForAwait() {
+    let input =
+      """
+      for await line in file {
+        print(line)
+      }
+      """
+
+    let expected =
+      """
+      for await line
+        in file
+      {
+        print(line)
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 15)
+  }
+
+  func testForTryAwait() {
+    let input =
+      """
+      for try await line in file {
+        for try await ch in line {
+          print(ch)
+        }
+      }
+      """
+
+    let expected =
+      """
+      for try await
+        line in file
+      {
+        for
+          try await
+          ch in line
+        {
+          print(ch)
+        }
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 14)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
@@ -1136,4 +1136,94 @@ final class FunctionDeclTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 23)
   }
+
+  func testFunctionDeclAsync() {
+    let input =
+      """
+      func myFun(var1: Int) async -> Double {
+        print("Hello World")
+        if badCondition {
+          throw Error
+        }
+        return 1.0
+      }
+      func reallyLongName(var1: Int, var2: Double, var3: Bool) async -> Double {
+        print("Hello World")
+        if badCondition {
+          throw Error
+        }
+        return 1.0
+      }
+      """
+
+    let expected =
+      """
+      func myFun(var1: Int) async -> Double {
+        print("Hello World")
+        if badCondition {
+          throw Error
+        }
+        return 1.0
+      }
+      func reallyLongName(
+        var1: Int, var2: Double, var3: Bool
+      ) async -> Double {
+        print("Hello World")
+        if badCondition {
+          throw Error
+        }
+        return 1.0
+      }
+
+      """
+
+    var config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 49, configuration: config)
+  }
+
+  func testFunctionDeclAsyncThrows() {
+    let input =
+      """
+      func myFun(var1: Int) async throws -> Double {
+        print("Hello World")
+        if badCondition {
+          throw Error
+        }
+        return 1.0
+      }
+      func reallyLongName(var1: Int, var2: Double, var3: Bool) async throws -> Double {
+        print("Hello World")
+        if badCondition {
+          throw Error
+        }
+        return 1.0
+      }
+      """
+
+    let expected =
+      """
+      func myFun(var1: Int) async throws -> Double {
+        print("Hello World")
+        if badCondition {
+          throw Error
+        }
+        return 1.0
+      }
+      func reallyLongName(
+        var1: Int, var2: Double, var3: Bool
+      ) async throws -> Double {
+        print("Hello World")
+        if badCondition {
+          throw Error
+        }
+        return 1.0
+      }
+
+      """
+
+    var config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 49, configuration: config)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/SequenceExprFoldingTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/SequenceExprFoldingTests.swift
@@ -118,6 +118,34 @@ final class SequenceExprFoldingTests: XCTestCase {
       "{ a ? b : try { c ( ) + { d * e }}}")
   }
 
+  func testAwaitFolding() {
+    assertFoldedExprStructure("await a() + b", "await { a ( ) + b }")
+    assertFoldedExprStructure("await a() + b * c", "await { a ( ) + { b * c }}")
+  }
+
+  func testAwaitTernaryFolding() {
+    assertFoldedExprStructure(
+      "a ? b : await c() + d",
+      "{ a ? b : await { c ( ) + d }}")
+    assertFoldedExprStructure(
+      "a ? b : await c() + d * e",
+      "{ a ? b : await { c ( ) + { d * e }}}")
+  }
+
+  func testTryAwaitFolding() {
+    assertFoldedExprStructure("try await a() + b", "try await { a ( ) + b }")
+    assertFoldedExprStructure("try await a() + b * c", "try await { a ( ) + { b * c }}")
+  }
+
+  func testTryAwaitTernaryFolding() {
+    assertFoldedExprStructure(
+      "a ? b : try await c() + d",
+      "{ a ? b : try await { c ( ) + d }}")
+    assertFoldedExprStructure(
+      "a ? b : try await c() + d * e",
+      "{ a ? b : try await { c ( ) + { d * e }}}")
+  }
+
   func testUnrecognizedOperators() {
     // If we see an operator we don't recognize, we arbitrarily bind them with
     // left associativity. This occurs even if something with high precedence,

--- a/Tests/SwiftFormatPrettyPrintTests/VariableDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/VariableDeclTests.swift
@@ -98,4 +98,28 @@ final class VariableDeclarationTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
   }
+
+  func testAsyncLetBindings() {
+    let input =
+      """
+      async let a = fetch("1.jpg")
+      async let b: Image = fetch("2.jpg")
+      async let secondPhotoToFetch = fetch("3.jpg")
+      async let theVeryLastPhotoWeWant = fetch("4.jpg")
+      """
+
+    let expected =
+      """
+      async let a = fetch("1.jpg")
+      async let b: Image = fetch(
+        "2.jpg")
+      async let secondPhotoToFetch =
+        fetch("3.jpg")
+      async let theVeryLastPhotoWeWant =
+        fetch("4.jpg")
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 29)
+  }
 }


### PR DESCRIPTION
Changes in this PR:

- `for await` and `for try await` loops
- `async` closure expressions
- Improve grouping for `async throws` in functions/closures
- `await` expressions
- `async let` declarations
- attributes in closure signatures
