### PR TITLE
Don't overwrite files if they are unchanged

### DIFF
--- a/Sources/swift-format/Frontend/FormatFrontend.swift
+++ b/Sources/swift-format/Frontend/FormatFrontend.swift
@@ -49,8 +49,10 @@ class FormatFrontend: Frontend {
           to: &buffer,
           parsingDiagnosticHandler: diagnosticsEngine.consumeParserDiagnostic)
 
-        let bufferData = buffer.data(using: .utf8)!  // Conversion to UTF-8 cannot fail
-        try bufferData.write(to: url, options: .atomic)
+        if buffer != source {
+          let bufferData = buffer.data(using: .utf8)!  // Conversion to UTF-8 cannot fail
+          try bufferData.write(to: url, options: .atomic)
+        }
       } else {
         try formatter.format(
           source: source,


### PR DESCRIPTION
Always writing to the file, even if unchanged, updates the modified time and prevents incremental builds in Xcode. This PR adds a simple equal check before actually writing anything, preserving timestamps if nothing in the output was changed.

I don't remember this being an issue for me before, but I also couldn't find any change that would've started to cause this. In any case, this completely resolves the problem.

In my testing with a small folder of files, this change also makes the formatting slightly faster.