### PR TITLE
Utilities: adjust `FileHandle` extension for Windows

### DIFF
--- a/Sources/swift-format/Utilities/FileHandle+TextOutputStream.swift
+++ b/Sources/swift-format/Utilities/FileHandle+TextOutputStream.swift
@@ -12,7 +12,12 @@
 
 import Foundation
 
+#if !os(Windows)
 extension FileHandle: TextOutputStream {
+}
+#endif
+
+extension FileHandle {
   public func write(_ string: String) {
     self.write(string.data(using: .utf8)!)  // Conversion to UTF-8 cannot fail
   }


### PR DESCRIPTION
TSCBasic provides an extension for `FileHandle` on Windows which
conforms to `WritableByteStream` which results in a duplicate protocol
conformance in the extension in swift-format.  Extract the conformance
under a guard to permit building swift-format on Windows once again.