### PR TITLE
Introduce cache to skip to process unmodified files

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,17 +33,18 @@ let package = Package(
         "SwiftFormatRules",
         "SwiftFormatWhitespaceLinter",
         "SwiftSyntax",
+        "SwiftSyntaxParser",
       ]
     ),
     .target(name: "SwiftFormatConfiguration"),
-    .target(name: "SwiftFormatCore", dependencies: ["SwiftFormatConfiguration", "SwiftSyntax"]),
+    .target(name: "SwiftFormatCore", dependencies: ["SwiftFormatConfiguration", "SwiftSyntax", "SwiftSyntaxParser"]),
     .target(
       name: "SwiftFormatRules",
-      dependencies: ["SwiftFormatCore", "SwiftFormatConfiguration"]
+      dependencies: ["SwiftFormatCore", "SwiftFormatConfiguration", "SwiftSyntax", "SwiftSyntaxParser"]
     ),
     .target(
       name: "SwiftFormatPrettyPrint",
-      dependencies: ["SwiftFormatCore", "SwiftFormatConfiguration"]
+      dependencies: ["SwiftFormatCore", "SwiftFormatConfiguration", "SwiftSyntaxParser"]
     ),
     .target(
       name: "SwiftFormatTestSupport",
@@ -51,6 +52,7 @@ let package = Package(
         "SwiftFormatCore",
         "SwiftFormatRules",
         "SwiftFormatConfiguration",
+        "SwiftSyntaxParser",
       ]
     ),
     .target(
@@ -58,6 +60,7 @@ let package = Package(
       dependencies: [
         "SwiftFormatCore",
         "SwiftSyntax",
+        "SwiftSyntaxParser",
       ]
     ),
     .target(
@@ -66,6 +69,7 @@ let package = Package(
         "SwiftFormatCore",
         "SwiftFormatRules",
         "SwiftSyntax",
+        "SwiftSyntaxParser",
       ]
     ),
     .target(
@@ -76,12 +80,14 @@ let package = Package(
         "SwiftFormatConfiguration",
         "SwiftFormatCore",
         "SwiftSyntax",
+        "SwiftSyntaxParser",
       ]
     ),
     .testTarget(
       name: "SwiftFormatTests",
       dependencies: [
         "SwiftFormat",
+        "SwiftSyntaxParser",
       ]
     ),
     .testTarget(
@@ -97,6 +103,7 @@ let package = Package(
         "SwiftFormatRules",
         "SwiftFormatTestSupport",
         "SwiftSyntax",
+        "SwiftSyntaxParser",
       ]
     ),
     .testTarget(
@@ -105,6 +112,7 @@ let package = Package(
         "SwiftFormatConfiguration",
         "SwiftFormatCore",
         "SwiftSyntax",
+        "SwiftSyntaxParser",
       ]
     ),
     .testTarget(
@@ -113,6 +121,7 @@ let package = Package(
         "SwiftFormatTestSupport",
         "SwiftFormatWhitespaceLinter",
         "SwiftSyntax",
+        "SwiftSyntaxParser",
       ]
     ),
     .testTarget(
@@ -124,6 +133,7 @@ let package = Package(
         "SwiftFormatRules",
         "SwiftFormatTestSupport",
         "SwiftSyntax",
+        "SwiftSyntaxParser",
       ]
     ),
     .testTarget(
@@ -134,6 +144,7 @@ let package = Package(
         "SwiftFormatTestSupport",
         "SwiftFormatWhitespaceLinter",
         "SwiftSyntax",
+        "SwiftSyntaxParser",
       ]
     ),
   ]

