### PR TITLE
Adjust for apple/swift-syntax@3c0c316d98dcbd9f150438d454ef850927b874ed

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -2011,8 +2011,8 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     return .visitChildren
   }
 
-  override func visit(_ node: SomeTypeSyntax) -> SyntaxVisitorContinueKind {
-    after(node.someSpecifier, tokens: .space)
+  override func visit(_ node: ConstrainedSugarTypeSyntax) -> SyntaxVisitorContinueKind {
+    after(node.someOrAnySpecifier, tokens: .space)
     return .visitChildren
   }
 


### PR DESCRIPTION
This updates the visitor interface for the updated swift-syntax
interface in 3c0c316d98dcbd9f150438d454ef850927b874ed.  This allows
building on main again.