### PR TITLE
Fix crash when running Lint from LegacyMain

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ as well as the following command line options:
   files in any directories listed on the command line and their descendants.
   Without this flag, it is an error to list a directory on the command line.
 
+* `-s/--strict`: If specified, exits non-zero code if one or more warning are found.
+  This option only works in lint mode.
+
 ### Configuration
 
 For any source file being checked or formatted, `swift-format` looks for a

--- a/Sources/swift-format/Subcommands/Lint.swift
+++ b/Sources/swift-format/Subcommands/Lint.swift
@@ -21,18 +21,12 @@ extension SwiftFormatCommand {
 
     @OptionGroup()
     var lintOptions: LintFormatOptions
-    
-    @Flag(
-      name: .shortAndLong,
-      help: "Fail on warnings."
-    )
-    var strict: Bool = false
 
     func run() throws {
       let frontend = LintFrontend(lintFormatOptions: lintOptions)
       frontend.run()
       if frontend.errorsWereEmitted { throw ExitCode.failure }
-      if strict,
+      if lintOptions.strict,
          frontend.diagnosticEngine.diagnostics
             .contains(where: { $0.message.severity == .warning }) {
         throw ExitCode.failure

--- a/Sources/swift-format/Subcommands/LintFormatOptions.swift
+++ b/Sources/swift-format/Subcommands/LintFormatOptions.swift
@@ -55,6 +55,11 @@ struct LintFormatOptions: ParsableArguments {
     help: "Process files in parallel, simultaneously across multiple cores.")
   var parallel: Bool = false
 
+  @Flag(
+    name: .shortAndLong,
+    help: "Fail on warnings.")
+  var strict: Bool = false
+
   /// The list of paths to Swift source files that should be formatted or linted.
   @Argument(help: "Zero or more input filenames.")
   var paths: [String] = []


### PR DESCRIPTION
Fix crash bug in LegacyMain lint mode. I test with Xcode 13 and [tag 0.50500.0](https://github.com/mtgto/swift-format/releases/tag/0.50500.0) on macOS 11.6 Intel.
This crash does not happen in using SubCommand lint.

In addition, adds a description of `strict` flag to README.


```console
$ swift run swift-format --mode lint Package.swift
[0/0] Build complete!
/Users/user/work/cocoa/swift-format/Package.swift:15:1: warning: [OrderedImports]: sort import statements lexicographically
/Users/user/work/cocoa/swift-format/Package.swift:83:22: warning: remove trailing comma from the last element in single line collection literal
/Users/user/work/cocoa/swift-format/Package.swift:24:18: warning: [RemoveLine]: remove line break
/Users/user/work/cocoa/swift-format/Package.swift:140:2: warning: [RemoveLine]: remove line break
/Users/user/work/cocoa/swift-format/Package.swift:147:1: warning: [LineLength]: line is too long
ArgumentParser/Flag.swift:103: Fatal error:
--------------------------------------------------------------------
Can't read a value from a parsable argument definition.

This error indicates that a property declared with an `@Argument`,
`@Option`, `@Flag`, or `@OptionGroup` property wrapper was neither
initialized to a value nor decoded from command-line arguments.

To get a valid value, either call one of the static parsing methods
(`parse`, `parseAsRoot`, or `main`) or define an initializer that
initializes _every_ property of your parsable type.
--------------------------------------------------------------------

zsh: illegal hardware instruction  swift run swift-format --mode lint Package.swift
```
----

#252 introduces `--strict`, but this flag should be defined in LintFormatOptions.swift, not Lint.swift.