### PR TITLE
Update for `async` being a contextual keyword.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1700,7 +1700,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     // this special exception for `async let` statements to avoid breaking prematurely between the
     // `async` and `let` keywords.
     let breakOrSpace: Token
-    if node.name.tokenKind == .identifier("async") {
+    if node.name.tokenKind == .contextualKeyword("async") {
       breakOrSpace = .space
     } else {
       breakOrSpace = .break


### PR DESCRIPTION
`async` was changed from an identifier to a contextual keyword by
https://github.com/apple/swift/pull/58912.