### PR TITLE
Bump platform requirement

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.4
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ import Foundation
 let package = Package(
   name: "swift-format",
   platforms: [
-    .macOS(.v10_11)
+    .macOS(.v10_13)
   ],
   products: [
     .executable(name: "swift-format", targets: ["swift-format"]),


### PR DESCRIPTION
Fixes #387.

The swift-tools-support-core dependency bumped its platform requirements, so swift-format should follow suit: https://github.com/apple/swift-tools-support-core/pull/329

Alternatively we could lock the dependency to an older version with more relaxed platform requirements.