### PR TITLE
Use a wrapper type instead of retro-conforming `FileHandle` to `TextOutputStream`.

### DIFF
--- a/Sources/swift-format/Frontend/FormatFrontend.swift
+++ b/Sources/swift-format/Frontend/FormatFrontend.swift
@@ -39,7 +39,7 @@ class FormatFrontend: Frontend {
       return
     }
 
-    var stdoutStream = FileHandle.standardOutput
+    var stdoutStream = FileHandleTextOutputStream(FileHandle.standardOutput)
     do {
       if inPlace {
         var buffer = ""

--- a/Sources/swift-format/Utilities/FileHandleTextOutputStream.swift
+++ b/Sources/swift-format/Utilities/FileHandleTextOutputStream.swift
@@ -12,8 +12,18 @@
 
 import Foundation
 
-extension FileHandle: TextOutputStream {
-  public func write(_ string: String) {
-    self.write(string.data(using: .utf8)!)  // Conversion to UTF-8 cannot fail
+/// Wraps a `FileHandle` so that it can be used by APIs that take a `TextOutputStream`-conforming
+/// type as an input.
+struct FileHandleTextOutputStream: TextOutputStream {
+  /// The underlying file handle to which the text will be written.
+  private var fileHandle: FileHandle
+
+  /// Creates a new output stream that writes to the given file handle.
+  init(_ fileHandle: FileHandle) {
+    self.fileHandle = fileHandle
+  }
+
+  func write(_ string: String) {
+    fileHandle.write(string.data(using: .utf8)!)  // Conversion to UTF-8 cannot fail
   }
 }

--- a/Sources/swift-format/Utilities/StderrDiagnosticPrinter.swift
+++ b/Sources/swift-format/Utilities/StderrDiagnosticPrinter.swift
@@ -64,7 +64,7 @@ final class StderrDiagnosticPrinter {
   /// Prints a diagnostic to standard error.
   func printDiagnostic(_ diagnostic: TSCBasic.Diagnostic) {
     printQueue.sync {
-      let stderr = FileHandle.standardError
+      let stderr = FileHandleTextOutputStream(FileHandle.standardError)
 
       stderr.write("\(ansiSGR(.boldWhite))\(diagnostic.location): ")
 


### PR DESCRIPTION
TSCBasic has a Windows-only retroactive `FileHandle: WritableByteStream`
conformance which confers `TextOutputStream` conformance, conflicting with the
one in our package. Instead of trying to reconcile this across all platforms,
just replace our retroactive conformance with a new wrapper type which can
never conflict with anything from an outside package.