### PR TITLE
Fix swift-format In Response to SwiftSyntax Changes

### DIFF
--- a/Sources/SwiftFormatRules/FullyIndirectEnum.swift
+++ b/Sources/SwiftFormatRules/FullyIndirectEnum.swift
@@ -68,8 +68,7 @@ public final class FullyIndirectEnum: SyntaxFormatRule {
 
     let newModifier = SyntaxFactory.makeDeclModifier(
       name: SyntaxFactory.makeIdentifier(
-        "indirect", leadingTrivia: leadingTrivia, trailingTrivia: .spaces(1)), detailLeftParen: nil,
-      detail: nil, detailRightParen: nil)
+        "indirect", leadingTrivia: leadingTrivia, trailingTrivia: .spaces(1)), detail: nil)
 
     let newMemberBlock = node.members.withMembers(SyntaxFactory.makeMemberDeclList(newMembers))
     return DeclSyntax(newEnumDecl.addModifier(newModifier).withMembers(newMemberBlock))

--- a/Sources/SwiftFormatRules/ModifierListSyntax+Convenience.swift
+++ b/Sources/SwiftFormatRules/ModifierListSyntax+Convenience.swift
@@ -50,7 +50,7 @@ extension ModifierListSyntax {
   func createModifierToken(name: String) -> DeclModifierSyntax {
     let id = SyntaxFactory.makeIdentifier(name, trailingTrivia: .spaces(1))
     let newModifier = SyntaxFactory.makeDeclModifier(
-      name: id, detailLeftParen: nil, detail: nil, detailRightParen: nil)
+      name: id, detail: nil)
     return newModifier
   }
 

--- a/Sources/SwiftFormatRules/ReturnVoidInsteadOfEmptyTuple.swift
+++ b/Sources/SwiftFormatRules/ReturnVoidInsteadOfEmptyTuple.swift
@@ -82,7 +82,7 @@ public final class ReturnVoidInsteadOfEmptyTuple: SyntaxFormatRule {
   private func hasNonWhitespaceLeadingTrivia(_ token: TokenSyntax) -> Bool {
     for piece in token.leadingTrivia {
       switch piece {
-      case .blockComment, .docBlockComment, .docLineComment, .garbageText, .lineComment:
+      case .blockComment, .docBlockComment, .docLineComment, .garbageText, .lineComment, .shebang:
         return true
       default:
         break

--- a/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
+++ b/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
@@ -40,7 +40,7 @@ public final class UseSynthesizedInitializer: SyntaxLintRule {
         // Collect any possible redundant initializers into a list
       } else if let initDecl = member.as(InitializerDeclSyntax.self) {
         guard initDecl.optionalMark == nil else { continue }
-        guard initDecl.throwsOrRethrowsKeyword == nil else { continue }
+        guard initDecl.signature.throwsOrRethrowsKeyword == nil else { continue }
         initializers.append(initDecl)
       }
     }
@@ -51,7 +51,7 @@ public final class UseSynthesizedInitializer: SyntaxLintRule {
     for initializer in initializers {
       guard
         matchesPropertyList(
-          parameters: initializer.parameters.parameterList,
+          parameters: initializer.signature.input.parameterList,
           properties: storedProperties)
       else { continue }
       guard

--- a/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
@@ -29,20 +29,19 @@ public final class ValidateDocumentationComments: SyntaxLintRule {
 
   public override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
     return checkFunctionLikeDocumentation(
-      DeclSyntax(node), name: "init", parameters: node.parameters.parameterList, throwsOrRethrowsKeyword: node.throwsOrRethrowsKeyword)
+      DeclSyntax(node), name: "init", signature: node.signature)
   }
 
   public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
     return checkFunctionLikeDocumentation(
-      DeclSyntax(node), name: node.identifier.text, parameters: node.signature.input.parameterList, throwsOrRethrowsKeyword: node.signature.throwsOrRethrowsKeyword,
+      DeclSyntax(node), name: node.identifier.text, signature: node.signature,
       returnClause: node.signature.output)
   }
 
   private func checkFunctionLikeDocumentation(
     _ node: DeclSyntax,
     name: String,
-    parameters: FunctionParameterListSyntax,
-    throwsOrRethrowsKeyword: TokenSyntax?,
+    signature: FunctionSignatureSyntax,
     returnClause: ReturnClauseSyntax? = nil
   ) -> SyntaxVisitorContinueKind {
     guard let declComment = node.docComment else { return .skipChildren }
@@ -64,10 +63,10 @@ public final class ValidateDocumentationComments: SyntaxLintRule {
     }
 
     validateThrows(
-      throwsOrRethrowsKeyword, name: name, throwsDesc: commentInfo.throwsDescription, node: node)
+      signature.throwsOrRethrowsKeyword, name: name, throwsDesc: commentInfo.throwsDescription, node: node)
     validateReturn(
       returnClause, name: name, returnDesc: commentInfo.returnsDescription, node: node)
-    let funcParameters = funcParametersIdentifiers(in: parameters)
+    let funcParameters = funcParametersIdentifiers(in: signature.input.parameterList)
 
     // If the documentation of the parameters is wrong 'docCommentInfo' won't
     // parse the parameters correctly. First the documentation has to be fix


### PR DESCRIPTION
There's been a bit of churn in the mainline of swift-syntax lately which has broken swift-format. Repair the build.