### PR TITLE
[5.6] Use a wrapper type instead of retro-conforming FileHandle to `TextOutputStream`.

### DIFF
--- a/Sources/swift-format/Frontend/FormatFrontend.swift
+++ b/Sources/swift-format/Frontend/FormatFrontend.swift
@@ -39,7 +39,7 @@ class FormatFrontend: Frontend {
       return
     }
 
-    var stdoutStream = FileHandle.standardOutput
+    var stdoutStream = FileHandleTextOutputStream(FileHandle.standardOutput)
     do {
       if inPlace {
         var buffer = ""

--- a/Sources/swift-format/Utilities/FileHandleTextOutputStream.swift
+++ b/Sources/swift-format/Utilities/FileHandleTextOutputStream.swift
@@ -12,8 +12,18 @@
 
 import Foundation
 
-extension FileHandle: TextOutputStream {
-  public func write(_ string: String) {
-    self.write(string.data(using: .utf8)!)  // Conversion to UTF-8 cannot fail
+/// Wraps a `FileHandle` so that it can be used by APIs that take a `TextOutputStream`-conforming
+/// type as an input.
+struct FileHandleTextOutputStream: TextOutputStream {
+  /// The underlying file handle to which the text will be written.
+  private var fileHandle: FileHandle
+
+  /// Creates a new output stream that writes to the given file handle.
+  init(_ fileHandle: FileHandle) {
+    self.fileHandle = fileHandle
+  }
+
+  func write(_ string: String) {
+    fileHandle.write(string.data(using: .utf8)!)  // Conversion to UTF-8 cannot fail
   }
 }

--- a/Sources/swift-format/Utilities/StderrDiagnosticPrinter.swift
+++ b/Sources/swift-format/Utilities/StderrDiagnosticPrinter.swift
@@ -64,7 +64,7 @@ final class StderrDiagnosticPrinter {
   /// Prints a diagnostic to standard error.
   func printDiagnostic(_ diagnostic: TSCBasic.Diagnostic) {
     printQueue.sync {
-      let stderr = FileHandle.standardError
+      let stderr = FileHandleTextOutputStream(FileHandle.standardError)
 
       stderr.write("\(ansiSGR(.boldWhite))\(diagnostic.location): ")
 

--- a/Sources/swift-format/VersionOptions.swift
+++ b/Sources/swift-format/VersionOptions.swift
@@ -20,7 +20,7 @@ struct VersionOptions: ParsableArguments {
   func validate() throws {
     if version {
       // TODO: Automate updates to this somehow.
-      print("0.50600.0")
+      print("0.50600.1")
       throw ExitCode.success
     }
   }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-format/pull/290, plus version number update.