### PR TITLE
Fix the column of a parse error.

### DIFF
--- a/Tests/SwiftFormatTests/SyntaxValidatingVisitorTests.swift
+++ b/Tests/SwiftFormatTests/SyntaxValidatingVisitorTests.swift
@@ -28,7 +28,7 @@ final class SyntaxValidatingVisitorTests: XCTestCase {
         var bar = 0
       }
       """
-    assertInvalidSyntax(in: input, atLine: 1, column: 1)
+    assertInvalidSyntax(in: input, atLine: 1, column: 7)
 
     input =
       """


### PR DESCRIPTION
For this particular test, the invalid syntax is flagged at
the first open brace instead of previously at the beginning
of the line.