### PR TITLE
Remove the hardcoded `suppressRules` list in `generate-pipeline`.

### DIFF
--- a/Sources/SwiftFormat/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Pipelines+Generated.swift
@@ -63,6 +63,7 @@ class LintPipeline: SyntaxVisitor {
   override func visit(_ node: CodeBlockItemListSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(DoNotUseSemicolons.visit, for: node)
     visitIfEnabled(OneVariableDeclarationPerLine.visit, for: node)
+    visitIfEnabled(UseEarlyExits.visit, for: node)
     return .visitChildren
   }
 
@@ -103,6 +104,11 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(DontRepeatTypeInStaticProperties.visit, for: node)
     visitIfEnabled(NoAccessLevelOnExtensionDeclaration.visit, for: node)
     visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
+    return .visitChildren
+  }
+
+  override func visit(_ node: ForInStmtSyntax) -> SyntaxVisitorContinueKind {
+    visitIfEnabled(UseWhereClausesInForLoops.visit, for: node)
     return .visitChildren
   }
 
@@ -314,9 +320,11 @@ extension FormatPipeline {
     node = OneVariableDeclarationPerLine(context: context).visit(node)
     node = OrderedImports(context: context).visit(node)
     node = ReturnVoidInsteadOfEmptyTuple(context: context).visit(node)
+    node = UseEarlyExits(context: context).visit(node)
     node = UseShorthandTypeNames(context: context).visit(node)
     node = UseSingleLinePropertyGetter(context: context).visit(node)
     node = UseTripleSlashForDocumentationComments(context: context).visit(node)
+    node = UseWhereClausesInForLoops(context: context).visit(node)
     return node
   }
 }

--- a/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
+++ b/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
@@ -40,11 +40,13 @@ enum RuleRegistry {
     "OnlyOneTrailingClosureArgument": true,
     "OrderedImports": true,
     "ReturnVoidInsteadOfEmptyTuple": true,
+    "UseEarlyExits": false,
     "UseLetInEveryBoundCaseVariable": true,
     "UseShorthandTypeNames": true,
     "UseSingleLinePropertyGetter": true,
     "UseSynthesizedInitializer": true,
     "UseTripleSlashForDocumentationComments": true,
+    "UseWhereClausesInForLoops": false,
     "ValidateDocumentationComments": false,
   ]
 }

--- a/Sources/SwiftFormatRules/UseEarlyExits.swift
+++ b/Sources/SwiftFormatRules/UseEarlyExits.swift
@@ -44,6 +44,10 @@ import SwiftSyntax
 ///         equivalent `guard ... else { return/throw/break/continue }` constructs.
 public final class UseEarlyExits: SyntaxFormatRule {
 
+  /// Identifies this rule as being opt-in. This rule is experimental and not yet stable enough to
+  /// be enabled by default.
+  public override class var isOptIn: Bool { return true }
+
   public override func visit(_ node: CodeBlockItemListSyntax) -> Syntax {
     // Continue recursing down the tree first, so that any nested/child nodes get transformed first.
     let nodeAfterTransformingChildren = super.visit(node)

--- a/Sources/SwiftFormatRules/UseWhereClausesInForLoops.swift
+++ b/Sources/SwiftFormatRules/UseWhereClausesInForLoops.swift
@@ -21,6 +21,10 @@ import SwiftSyntax
 ///         statement factored out to a `where` clause.
 public final class UseWhereClausesInForLoops: SyntaxFormatRule {
 
+  /// Identifies this rule as being opt-in. This rule is experimental and not yet stable enough to
+  /// be enabled by default.
+  public override class var isOptIn: Bool { return true }
+
   public override func visit(_ node: ForInStmtSyntax) -> StmtSyntax {
     // Extract IfStmt node if it's the only node in the function's body.
     guard !node.body.statements.isEmpty else { return StmtSyntax(node) }

--- a/Sources/generate-pipeline/RuleCollector.swift
+++ b/Sources/generate-pipeline/RuleCollector.swift
@@ -14,9 +14,6 @@ import Foundation
 import SwiftFormatCore
 import SwiftSyntax
 
-// These rules will not be added to the pipeline.
-let suppressRules = ["UseEarlyExits", "UseWhereClausesInForLoops"]
-
 /// Collects information about rules in the formatter code base.
 final class RuleCollector {
   /// Information about a detected rule.
@@ -99,8 +96,8 @@ final class RuleCollector {
       return nil
     }
 
-    // Make sure the rule isn't suppressed, and it must have an inheritance clause.
-    guard !suppressRules.contains(typeName), let inheritanceClause = maybeInheritanceClause else {
+    // Make sure it has an inheritance clause.
+    guard let inheritanceClause = maybeInheritanceClause else {
       return nil
     }
 


### PR DESCRIPTION
Now that we have the `isOptIn` property for rules, this should be used to disable rules by default instead of removing them from pipeline generation entirely. This also unblocks https://github.com/apple/swift-format/pull/261, since excluded rules wouldn't show up in the generated name cache, causing their tests to crash.