### PR TITLE
Pin swift-5.5-branch to specific versions of dependencies.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -139,8 +139,8 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   // Building standalone.
   package.dependencies += [
-    .package(url: "https://github.com/apple/swift-syntax", .branch("main")),
-    .package(url: "https://github.com/apple/swift-argument-parser.git", .branch("main")),
+    .package(url: "https://github.com/apple/swift-syntax", .revision("9a8d3d8b9fb42bdd9cffc18219b5efb584b5b998")),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.4.3")),
   ]
 } else {
   package.dependencies += [


### PR DESCRIPTION
For now, while Xcode 13.0 is in beta, we pin to a precise commit
that we know is compatible with the released toolchain (beta 3,
at the time of this writing).

Tested by running `swift test` with Xcode 13.0b3; all tests build
and pass.