### PR TITLE
Don't emit AlwaysUseLowerCamelCase for decls that `override`

### DIFF
--- a/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
+++ b/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
@@ -51,6 +51,13 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
   }
 
   public override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+    // Don't diagnose any issues when the variable is overriding, because this declaration can't
+    // rename the variable. If the user analyzes the code where the variable is really declared,
+    // then the diagnostic can be raised for just that location.
+    if let modifiers = node.modifiers, modifiers.has(modifier: "override") {
+      return .visitChildren
+    }
+
     for binding in node.bindings {
       guard let pat = binding.pattern.as(IdentifierPatternSyntax.self) else {
         continue
@@ -94,6 +101,13 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
   }
 
   public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+    // Don't diagnose any issues when the function is overriding, because this declaration can't
+    // rename the function. If the user analyzes the code where the function is really declared,
+    // then the diagnostic can be raised for just that location.
+    if let modifiers = node.modifiers, modifiers.has(modifier: "override") {
+      return .visitChildren
+    }
+
     // We allow underscores in test names, because there's an existing convention of using
     // underscores to separate phrases in very detailed test names.
     let allowUnderscores = testCaseFuncs.contains(node)

--- a/Tests/SwiftFormatRulesTests/AlwaysUseLowerCamelCaseTests.swift
+++ b/Tests/SwiftFormatRulesTests/AlwaysUseLowerCamelCaseTests.swift
@@ -123,4 +123,25 @@ final class AlwaysUseLowerCamelCaseTests: LintOrFormatRuleTestCase {
     XCTAssertNotDiagnosed(
       .nameMustBeLowerCamelCase("test_HappyPath_Through_GoodCode_Throws", description: "function"))
   }
+
+  func testIgnoresFunctionOverrides() {
+    let input =
+      """
+      class ParentClass {
+        var poorly_named_variable: Int = 5
+        func poorly_named_method() {}
+      }
+
+      class ChildClass: ParentClass {
+        override var poorly_named_variable: Int = 5
+        override func poorly_named_method() {}
+      }
+      """
+
+    performLint(AlwaysUseLowerCamelCase.self, input: input)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("poorly_named_variable", description: "variable"), line: 2, column: 7)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("poorly_named_method", description: "function"), line: 3, column: 8)
+  }
 }


### PR DESCRIPTION
Specifically this applies to function and variable decls. When one of those is overriding a decl in a super class, then this specific instance of the decl cannot be renamed to fix the issue. The original decl in the super class must be renamed. The finding is still raised if the super class is linted.

Raising the finding in every subclass is noisy and frustrating, since it can't really be fixed in the subclass.