### PR TITLE
fix for SwiftSyntaxParser changes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,17 +33,18 @@ let package = Package(
         "SwiftFormatRules",
         "SwiftFormatWhitespaceLinter",
         "SwiftSyntax",
+        "SwiftSyntaxParser",
       ]
     ),
     .target(name: "SwiftFormatConfiguration"),
-    .target(name: "SwiftFormatCore", dependencies: ["SwiftFormatConfiguration", "SwiftSyntax"]),
+    .target(name: "SwiftFormatCore", dependencies: ["SwiftFormatConfiguration", "SwiftSyntax", "SwiftSyntaxParser"]),
     .target(
       name: "SwiftFormatRules",
-      dependencies: ["SwiftFormatCore", "SwiftFormatConfiguration"]
+      dependencies: ["SwiftFormatCore", "SwiftFormatConfiguration", "SwiftSyntax", "SwiftSyntaxParser"]
     ),
     .target(
       name: "SwiftFormatPrettyPrint",
-      dependencies: ["SwiftFormatCore", "SwiftFormatConfiguration"]
+      dependencies: ["SwiftFormatCore", "SwiftFormatConfiguration", "SwiftSyntaxParser"]
     ),
     .target(
       name: "SwiftFormatTestSupport",
@@ -51,6 +52,7 @@ let package = Package(
         "SwiftFormatCore",
         "SwiftFormatRules",
         "SwiftFormatConfiguration",
+        "SwiftSyntaxParser",
       ]
     ),
     .target(
@@ -58,6 +60,7 @@ let package = Package(
       dependencies: [
         "SwiftFormatCore",
         "SwiftSyntax",
+        "SwiftSyntaxParser",
       ]
     ),
     .target(
@@ -66,6 +69,7 @@ let package = Package(
         "SwiftFormatCore",
         "SwiftFormatRules",
         "SwiftSyntax",
+        "SwiftSyntaxParser",
       ]
     ),
     .target(
@@ -76,12 +80,14 @@ let package = Package(
         "SwiftFormatConfiguration",
         "SwiftFormatCore",
         "SwiftSyntax",
+        "SwiftSyntaxParser",
       ]
     ),
     .testTarget(
       name: "SwiftFormatTests",
       dependencies: [
         "SwiftFormat",
+        "SwiftSyntaxParser",
       ]
     ),
     .testTarget(
@@ -97,6 +103,7 @@ let package = Package(
         "SwiftFormatRules",
         "SwiftFormatTestSupport",
         "SwiftSyntax",
+        "SwiftSyntaxParser",
       ]
     ),
     .testTarget(
@@ -105,6 +112,7 @@ let package = Package(
         "SwiftFormatConfiguration",
         "SwiftFormatCore",
         "SwiftSyntax",
+        "SwiftSyntaxParser",
       ]
     ),
     .testTarget(
@@ -113,6 +121,7 @@ let package = Package(
         "SwiftFormatTestSupport",
         "SwiftFormatWhitespaceLinter",
         "SwiftSyntax",
+        "SwiftSyntaxParser",
       ]
     ),
     .testTarget(
@@ -124,6 +133,7 @@ let package = Package(
         "SwiftFormatRules",
         "SwiftFormatTestSupport",
         "SwiftSyntax",
+        "SwiftSyntaxParser",
       ]
     ),
     .testTarget(
@@ -134,6 +144,7 @@ let package = Package(
         "SwiftFormatTestSupport",
         "SwiftFormatWhitespaceLinter",
         "SwiftSyntax",
+        "SwiftSyntaxParser",
       ]
     ),
   ]

