### PR TITLE
UseSingleLinePropertyGetter: respect `async` and `throws` on getters

### DIFF
--- a/Sources/SwiftFormatRules/UseSingleLinePropertyGetter.swift
+++ b/Sources/SwiftFormatRules/UseSingleLinePropertyGetter.swift
@@ -28,7 +28,9 @@ public final class UseSingleLinePropertyGetter: SyntaxFormatRule {
       accessorBlock.accessors.count == 1,
       acc.accessorKind.tokenKind == .contextualKeyword("get"),
       acc.attributes == nil,
-      acc.modifier == nil
+      acc.modifier == nil,
+      acc.asyncKeyword == nil,
+      acc.throwsKeyword == nil
     else { return Syntax(node) }
 
     diagnose(.removeExtraneousGetBlock, on: acc)

--- a/Tests/SwiftFormatRulesTests/UseSingleLinePropertyGetterTests.swift
+++ b/Tests/SwiftFormatRulesTests/UseSingleLinePropertyGetterTests.swift
@@ -18,6 +18,21 @@ final class UseSingleLinePropertyGetterTests: LintOrFormatRuleTestCase {
              var j: Int {
                mutating get { return 0 }
              }
+             var k: Int {
+               get async {
+                 return 4
+               }
+             }
+             var l: Int {
+               get throws {
+                 return 4
+               }
+             }
+             var m: Int {
+               get async throws {
+                 return 4
+               }
+             }
              """,
       expected: """
                 var g: Int { return 4 }
@@ -30,6 +45,21 @@ final class UseSingleLinePropertyGetterTests: LintOrFormatRuleTestCase {
                 }
                 var j: Int {
                   mutating get { return 0 }
+                }
+                var k: Int {
+                  get async {
+                    return 4
+                  }
+                }
+                var l: Int {
+                  get throws {
+                    return 4
+                  }
+                }
+                var m: Int {
+                  get async throws {
+                    return 4
+                  }
                 }
                 """)
   }


### PR DESCRIPTION
Resolves: SR-15671

With this patch, the `UseSingleLinePropertyGetter` rule will take `async` and `throws` on getters into account. When one of those is present, the rule won't be applied; otherwise, the semantics would be changed, by removing `async` and/or `throws`.
The tests are extended accordingly.