--- a/Sources/SwiftFormat/SwiftFormatter.swift
+++ b/Sources/SwiftFormat/SwiftFormatter.swift
@@ -16,6 +16,7 @@ import SwiftFormatCore
 import SwiftFormatPrettyPrint
 import SwiftFormatRules
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Formats Swift source code or syntax trees according to the Swift style guidelines.
 public final class SwiftFormatter {

--- a/Sources/SwiftFormat/SwiftLinter.swift
+++ b/Sources/SwiftFormat/SwiftLinter.swift
@@ -17,6 +17,7 @@ import SwiftFormatPrettyPrint
 import SwiftFormatRules
 import SwiftFormatWhitespaceLinter
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Diagnoses and reports problems in Swift source code or syntax trees according to the Swift style
 /// guidelines.

--- a/Sources/SwiftFormatCore/Context.swift
+++ b/Sources/SwiftFormatCore/Context.swift
@@ -13,6 +13,7 @@
 import Foundation
 import SwiftFormatConfiguration
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Context contains the bits that each formatter and linter will need access to.
 ///

--- a/Sources/SwiftFormatCore/Diagnostic+Rule.swift
+++ b/Sources/SwiftFormatCore/Diagnostic+Rule.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftSyntax
+import SwiftSyntaxParser
 
 extension Diagnostic.Message {
   /// Prepends the name of a rule to this diagnostic message.

--- a/Sources/SwiftFormatCore/SyntaxLintRule.swift
+++ b/Sources/SwiftFormatCore/SyntaxLintRule.swift
@@ -12,6 +12,7 @@
 
 import Foundation
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// A rule that lints a given file.
 open class SyntaxLintRule: SyntaxVisitor, Rule {

--- a/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
@@ -13,6 +13,7 @@
 import SwiftFormatConfiguration
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// PrettyPrinter takes a Syntax node and outputs a well-formatted, re-indented reproduction of the
 /// code as a String.

--- a/Sources/SwiftFormatRules/AllPublicDeclarationsHaveDocumentation.swift
+++ b/Sources/SwiftFormatRules/AllPublicDeclarationsHaveDocumentation.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// All public or open declarations must have a top-level documentation comment.
 ///

--- a/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
+++ b/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// All values should be written in lower camel-case (`lowerCamelCase`).
 /// Underscores (except at the beginning of an identifier) are disallowed.

--- a/Sources/SwiftFormatRules/AmbiguousTrailingClosureOverload.swift
+++ b/Sources/SwiftFormatRules/AmbiguousTrailingClosureOverload.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Overloads with only a closure argument should not be disambiguated by parameter labels.
 ///

--- a/Sources/SwiftFormatRules/BeginDocumentationCommentWithOneLineSummary.swift
+++ b/Sources/SwiftFormatRules/BeginDocumentationCommentWithOneLineSummary.swift
@@ -13,6 +13,7 @@
 import Foundation
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// All documentation comments must begin with a one-line summary of the declaration.
 ///

--- a/Sources/SwiftFormatRules/DoNotUseSemicolons.swift
+++ b/Sources/SwiftFormatRules/DoNotUseSemicolons.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Semicolons should not be present in Swift code.
 ///

--- a/Sources/SwiftFormatRules/DontRepeatTypeInStaticProperties.swift
+++ b/Sources/SwiftFormatRules/DontRepeatTypeInStaticProperties.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Static properties of a type that return that type should not include a reference to their type.
 ///

--- a/Sources/SwiftFormatRules/FileScopedDeclarationPrivacy.swift
+++ b/Sources/SwiftFormatRules/FileScopedDeclarationPrivacy.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Declarations at file scope with effective private access should be consistently declared as
 /// either `fileprivate` or `private`, determined by configuration.

--- a/Sources/SwiftFormatRules/FullyIndirectEnum.swift
+++ b/Sources/SwiftFormatRules/FullyIndirectEnum.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// If all cases of an enum are `indirect`, the entire enum should be marked `indirect`.
 ///

--- a/Sources/SwiftFormatRules/GroupNumericLiterals.swift
+++ b/Sources/SwiftFormatRules/GroupNumericLiterals.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Numeric literals should be grouped with `_`s to delimit common separators.
 ///

--- a/Sources/SwiftFormatRules/IdentifiersMustBeASCII.swift
+++ b/Sources/SwiftFormatRules/IdentifiersMustBeASCII.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// All identifiers must be ASCII.
 ///

--- a/Sources/SwiftFormatRules/NeverForceUnwrap.swift
+++ b/Sources/SwiftFormatRules/NeverForceUnwrap.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Force-unwraps are strongly discouraged and must be documented.
 ///

--- a/Sources/SwiftFormatRules/NeverUseForceTry.swift
+++ b/Sources/SwiftFormatRules/NeverUseForceTry.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Force-try (`try!`) is forbidden.
 ///

--- a/Sources/SwiftFormatRules/NeverUseImplicitlyUnwrappedOptionals.swift
+++ b/Sources/SwiftFormatRules/NeverUseImplicitlyUnwrappedOptionals.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Implicitly unwrapped optionals (e.g. `var s: String!`) are forbidden.
 ///

--- a/Sources/SwiftFormatRules/NoAccessLevelOnExtensionDeclaration.swift
+++ b/Sources/SwiftFormatRules/NoAccessLevelOnExtensionDeclaration.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Specifying an access level for an extension declaration is forbidden.
 ///

--- a/Sources/SwiftFormatRules/NoBlockComments.swift
+++ b/Sources/SwiftFormatRules/NoBlockComments.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Block comments should be avoided in favor of line comments.
 ///

--- a/Sources/SwiftFormatRules/NoCasesWithOnlyFallthrough.swift
+++ b/Sources/SwiftFormatRules/NoCasesWithOnlyFallthrough.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Cases that contain only the `fallthrough` statement are forbidden.
 ///

--- a/Sources/SwiftFormatRules/NoEmptyTrailingClosureParentheses.swift
+++ b/Sources/SwiftFormatRules/NoEmptyTrailingClosureParentheses.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Function calls with no arguments and a trailing closure should not have empty parentheses.
 ///

--- a/Sources/SwiftFormatRules/NoLabelsInCasePatterns.swift
+++ b/Sources/SwiftFormatRules/NoLabelsInCasePatterns.swift
@@ -13,6 +13,7 @@
 import Foundation
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Redundant labels are forbidden in case patterns.
 ///

--- a/Sources/SwiftFormatRules/NoLeadingUnderscores.swift
+++ b/Sources/SwiftFormatRules/NoLeadingUnderscores.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Identifiers in declarations and patterns should not have leading underscores.
 ///

--- a/Sources/SwiftFormatRules/NoParensAroundConditions.swift
+++ b/Sources/SwiftFormatRules/NoParensAroundConditions.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Enforces rules around parentheses in conditions or matched expressions.
 ///

--- a/Sources/SwiftFormatRules/NoVoidReturnOnFunctionSignature.swift
+++ b/Sources/SwiftFormatRules/NoVoidReturnOnFunctionSignature.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Functions that return `()` or `Void` should omit the return signature.
 ///

--- a/Sources/SwiftFormatRules/OneCasePerLine.swift
+++ b/Sources/SwiftFormatRules/OneCasePerLine.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Each enum case with associated values or a raw value should appear in its own case declaration.
 ///

--- a/Sources/SwiftFormatRules/OneVariableDeclarationPerLine.swift
+++ b/Sources/SwiftFormatRules/OneVariableDeclarationPerLine.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Each variable declaration, with the exception of tuple destructuring, should
 /// declare 1 variable.

--- a/Sources/SwiftFormatRules/OnlyOneTrailingClosureArgument.swift
+++ b/Sources/SwiftFormatRules/OnlyOneTrailingClosureArgument.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Function calls should never mix normal closure arguments and trailing closures.
 ///

--- a/Sources/SwiftFormatRules/OrderedImports.swift
+++ b/Sources/SwiftFormatRules/OrderedImports.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Imports must be lexicographically ordered and logically grouped at the top of each source file.
 /// The order of the import groups is 1) regular imports, 2) declaration imports, and 3) @testable

--- a/Sources/SwiftFormatRules/ReturnVoidInsteadOfEmptyTuple.swift
+++ b/Sources/SwiftFormatRules/ReturnVoidInsteadOfEmptyTuple.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Return `Void`, not `()`, in signatures.
 ///

--- a/Sources/SwiftFormatRules/UseEarlyExits.swift
+++ b/Sources/SwiftFormatRules/UseEarlyExits.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Early exits should be used whenever possible.
 ///

--- a/Sources/SwiftFormatRules/UseLetInEveryBoundCaseVariable.swift
+++ b/Sources/SwiftFormatRules/UseLetInEveryBoundCaseVariable.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Every variable bound in a `case` pattern must have its own `let/var`.
 ///

--- a/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
+++ b/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Shorthand type forms must be used wherever possible.
 ///

--- a/Sources/SwiftFormatRules/UseSingleLinePropertyGetter.swift
+++ b/Sources/SwiftFormatRules/UseSingleLinePropertyGetter.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Read-only computed properties must use implicit `get` blocks.
 ///

--- a/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
+++ b/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
@@ -13,6 +13,7 @@
 import Foundation
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// When possible, the synthesized `struct` initializer should be used.
 ///

--- a/Sources/SwiftFormatRules/UseTripleSlashForDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/UseTripleSlashForDocumentationComments.swift
@@ -13,6 +13,7 @@
 import Foundation
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Documentation comments must use the `///` form.
 ///

--- a/Sources/SwiftFormatRules/UseWhereClausesInForLoops.swift
+++ b/Sources/SwiftFormatRules/UseWhereClausesInForLoops.swift
@@ -12,6 +12,7 @@
 
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// `for` loops that consist of a single `if` statement must use `where` clauses instead.
 ///

--- a/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
@@ -13,6 +13,7 @@
 import Foundation
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Documentation comments must be complete and valid.
 ///

--- a/Sources/SwiftFormatTestSupport/DiagnosingTestCase.swift
+++ b/Sources/SwiftFormatTestSupport/DiagnosingTestCase.swift
@@ -2,6 +2,7 @@ import SwiftFormatConfiguration
 import SwiftFormatCore
 import SwiftFormatRules
 import SwiftSyntax
+import SwiftSyntaxParser
 import XCTest
 
 /// DiagnosingTestCase is an XCTestCase subclass meant to inject diagnostic-specific testing

--- a/Sources/SwiftFormatTestSupport/DiagnosticTrackingConsumer.swift
+++ b/Sources/SwiftFormatTestSupport/DiagnosticTrackingConsumer.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Information about a diagnostic tracked by `DiagnosticTrackingConsumer`.
 struct EmittedDiagnostic {

--- a/Sources/SwiftFormatWhitespaceLinter/WhitespaceLinter.swift
+++ b/Sources/SwiftFormatWhitespaceLinter/WhitespaceLinter.swift
@@ -13,6 +13,7 @@
 import SwiftFormatConfiguration
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 private let utf8Newline = UTF8.CodeUnit(ascii: "\n")
 private let utf8Tab = UTF8.CodeUnit(ascii: "\t")

--- a/Sources/generate-pipeline/RuleCollector.swift
+++ b/Sources/generate-pipeline/RuleCollector.swift
@@ -13,6 +13,7 @@
 import Foundation
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// Collects information about rules in the formatter code base.
 final class RuleCollector {

--- a/Sources/swift-format/Frontend/CacheProcessor.swift
+++ b/Sources/swift-format/Frontend/CacheProcessor.swift
@@ -1,0 +1,171 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import SwiftSyntaxParser
+
+class CacheProcessor {
+  private let fileIterator: FileIterator
+  private let diagnosticEngine: DiagnosticEngine
+  private let fileManager: FileManager
+  private let frontendName: String
+
+  init(
+    fileIterator: FileIterator,
+    diagnosticEngine: DiagnosticEngine,
+    fileManager: FileManager,
+    frontendName: String
+  ) {
+    self.fileIterator = fileIterator
+    self.diagnosticEngine = diagnosticEngine
+    self.fileManager = fileManager
+    self.frontendName = frontendName
+  }
+
+  func process(_ work: ([String]) -> Void) {
+    let cacheDirURL = fileManager.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        .appendingPathComponent("swift-format", isDirectory: true)
+    let cacheFileURL = cacheDirURL.appendingPathComponent("cache.json")
+    var caches: FrontendCache
+    if fileManager.fileExists(atPath: cacheFileURL.path) {
+      let cacheData: Data
+      do {
+        cacheData = try Data(contentsOf: cacheFileURL)
+      } catch {
+        diagnosticEngine.diagnose(Diagnostic.Message.init(
+          .warning,
+          "We won't use cache due to cannot read cache data in '\(cacheFileURL)': \(error.localizedDescription)")
+        )
+        work(Array(fileIterator))
+        return
+      }
+
+      do {
+        caches = try JSONDecoder().decode(FrontendCache.self, from: cacheData)
+      } catch {
+        diagnosticEngine.diagnose(Diagnostic.Message.init(
+          .warning,
+          "We won't use cache due to failed to decode cache data in '\(cacheFileURL)': \(error.localizedDescription)")
+        )
+        work(Array(fileIterator))
+        return
+      }
+    } else {
+      caches = .init()
+    }
+
+    let cache = caches[frontendName] ?? Cache()
+
+    work(filePathsToProcess(cache: cache))
+
+    updateCacheFile(caches: caches, cacheFileURL: cacheFileURL)
+  }
+
+  private func filePathsToProcess(cache: Cache) -> [String] {
+    let lock = NSLock()
+
+    var filePathsToProcess: [String] = []
+
+    let dispatchGroup = DispatchGroup()
+    let filePaths = Array(fileIterator)
+    for filePath in filePaths {
+      dispatchGroup.enter()
+      DispatchQueue.global().async(execute: { [weak self] in
+        defer { dispatchGroup.leave() }
+        guard let self = self else { return }
+        guard let attrs = try? self.fileManager.attributesOfItem(atPath: filePath) else {
+          return
+        }
+        guard let modificationDate = attrs[.modificationDate] as? Date else {
+          return
+        }
+        guard let cachedModDate = cache[filePath] else {
+          lock.lock()
+          filePathsToProcess.append(filePath)
+          lock.unlock()
+          return
+        }
+        if modificationDate > cachedModDate {
+          lock.lock()
+          filePathsToProcess.append(filePath)
+          lock.unlock()
+        }
+      })
+    }
+    dispatchGroup.wait()
+
+    return filePathsToProcess
+  }
+
+  private func updateCacheFile(caches: FrontendCache, cacheFileURL: URL) {
+    let lock = NSLock()
+    var caches = caches
+    var cache = caches[self.frontendName] ?? Cache()
+
+    let dispatchGroup = DispatchGroup()
+    let filePaths = Array(fileIterator)
+    for filePath in filePaths {
+      dispatchGroup.enter()
+      DispatchQueue.global().async(execute: { [weak self] in
+        defer { dispatchGroup.leave() }
+        guard let self = self else { return }
+        guard let attrs = try? self.fileManager.attributesOfItem(atPath: filePath) else {
+          return
+        }
+        guard let modificationDate = attrs[.modificationDate] as? Date else {
+          return
+        }
+        lock.lock()
+        cache[filePath] = modificationDate
+        lock.unlock()
+      })
+    }
+    dispatchGroup.wait()
+
+    caches[frontendName] = cache
+
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = .prettyPrinted
+
+    let data: Data
+    do {
+      data = try encoder.encode(caches)
+    } catch {
+      diagnosticEngine.diagnose(Diagnostic.Message.init(
+        .warning,
+        "Failed to encode cache data: \(error.localizedDescription)")
+      )
+      return
+    }
+
+    let cacheDirURL = cacheFileURL.deletingLastPathComponent()
+    do {
+      try fileManager.createDirectory(at: cacheDirURL, withIntermediateDirectories: true)
+    } catch {
+      diagnosticEngine.diagnose(Diagnostic.Message.init(
+        .warning,
+        "Failed to create cache directory '\(cacheDirURL)': \(error.localizedDescription)")
+      )
+    }
+
+    fileManager.createFile(atPath: cacheFileURL.path, contents: nil)
+
+    do {
+      try data.write(to: cacheFileURL)
+    } catch {
+      diagnosticEngine.diagnose(Diagnostic.Message.init(
+        .warning,
+        "Failed to update cache file '\(cacheFileURL)': \(error.localizedDescription)")
+      )
+    }
+  }
+}

--- a/Sources/swift-format/Frontend/FormatFrontend.swift
+++ b/Sources/swift-format/Frontend/FormatFrontend.swift
@@ -26,6 +26,8 @@ class FormatFrontend: Frontend {
     super.init(lintFormatOptions: lintFormatOptions)
   }
 
+  override var name: String { "format" }
+
   override func processFile(_ fileToProcess: FileToProcess) {
     // Even though `diagnosticEngine` is defined, it's use is reserved for fatal messages. Pass nil
     // to the formatter to suppress other messages since they will be fixed or can't be

--- a/Sources/swift-format/Frontend/FormatFrontend.swift
+++ b/Sources/swift-format/Frontend/FormatFrontend.swift
@@ -14,6 +14,7 @@ import Foundation
 import SwiftFormat
 import SwiftFormatConfiguration
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// The frontend for formatting operations.
 class FormatFrontend: Frontend {

--- a/Sources/swift-format/Frontend/Frontend.swift
+++ b/Sources/swift-format/Frontend/Frontend.swift
@@ -14,6 +14,7 @@ import Foundation
 import SwiftFormat
 import SwiftFormatConfiguration
 import SwiftSyntax
+import SwiftSyntaxParser
 
 class Frontend {
   /// Represents a file to be processed by the frontend and any file-specific options associated

--- a/Sources/swift-format/Frontend/FrontendCache.swift
+++ b/Sources/swift-format/Frontend/FrontendCache.swift
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+typealias FrontendName = String
+typealias FrontendCache = [FrontendName: Cache]
+
+struct Cache: Codable {
+  typealias Key = String
+  typealias Value = Date
+
+  private var modifiedDateByFilepath: [Key: Value]
+
+  subscript(filepath: Key) -> Value? {
+    get {
+      return modifiedDateByFilepath[filepath]
+    }
+    set {
+      modifiedDateByFilepath[filepath] = newValue
+    }
+  }
+
+  init() {
+    self.modifiedDateByFilepath = [:]
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    self.modifiedDateByFilepath = try container.decode([Key:Value].self)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(modifiedDateByFilepath)
+  }
+}

--- a/Sources/swift-format/Frontend/LintFrontend.swift
+++ b/Sources/swift-format/Frontend/LintFrontend.swift
@@ -18,6 +18,8 @@ import SwiftSyntaxParser
 
 /// The frontend for linting operations.
 class LintFrontend: Frontend {
+  override var name: String { "lint" }
+
   override func processFile(_ fileToProcess: FileToProcess) {
     let linter = SwiftLinter(
       configuration: fileToProcess.configuration, diagnosticEngine: diagnosticEngine)

--- a/Sources/swift-format/Frontend/LintFrontend.swift
+++ b/Sources/swift-format/Frontend/LintFrontend.swift
@@ -14,6 +14,7 @@ import Foundation
 import SwiftFormat
 import SwiftFormatConfiguration
 import SwiftSyntax
+import SwiftSyntaxParser
 
 /// The frontend for linting operations.
 class LintFrontend: Frontend {

--- a/Sources/swift-format/Subcommands/DeleteCache.swift
+++ b/Sources/swift-format/Subcommands/DeleteCache.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import Foundation
+
+extension SwiftFormatCommand {
+  /// Delete format and lint cache
+  struct DeleteCache: ParsableCommand {
+    static var configuration = CommandConfiguration(
+      abstract: "Delete format and lint cache"
+    )
+
+    func run() throws {
+      let fileManager = FileManager.default
+      let cacheDirURL = fileManager.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+          .appendingPathComponent("swift-format", isDirectory: true)
+      let cacheFileURL = cacheDirURL.appendingPathComponent("cache.json")
+      try fileManager.removeItem(at: cacheFileURL)
+    }
+  }
+}

--- a/Sources/swift-format/Subcommands/LintFormatOptions.swift
+++ b/Sources/swift-format/Subcommands/LintFormatOptions.swift
@@ -55,6 +55,12 @@ struct LintFormatOptions: ParsableArguments {
     help: "Process files in parallel, simultaneously across multiple cores.")
   var parallel: Bool = false
 
+  @Flag(
+    name: .shortAndLong,
+    help: "Use cache to skip process files which are not modified"
+  )
+  var cache: Bool = false
+
   /// The list of paths to Swift source files that should be formatted or linted.
   @Argument(help: "Zero or more input filenames.")
   var paths: [String] = []

--- a/Sources/swift-format/main.swift
+++ b/Sources/swift-format/main.swift
@@ -23,6 +23,7 @@ struct SwiftFormatCommand: ParsableCommand {
       Format.self,
       LegacyMain.self,
       Lint.self,
+      DeleteCache.self,
     ],
     // TODO: Change the default to `Format` when we delete the legacy interface after a short
     // period of time.

--- a/Tests/SwiftFormatCoreTests/RuleMaskTests.swift
+++ b/Tests/SwiftFormatCoreTests/RuleMaskTests.swift
@@ -1,5 +1,6 @@
 import SwiftFormatCore
 import SwiftSyntax
+import SwiftSyntaxParser
 import XCTest
 
 final class RuleMaskTests: XCTestCase {

--- a/Tests/SwiftFormatPerformanceTests/WhitespaceLinterPerformanceTests.swift
+++ b/Tests/SwiftFormatPerformanceTests/WhitespaceLinterPerformanceTests.swift
@@ -1,6 +1,7 @@
 import SwiftFormatTestSupport
 import SwiftFormatWhitespaceLinter
 import SwiftSyntax
+import SwiftSyntaxParser
 import XCTest
 
 final class WhitespaceLinterPerformanceTests: DiagnosingTestCase {

--- a/Tests/SwiftFormatPrettyPrintTests/PrettyPrintTestCase.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/PrettyPrintTestCase.swift
@@ -3,6 +3,7 @@ import SwiftFormatCore
 import SwiftFormatPrettyPrint
 import SwiftFormatTestSupport
 import SwiftSyntax
+import SwiftSyntaxParser
 import XCTest
 
 class PrettyPrintTestCase: DiagnosingTestCase {

--- a/Tests/SwiftFormatPrettyPrintTests/SequenceExprFoldingTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/SequenceExprFoldingTests.swift
@@ -1,5 +1,6 @@
 import SwiftFormatPrettyPrint
 import SwiftSyntax
+import SwiftSyntaxParser
 import XCTest
 
 final class SequenceExprFoldingTests: XCTestCase {

--- a/Tests/SwiftFormatRulesTests/FileScopedDeclarationPrivacyTests.swift
+++ b/Tests/SwiftFormatRulesTests/FileScopedDeclarationPrivacyTests.swift
@@ -1,6 +1,7 @@
 import SwiftFormatConfiguration
 import SwiftFormatRules
 import SwiftSyntax
+import SwiftSyntaxParser
 
 private typealias TestConfiguration = (
   original: String,

--- a/Tests/SwiftFormatRulesTests/LintOrFormatRuleTestCase.swift
+++ b/Tests/SwiftFormatRulesTests/LintOrFormatRuleTestCase.swift
@@ -2,6 +2,7 @@ import SwiftFormatConfiguration
 import SwiftFormatCore
 import SwiftFormatTestSupport
 import SwiftSyntax
+import SwiftSyntaxParser
 import XCTest
 
 class LintOrFormatRuleTestCase: DiagnosingTestCase {

--- a/Tests/SwiftFormatTests/SyntaxValidatingVisitorTests.swift
+++ b/Tests/SwiftFormatTests/SyntaxValidatingVisitorTests.swift
@@ -1,5 +1,6 @@
 import SwiftFormat
 import SwiftSyntax
+import SwiftSyntaxParser
 import XCTest
 
 final class SyntaxValidatingVisitorTests: XCTestCase {

--- a/Tests/SwiftFormatWhitespaceLinterTests/WhitespaceTestCase.swift
+++ b/Tests/SwiftFormatWhitespaceLinterTests/WhitespaceTestCase.swift
@@ -3,6 +3,7 @@ import SwiftFormatCore
 import SwiftFormatTestSupport
 import SwiftFormatWhitespaceLinter
 import SwiftSyntax
+import SwiftSyntaxParser
 import XCTest
 
 class WhitespaceTestCase: DiagnosingTestCase {


### PR DESCRIPTION
When you integrate `swift-format` on Xcode build phase, it spends a lot of time to process unmodified files.
You may usually edit under 10 files per one build, so linting and formatting whole files is not you want.

This PR introduce cache system to each FrontEnd based on file system's modified time.
With `-c` command line option, swift-format try to read the cache file that is written on last execution.
The `swift-format` will skip to process file that is on cache file and modified date is equal to current file's one.
This idea is come from the cache system of https://github.com/nicklockwood/SwiftFormat.

Below is an example of the cache file.
```json
{
  "format" : {
    "\/Users\/wonyoungju\/jyg_order_ios_review\/Jeongyookgak App\/Application\/Goods Detail\/GoodsDetailViewReactor.swift" : 655044856.57068825,
    "\/Users\/wonyoungju\/jyg_order_ios_review\/Jeongyookgak App\/Common\/Extensions\/UIKit\/UIColor\/UIColor+Extensions.swift" : 655044808.36886001,
    "\/Users\/wonyoungju\/jyg_order_ios_review\/Jeongyookgak App\/Application\/Goods Detail\/GoodsDetailShippingTypeMetas\/GoodsDetailShippingTypeMetasView.swift" : 655044857.62721944,
    "\/Users\/wonyoungju\/jyg_order_ios_review\/Jeongyookgak App\/Common\/Views\/Label\/YGCopyableLabel.swift" : 655044814.26825607
  },
  "lint": {
    "\/Users\/wonyoungju\/jyg_order_ios_review\/Jeongyookgak App\/Application\/Goods Detail\/GoodsDetailShippingTypeMetas\/GoodsDetailShippingTypeMetasView.swift" : 655044857.62721944,
    "\/Users\/wonyoungju\/jyg_order_ios_review\/Jeongyookgak App\/Common\/Views\/Label\/YGCopyableLabel.swift" : 655044814.26825607
  }
}
```

Note that this PR depends on #268 to handle SwiftSyntaxParser change and make it compile.