--- a/Sources/SwiftFormat/SwiftFormatter.swift
+++ b/Sources/SwiftFormat/SwiftFormatter.swift
@@ -16,6 +16,7 @@ import SwiftFormatCore
 import SwiftFormatPrettyPrint
 import SwiftFormatRules
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Formats Swift source code or syntax trees according to the Swift style guidelines.
 public final class SwiftFormatter {

--- a/Sources/SwiftFormat/SwiftLinter.swift
+++ b/Sources/SwiftFormat/SwiftLinter.swift
@@ -17,6 +17,7 @@ import SwiftFormatPrettyPrint
 import SwiftFormatRules
 import SwiftFormatWhitespaceLinter
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Diagnoses and reports problems in Swift source code or syntax trees according to the Swift style
 /// guidelines.

--- a/Sources/SwiftFormatCore/Context.swift
+++ b/Sources/SwiftFormatCore/Context.swift
@@ -13,6 +13,7 @@
 import Foundation
 import SwiftFormatConfiguration
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Context contains the bits that each formatter and linter will need access to.
 ///

--- a/Sources/SwiftFormatCore/Diagnostic+Rule.swift
+++ b/Sources/SwiftFormatCore/Diagnostic+Rule.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftSyntax
+import SwiftSyntaxParser
 
 extension Diagnostic.Message {
   /// Prepends the name of a rule to this diagnostic message.

--- a/Sources/SwiftFormatCore/SyntaxLintRule.swift
+++ b/Sources/SwiftFormatCore/SyntaxLintRule.swift
@@ -12,6 +12,7 @@
 
 import Foundation
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// A rule that lints a given file.
 open class SyntaxLintRule: SyntaxVisitor, Rule {

--- a/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
@@ -13,6 +13,7 @@
 import SwiftFormatConfiguration
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// PrettyPrinter takes a Syntax node and outputs a well-formatted, re-indented reproduction of the
 /// code as a String.

--- a/Sources/SwiftFormatRules/AllPublicDeclarationsHaveDocumentation.swift
+++ b/Sources/SwiftFormatRules/AllPublicDeclarationsHaveDocumentation.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// All public or open declarations must have a top-level documentation comment.
 ///

--- a/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
+++ b/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// All values should be written in lower camel-case (`lowerCamelCase`).
 /// Underscores (except at the beginning of an identifier) are disallowed.

--- a/Sources/SwiftFormatRules/AmbiguousTrailingClosureOverload.swift
+++ b/Sources/SwiftFormatRules/AmbiguousTrailingClosureOverload.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Overloads with only a closure argument should not be disambiguated by parameter labels.
 ///

--- a/Sources/SwiftFormatRules/BeginDocumentationCommentWithOneLineSummary.swift
+++ b/Sources/SwiftFormatRules/BeginDocumentationCommentWithOneLineSummary.swift
@@ -13,6 +13,7 @@
 import Foundation
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// All documentation comments must begin with a one-line summary of the declaration.
 ///

--- a/Sources/SwiftFormatRules/DoNotUseSemicolons.swift
+++ b/Sources/SwiftFormatRules/DoNotUseSemicolons.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Semicolons should not be present in Swift code.
 ///

--- a/Sources/SwiftFormatRules/DontRepeatTypeInStaticProperties.swift
+++ b/Sources/SwiftFormatRules/DontRepeatTypeInStaticProperties.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Static properties of a type that return that type should not include a reference to their type.
 ///

--- a/Sources/SwiftFormatRules/FileScopedDeclarationPrivacy.swift
+++ b/Sources/SwiftFormatRules/FileScopedDeclarationPrivacy.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Declarations at file scope with effective private access should be consistently declared as
 /// either `fileprivate` or `private`, determined by configuration.

--- a/Sources/SwiftFormatRules/FullyIndirectEnum.swift
+++ b/Sources/SwiftFormatRules/FullyIndirectEnum.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// If all cases of an enum are `indirect`, the entire enum should be marked `indirect`.
 ///

--- a/Sources/SwiftFormatRules/GroupNumericLiterals.swift
+++ b/Sources/SwiftFormatRules/GroupNumericLiterals.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Numeric literals should be grouped with `_`s to delimit common separators.
 ///

--- a/Sources/SwiftFormatRules/IdentifiersMustBeASCII.swift
+++ b/Sources/SwiftFormatRules/IdentifiersMustBeASCII.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// All identifiers must be ASCII.
 ///

--- a/Sources/SwiftFormatRules/NeverForceUnwrap.swift
+++ b/Sources/SwiftFormatRules/NeverForceUnwrap.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Force-unwraps are strongly discouraged and must be documented.
 ///

--- a/Sources/SwiftFormatRules/NeverUseForceTry.swift
+++ b/Sources/SwiftFormatRules/NeverUseForceTry.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Force-try (`try!`) is forbidden.
 ///

--- a/Sources/SwiftFormatRules/NeverUseImplicitlyUnwrappedOptionals.swift
+++ b/Sources/SwiftFormatRules/NeverUseImplicitlyUnwrappedOptionals.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Implicitly unwrapped optionals (e.g. `var s: String!`) are forbidden.
 ///

--- a/Sources/SwiftFormatRules/NoAccessLevelOnExtensionDeclaration.swift
+++ b/Sources/SwiftFormatRules/NoAccessLevelOnExtensionDeclaration.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Specifying an access level for an extension declaration is forbidden.
 ///

--- a/Sources/SwiftFormatRules/NoBlockComments.swift
+++ b/Sources/SwiftFormatRules/NoBlockComments.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Block comments should be avoided in favor of line comments.
 ///

--- a/Sources/SwiftFormatRules/NoCasesWithOnlyFallthrough.swift
+++ b/Sources/SwiftFormatRules/NoCasesWithOnlyFallthrough.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Cases that contain only the `fallthrough` statement are forbidden.
 ///

--- a/Sources/SwiftFormatRules/NoEmptyTrailingClosureParentheses.swift
+++ b/Sources/SwiftFormatRules/NoEmptyTrailingClosureParentheses.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Function calls with no arguments and a trailing closure should not have empty parentheses.
 ///

--- a/Sources/SwiftFormatRules/NoLabelsInCasePatterns.swift
+++ b/Sources/SwiftFormatRules/NoLabelsInCasePatterns.swift
@@ -13,6 +13,7 @@
 import Foundation
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Redundant labels are forbidden in case patterns.
 ///

--- a/Sources/SwiftFormatRules/NoLeadingUnderscores.swift
+++ b/Sources/SwiftFormatRules/NoLeadingUnderscores.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Identifiers in declarations and patterns should not have leading underscores.
 ///

--- a/Sources/SwiftFormatRules/NoParensAroundConditions.swift
+++ b/Sources/SwiftFormatRules/NoParensAroundConditions.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Enforces rules around parentheses in conditions or matched expressions.
 ///

--- a/Sources/SwiftFormatRules/NoVoidReturnOnFunctionSignature.swift
+++ b/Sources/SwiftFormatRules/NoVoidReturnOnFunctionSignature.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Functions that return `()` or `Void` should omit the return signature.
 ///

--- a/Sources/SwiftFormatRules/OneCasePerLine.swift
+++ b/Sources/SwiftFormatRules/OneCasePerLine.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Each enum case with associated values or a raw value should appear in its own case declaration.
 ///

--- a/Sources/SwiftFormatRules/OneVariableDeclarationPerLine.swift
+++ b/Sources/SwiftFormatRules/OneVariableDeclarationPerLine.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Each variable declaration, with the exception of tuple destructuring, should
 /// declare 1 variable.

--- a/Sources/SwiftFormatRules/OnlyOneTrailingClosureArgument.swift
+++ b/Sources/SwiftFormatRules/OnlyOneTrailingClosureArgument.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Function calls should never mix normal closure arguments and trailing closures.
 ///

--- a/Sources/SwiftFormatRules/OrderedImports.swift
+++ b/Sources/SwiftFormatRules/OrderedImports.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Imports must be lexicographically ordered and logically grouped at the top of each source file.
 /// The order of the import groups is 1) regular imports, 2) declaration imports, and 3) @testable

--- a/Sources/SwiftFormatRules/ReturnVoidInsteadOfEmptyTuple.swift
+++ b/Sources/SwiftFormatRules/ReturnVoidInsteadOfEmptyTuple.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Return `Void`, not `()`, in signatures.
 ///

--- a/Sources/SwiftFormatRules/UseEarlyExits.swift
+++ b/Sources/SwiftFormatRules/UseEarlyExits.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Early exits should be used whenever possible.
 ///

--- a/Sources/SwiftFormatRules/UseLetInEveryBoundCaseVariable.swift
+++ b/Sources/SwiftFormatRules/UseLetInEveryBoundCaseVariable.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Every variable bound in a `case` pattern must have its own `let/var`.
 ///

--- a/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
+++ b/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Shorthand type forms must be used wherever possible.
 ///

--- a/Sources/SwiftFormatRules/UseSingleLinePropertyGetter.swift
+++ b/Sources/SwiftFormatRules/UseSingleLinePropertyGetter.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Read-only computed properties must use implicit `get` blocks.
 ///

--- a/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
+++ b/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
@@ -13,6 +13,7 @@
 import Foundation
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// When possible, the synthesized `struct` initializer should be used.
 ///

--- a/Sources/SwiftFormatRules/UseTripleSlashForDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/UseTripleSlashForDocumentationComments.swift
@@ -13,6 +13,7 @@
 import Foundation
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Documentation comments must use the `///` form.
 ///

--- a/Sources/SwiftFormatRules/UseWhereClausesInForLoops.swift
+++ b/Sources/SwiftFormatRules/UseWhereClausesInForLoops.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// `for` loops that consist of a single `if` statement must use `where` clauses instead.
 ///

--- a/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
@@ -13,6 +13,7 @@
 import Foundation
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Documentation comments must be complete and valid.
 ///

--- a/Sources/SwiftFormatTestSupport/DiagnosingTestCase.swift
+++ b/Sources/SwiftFormatTestSupport/DiagnosingTestCase.swift
@@ -2,6 +2,7 @@ import SwiftFormatConfiguration
 import SwiftFormatCore
 import SwiftFormatRules
 import SwiftSyntax
+import SwiftSyntaxParser
 import XCTest
 
 /// DiagnosingTestCase is an XCTestCase subclass meant to inject diagnostic-specific testing

--- a/Sources/SwiftFormatTestSupport/DiagnosticTrackingConsumer.swift
+++ b/Sources/SwiftFormatTestSupport/DiagnosticTrackingConsumer.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Information about a diagnostic tracked by `DiagnosticTrackingConsumer`.
 struct EmittedDiagnostic {

--- a/Sources/SwiftFormatWhitespaceLinter/WhitespaceLinter.swift
+++ b/Sources/SwiftFormatWhitespaceLinter/WhitespaceLinter.swift
@@ -13,6 +13,7 @@
 import SwiftFormatConfiguration
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 private let utf8Newline = UTF8.CodeUnit(ascii: "\n")
 private let utf8Tab = UTF8.CodeUnit(ascii: "\t")

--- a/Sources/generate-pipeline/RuleCollector.swift
+++ b/Sources/generate-pipeline/RuleCollector.swift
@@ -13,6 +13,7 @@
 import Foundation
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Collects information about rules in the formatter code base.
 final class RuleCollector {

--- a/Sources/swift-format/Frontend/FormatFrontend.swift
+++ b/Sources/swift-format/Frontend/FormatFrontend.swift
@@ -14,6 +14,7 @@ import Foundation
 import SwiftFormat
 import SwiftFormatConfiguration
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// The frontend for formatting operations.
 class FormatFrontend: Frontend {

--- a/Sources/swift-format/Frontend/Frontend.swift
+++ b/Sources/swift-format/Frontend/Frontend.swift
@@ -14,6 +14,7 @@ import Foundation
 import SwiftFormat
 import SwiftFormatConfiguration
 import SwiftSyntax
+import SwiftSyntaxParser
 
 class Frontend {
   /// Represents a file to be processed by the frontend and any file-specific options associated

--- a/Sources/swift-format/Frontend/LintFrontend.swift
+++ b/Sources/swift-format/Frontend/LintFrontend.swift
@@ -14,6 +14,7 @@ import Foundation
 import SwiftFormat
 import SwiftFormatConfiguration
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// The frontend for linting operations.
 class LintFrontend: Frontend {

--- a/Tests/SwiftFormatCoreTests/RuleMaskTests.swift
+++ b/Tests/SwiftFormatCoreTests/RuleMaskTests.swift
@@ -1,5 +1,6 @@
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 import XCTest
 
 final class RuleMaskTests: XCTestCase {

--- a/Tests/SwiftFormatPerformanceTests/WhitespaceLinterPerformanceTests.swift
+++ b/Tests/SwiftFormatPerformanceTests/WhitespaceLinterPerformanceTests.swift
@@ -1,6 +1,7 @@
 import SwiftFormatTestSupport
 import SwiftFormatWhitespaceLinter
 import SwiftSyntax
+import SwiftSyntaxParser
 import XCTest
 
 final class WhitespaceLinterPerformanceTests: DiagnosingTestCase {

--- a/Tests/SwiftFormatPrettyPrintTests/PrettyPrintTestCase.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/PrettyPrintTestCase.swift
@@ -3,6 +3,7 @@ import SwiftFormatCore
 import SwiftFormatPrettyPrint
 import SwiftFormatTestSupport
 import SwiftSyntax
+import SwiftSyntaxParser
 import XCTest
 
 class PrettyPrintTestCase: DiagnosingTestCase {

--- a/Tests/SwiftFormatPrettyPrintTests/SequenceExprFoldingTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/SequenceExprFoldingTests.swift
@@ -1,5 +1,6 @@
 import SwiftFormatPrettyPrint
 import SwiftSyntax
+import SwiftSyntaxParser
 import XCTest
 
 final class SequenceExprFoldingTests: XCTestCase {

--- a/Tests/SwiftFormatRulesTests/FileScopedDeclarationPrivacyTests.swift
+++ b/Tests/SwiftFormatRulesTests/FileScopedDeclarationPrivacyTests.swift
@@ -1,6 +1,7 @@
 import SwiftFormatConfiguration
 import SwiftFormatRules
 import SwiftSyntax
+import SwiftSyntaxParser
 
 private typealias TestConfiguration = (
   original: String,

--- a/Tests/SwiftFormatRulesTests/LintOrFormatRuleTestCase.swift
+++ b/Tests/SwiftFormatRulesTests/LintOrFormatRuleTestCase.swift
@@ -2,6 +2,7 @@ import SwiftFormatConfiguration
 import SwiftFormatCore
 import SwiftFormatTestSupport
 import SwiftSyntax
+import SwiftSyntaxParser
 import XCTest
 
 class LintOrFormatRuleTestCase: DiagnosingTestCase {

--- a/Tests/SwiftFormatTests/SyntaxValidatingVisitorTests.swift
+++ b/Tests/SwiftFormatTests/SyntaxValidatingVisitorTests.swift
@@ -1,5 +1,6 @@
 import SwiftFormat
 import SwiftSyntax
+import SwiftSyntaxParser
 import XCTest
 
 final class SyntaxValidatingVisitorTests: XCTestCase {

--- a/Tests/SwiftFormatWhitespaceLinterTests/WhitespaceTestCase.swift
+++ b/Tests/SwiftFormatWhitespaceLinterTests/WhitespaceTestCase.swift
@@ -3,6 +3,7 @@ import SwiftFormatCore
 import SwiftFormatTestSupport
 import SwiftFormatWhitespaceLinter
 import SwiftSyntax
+import SwiftSyntaxParser
 import XCTest
 
 class WhitespaceTestCase: DiagnosingTestCase {


### PR DESCRIPTION
This PR updates the imports to handle the separation of SwiftSyntax and SwiftSyntaxParser:

https://github.com/apple/swift-syntax/pull/309