### PR TITLE
Check for else statement during where clause substitution

### DIFF
--- a/Sources/SwiftFormatRules/UseWhereClausesInForLoops.swift
+++ b/Sources/SwiftFormatRules/UseWhereClausesInForLoops.swift
@@ -41,7 +41,8 @@ public final class UseWhereClausesInForLoops: SyntaxFormatRule {
     //    with a single condition whose body is just `continue`.
     switch stmt.item.as(SyntaxEnum.self) {
     case .ifStmt(let ifStmt)
-    where ifStmt.conditions.count == 1 && node.body.statements.count == 1:
+    where ifStmt.conditions.count == 1 && ifStmt.elseKeyword == nil
+      && node.body.statements.count == 1:
       // Extract the condition of the IfStmt.
       let conditionElement = ifStmt.conditions.first!
       guard let condition = conditionElement.condition.as(ExprSyntax.self) else {

--- a/Tests/SwiftFormatRulesTests/UseWhereClausesInForLoopsTests.swift
+++ b/Tests/SwiftFormatRulesTests/UseWhereClausesInForLoopsTests.swift
@@ -14,6 +14,22 @@ final class UseWhereClausesInForLoopsTests: LintOrFormatRuleTestCase {
              for i in [0, 1, 2, 3] {
                if i > 30 {
                  print(i)
+               } else {
+                 print(i)
+               }
+             }
+
+             for i in [0, 1, 2, 3] {
+               if i > 30 {
+                 print(i)
+               } else if i > 40 {
+                 print(i)
+               }
+             }
+
+             for i in [0, 1, 2, 3] {
+               if i > 30 {
+                 print(i)
                }
                print(i)
              }
@@ -34,6 +50,22 @@ final class UseWhereClausesInForLoopsTests: LintOrFormatRuleTestCase {
       expected: """
                 for i in [0, 1, 2, 3] where i > 30 {
                     print(i)
+                }
+
+                for i in [0, 1, 2, 3] {
+                  if i > 30 {
+                    print(i)
+                  } else {
+                    print(i)
+                  }
+                }
+
+                for i in [0, 1, 2, 3] {
+                  if i > 30 {
+                    print(i)
+                  } else if i > 40 {
+                    print(i)
+                  }
                 }
 
                 for i in [0, 1, 2, 3] {


### PR DESCRIPTION
### Summary
The `UseWhereClausesInForLoops` rule fails to check for an `else` keyword when replacing a single `if` statement. The formatted statement drops the behavior defined in the `else` body completely. 

### Example
```swift
for i in [0, 1, 2, 3] {
   if i > 30 {
     print(i)
   } else {
     print(i)
   }
 }

// Is formatted as:

for i in [0, 1, 2, 3] where i > 30 {
   print(i)
 }
```

### Solution
This fix adds an additional check to ensure that there is no `else` case attached to the `if` statement. Unit tests were updated to cover this behavior.