### PR TITLE
Fix up file URL handling.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,9 @@ import Foundation
 
 let package = Package(
   name: "swift-format",
+  platforms: [
+    .macOS(.v10_11)
+  ],
   products: [
     .executable(name: "swift-format", targets: ["swift-format"]),
     .library(name: "SwiftFormat", targets: ["SwiftFormat", "SwiftFormatConfiguration"]),

--- a/Sources/SwiftFormatCore/Context.swift
+++ b/Sources/SwiftFormatCore/Context.swift
@@ -69,8 +69,8 @@ public final class Context {
     self.fileURL = fileURL
     self.importsXCTest = .notDetermined
     self.sourceLocationConverter =
-      source.map { SourceLocationConverter(file: fileURL.path, source: $0) }
-      ?? SourceLocationConverter(file: fileURL.path, tree: sourceFileSyntax)
+      source.map { SourceLocationConverter(file: fileURL.relativePath, source: $0) }
+      ?? SourceLocationConverter(file: fileURL.relativePath, tree: sourceFileSyntax)
     self.ruleMask = RuleMask(
       syntaxNode: Syntax(sourceFileSyntax),
       sourceLocationConverter: sourceLocationConverter


### PR DESCRIPTION
This change unifies the use of `URL`s for file paths throughout the
frontend instead of the current mix of `URL`s and `String`s. In
addition, it aims to preserve relative URLs where possible,
improving the presentation of diagnostics; the filenames will be
printed relative to the current working directory where swift-format
is run, rather than always printing their absolute paths.

The diagnostic/finding types, however, still represent the path of a
diagnostic or finding as the `String` to be displayed or serialized,
since they are obtained from the SwiftSyntax `SourceLocationConverter`
which uses `String` to present the file path. At the API layer (the
`SwiftFormatter` and `SwiftLinter` classes), the
`SourceLocationConverter` will always be created using the input
URL's `relativePath`, so if one wishes to force absolute paths to be
produced by findings, call `absoluteURL` before passing them to the
API.