### PR TITLE
Sort imports case-insensitive

### DIFF
--- a/Sources/SwiftFormatRules/OrderedImports.swift
+++ b/Sources/SwiftFormatRules/OrderedImports.swift
@@ -13,6 +13,12 @@
 import SwiftFormatCore
 import SwiftSyntax
 
+fileprivate extension String {
+  func lexicographicallyPrecedesCaseInsensitive(_ other: String) -> Bool {
+    return self.lowercased().lexicographicallyPrecedes(other.lowercased())
+  }
+}
+
 /// Imports must be lexicographically ordered and logically grouped at the top of each source file.
 /// The order of the import groups is 1) regular imports, 2) declaration imports, and 3) @testable
 /// imports. These groups are separated by a single blank line. Blank lines in between the import
@@ -224,7 +230,7 @@ public final class OrderedImports: SyntaxFormatRule {
           // them. Leave this duplicate import.
         }
         if let previousImport = previousImport,
-          line.importName.lexicographicallyPrecedes(previousImport.importName) && !diagnosed
+          line.importName.lexicographicallyPrecedesCaseInsensitive(previousImport.importName) && !diagnosed
             // Only warn to sort imports that shouldn't be removed.
             && visitedImports[fullyQualifiedImport] == nil
         {
@@ -243,7 +249,7 @@ public final class OrderedImports: SyntaxFormatRule {
       }
     }
 
-    linesWithLeadingComments.sort { $0.0.importName.lexicographicallyPrecedes($1.0.importName) }
+    linesWithLeadingComments.sort { $0.0.importName.lexicographicallyPrecedesCaseInsensitive($1.0.importName) }
 
     // Unpack the tuples back into a list of Lines.
     var output: [Line] = []

--- a/Tests/SwiftFormatRulesTests/OrderedImportsTests.swift
+++ b/Tests/SwiftFormatRulesTests/OrderedImportsTests.swift
@@ -412,9 +412,9 @@ final class OrderedImportsTests: LintOrFormatRuleTestCase {
       import
         Alpha
       import Beta
-      import Zeta
       import
         zeta
+      import Zeta
       """
 
     XCTAssertFormatting(OrderedImports.self, input: input, expected: expected)
@@ -450,13 +450,13 @@ final class OrderedImportsTests: LintOrFormatRuleTestCase {
       import AppKit
       // CoreLocation is necessary to get location stuff.
       import CoreLocation  // This import must stay.
+      import foo
       // UIKit does UI Stuff?
       import UIKit
       // This is the second CoreLocation import.
       import CoreLocation  // The 2nd CL import has a comment here too.
       // Comment about ZeeFramework.
       import ZeeFramework
-      import foo
       // Second comment about ZeeFramework.
       import ZeeFramework  // This one has a trailing comment too.
       foo()
@@ -469,12 +469,12 @@ final class OrderedImportsTests: LintOrFormatRuleTestCase {
       import CoreLocation  // This import must stay.
       // This is the second CoreLocation import.
       import CoreLocation  // The 2nd CL import has a comment here too.
+      import foo
       // UIKit does UI Stuff?
       import UIKit
       // Comment about ZeeFramework.
       // Second comment about ZeeFramework.
       import ZeeFramework  // This one has a trailing comment too.
-      import foo
 
       foo()
       """
@@ -484,7 +484,7 @@ final class OrderedImportsTests: LintOrFormatRuleTestCase {
 
     // Even though this import is technically also not sorted, that won't matter if the import is
     // removed so there should only be a warning to remove it.
-    XCTAssertDiagnosed(.removeDuplicateImport, line: 7, column: 1)
+    XCTAssertDiagnosed(.removeDuplicateImport, line: 8, column: 1)
     XCTAssertDiagnosed(.removeDuplicateImport, line: 12, column: 1)
   }
 
@@ -637,6 +637,24 @@ final class OrderedImportsTests: LintOrFormatRuleTestCase {
       foo()
       bar()
       baz()
+      """
+
+    XCTAssertFormatting(OrderedImports.self, input: input, expected: expected)
+  }
+
+  func testSortCaseInsensitive() {
+    let input =
+      """
+      import RadarFoundation
+      import RDARFramework
+      import UIKit
+      """
+
+    let expected =
+      """
+      import RadarFoundation
+      import RDARFramework
+      import UIKit
       """
 
     XCTAssertFormatting(OrderedImports.self, input: input, expected: expected)


### PR DESCRIPTION
Sort imports case-insensitive instead of case-sensitive as that seems more natural to me. Unless using case-sensitive sorting was a deliberate decision @allevato.

rdar://86096207 [SR-15565]