### PR TITLE
Prepare for 0.50700.0 release.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -179,15 +179,15 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   package.dependencies += [
     .package(
       url: "https://github.com/apple/swift-argument-parser.git",
-      branch: "main"
+      .upToNextMinor(from: "1.1.4")
     ),
     .package(
       url: "https://github.com/apple/swift-syntax",
-      branch: "main"
+      branch: "swift-5.7-RELEASE"
     ),
     .package(
       url: "https://github.com/apple/swift-tools-support-core.git",
-      branch: "main"
+      .upToNextMinor(from: "0.2.7")
     ),
   ]
 } else {

--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1289,7 +1289,15 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       before(tokenToOpenWith.nextToken, tokens: .break(breakKindClose, newlines: .soft), .close)
     }
 
-    if let condition = node.condition {
+    if isNestedInPostfixIfConfig(node: Syntax(node)) {
+      before(
+        node.firstToken,
+        tokens: [
+          .printerControl(kind: .enableBreaking),
+          .break(.reset),
+        ]
+      )
+    } else if let condition = node.condition {
       before(condition.firstToken, tokens: .printerControl(kind: .disableBreaking))
       after(
         condition.lastToken,
@@ -3441,7 +3449,11 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
       if let calledMemberAccessExpr = calledExpression.as(MemberAccessExprSyntax.self) {
         if calledMemberAccessExpr.base != nil {
-          before(calledMemberAccessExpr.dot, tokens: [.break(.contextual, size: 0)])
+          if isNestedInPostfixIfConfig(node: Syntax(calledMemberAccessExpr)) {
+            before(calledMemberAccessExpr.dot, tokens: [.break(.same, size: 0)])
+          } else {
+            before(calledMemberAccessExpr.dot, tokens: [.break(.contextual, size: 0)])
+          }
         }
         before(calledMemberAccessExpr.dot, tokens: beforeTokens)
         after(expr.lastToken, tokens: afterTokens)
@@ -3464,6 +3476,20 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     let hasCompoundExpression = !expr.is(IdentifierExprSyntax.self)
     return (hasCompoundExpression, false)
   }
+}
+
+private func isNestedInPostfixIfConfig(node: Syntax) -> Bool {
+    var this: Syntax? = node
+
+    while this?.parent != nil {
+      if this?.parent?.is(PostfixIfConfigExprSyntax.self) == true {
+        return true
+      }
+
+      this = this?.parent
+    }
+
+    return false
 }
 
 extension Syntax {

--- a/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
+++ b/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
@@ -51,6 +51,13 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
   }
 
   public override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+    // Don't diagnose any issues when the variable is overriding, because this declaration can't
+    // rename the variable. If the user analyzes the code where the variable is really declared,
+    // then the diagnostic can be raised for just that location.
+    if let modifiers = node.modifiers, modifiers.has(modifier: "override") {
+      return .visitChildren
+    }
+
     for binding in node.bindings {
       guard let pat = binding.pattern.as(IdentifierPatternSyntax.self) else {
         continue
@@ -94,6 +101,13 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
   }
 
   public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+    // Don't diagnose any issues when the function is overriding, because this declaration can't
+    // rename the function. If the user analyzes the code where the function is really declared,
+    // then the diagnostic can be raised for just that location.
+    if let modifiers = node.modifiers, modifiers.has(modifier: "override") {
+      return .visitChildren
+    }
+
     // We allow underscores in test names, because there's an existing convention of using
     // underscores to separate phrases in very detailed test names.
     let allowUnderscores = testCaseFuncs.contains(node)

--- a/Sources/SwiftFormatRules/UseWhereClausesInForLoops.swift
+++ b/Sources/SwiftFormatRules/UseWhereClausesInForLoops.swift
@@ -41,7 +41,8 @@ public final class UseWhereClausesInForLoops: SyntaxFormatRule {
     //    with a single condition whose body is just `continue`.
     switch stmt.item.as(SyntaxEnum.self) {
     case .ifStmt(let ifStmt)
-    where ifStmt.conditions.count == 1 && node.body.statements.count == 1:
+    where ifStmt.conditions.count == 1 && ifStmt.elseKeyword == nil
+      && node.body.statements.count == 1:
       // Extract the condition of the IfStmt.
       let conditionElement = ifStmt.conditions.first!
       guard let condition = conditionElement.condition.as(ExprSyntax.self) else {

--- a/Sources/swift-format/Frontend/FormatFrontend.swift
+++ b/Sources/swift-format/Frontend/FormatFrontend.swift
@@ -49,8 +49,10 @@ class FormatFrontend: Frontend {
           to: &buffer,
           parsingDiagnosticHandler: diagnosticsEngine.consumeParserDiagnostic)
 
-        let bufferData = buffer.data(using: .utf8)!  // Conversion to UTF-8 cannot fail
-        try bufferData.write(to: url, options: .atomic)
+        if buffer != source {
+          let bufferData = buffer.data(using: .utf8)!  // Conversion to UTF-8 cannot fail
+          try bufferData.write(to: url, options: .atomic)
+        }
       } else {
         try formatter.format(
           source: source,

--- a/Sources/swift-format/VersionOptions.swift
+++ b/Sources/swift-format/VersionOptions.swift
@@ -20,7 +20,7 @@ struct VersionOptions: ParsableArguments {
   func validate() throws {
     if version {
       // TODO: Automate updates to this somehow.
-      print("0.50500.0")
+      print("0.50700.0")
       throw ExitCode.success
     }
   }

--- a/Tests/SwiftFormatPrettyPrintTests/IfConfigTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/IfConfigTests.swift
@@ -230,4 +230,164 @@ final class IfConfigTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
   }
+
+  func testPostfixPoundIfAfterParentheses() {
+    let input =
+      """
+      VStack {
+        Text("something")
+        #if os(iOS)
+        .iOSSpecificModifier()
+        #endif
+        .commonModifier()
+      }
+      """
+
+    let expected =
+      """
+      VStack {
+        Text("something")
+        #if os(iOS)
+          .iOSSpecificModifier()
+        #endif
+        .commonModifier()
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
+  }
+
+  func testPostfixPoundIfAfterParenthesesMultipleMembers() {
+    let input =
+      """
+      VStack {
+        Text("something")
+        #if os(iOS)
+        .iOSSpecificModifier()
+        .anotherModifier()
+        .anotherAnotherModifier()
+        #endif
+        .commonModifier()
+        .anotherCommonModifier()
+      }
+      """
+
+    let expected =
+      """
+      VStack {
+        Text("something")
+        #if os(iOS)
+          .iOSSpecificModifier()
+          .anotherModifier()
+          .anotherAnotherModifier()
+        #endif
+        .commonModifier()
+        .anotherCommonModifier()
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
+  }
+
+  func testPostfixPoundIfNested() {
+    let input =
+      """
+      VStack {
+        Text("something")
+        #if os(iOS) || os(watchOS)
+          #if os(iOS)
+          .iOSModifier()
+          #else
+          .watchOSModifier()
+          #endif
+        .iOSAndWatchOSModifier()
+        #endif
+      }
+      """
+
+    let expected =
+      """
+      VStack {
+        Text("something")
+        #if os(iOS) || os(watchOS)
+          #if os(iOS)
+            .iOSModifier()
+          #else
+            .watchOSModifier()
+          #endif
+          .iOSAndWatchOSModifier()
+        #endif
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
+  }
+
+
+  func testPostfixPoundIfAfterVariables() {
+    let input =
+      """
+      VStack {
+        textView
+        #if os(iOS)
+        .iOSSpecificModifier()
+        #endif
+        .commonModifier()
+      }
+      """
+
+    let expected =
+      """
+      VStack {
+        textView
+        #if os(iOS)
+          .iOSSpecificModifier()
+        #endif
+        .commonModifier()
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
+  }
+
+  func testPostfixPoundIfAfterClosingBrace() {
+    let input =
+      """
+      HStack {
+          Toggle(isOn: binding) {
+              Text("Some text")
+          }
+          #if !os(tvOS)
+          .toggleStyle(SwitchToggleStyle(tint: Color.blue))
+          #endif
+          .accessibilityValue(
+              binding.wrappedValue == true ? "On" : "Off"
+          )
+      }
+      """
+
+    let expected =
+      """
+      HStack {
+        Toggle(isOn: binding) {
+          Text("Some text")
+        }
+        #if !os(tvOS)
+          .toggleStyle(
+            SwitchToggleStyle(tint: Color.blue))
+        #endif
+        .accessibilityValue(
+          binding.wrappedValue == true
+            ? "On" : "Off"
+        )
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
+  }
 }

--- a/Tests/SwiftFormatRulesTests/AlwaysUseLowerCamelCaseTests.swift
+++ b/Tests/SwiftFormatRulesTests/AlwaysUseLowerCamelCaseTests.swift
@@ -123,4 +123,25 @@ final class AlwaysUseLowerCamelCaseTests: LintOrFormatRuleTestCase {
     XCTAssertNotDiagnosed(
       .nameMustBeLowerCamelCase("test_HappyPath_Through_GoodCode_Throws", description: "function"))
   }
+
+  func testIgnoresFunctionOverrides() {
+    let input =
+      """
+      class ParentClass {
+        var poorly_named_variable: Int = 5
+        func poorly_named_method() {}
+      }
+
+      class ChildClass: ParentClass {
+        override var poorly_named_variable: Int = 5
+        override func poorly_named_method() {}
+      }
+      """
+
+    performLint(AlwaysUseLowerCamelCase.self, input: input)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("poorly_named_variable", description: "variable"), line: 2, column: 7)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("poorly_named_method", description: "function"), line: 3, column: 8)
+  }
 }

--- a/Tests/SwiftFormatRulesTests/UseWhereClausesInForLoopsTests.swift
+++ b/Tests/SwiftFormatRulesTests/UseWhereClausesInForLoopsTests.swift
@@ -14,6 +14,22 @@ final class UseWhereClausesInForLoopsTests: LintOrFormatRuleTestCase {
              for i in [0, 1, 2, 3] {
                if i > 30 {
                  print(i)
+               } else {
+                 print(i)
+               }
+             }
+
+             for i in [0, 1, 2, 3] {
+               if i > 30 {
+                 print(i)
+               } else if i > 40 {
+                 print(i)
+               }
+             }
+
+             for i in [0, 1, 2, 3] {
+               if i > 30 {
+                 print(i)
                }
                print(i)
              }
@@ -34,6 +50,22 @@ final class UseWhereClausesInForLoopsTests: LintOrFormatRuleTestCase {
       expected: """
                 for i in [0, 1, 2, 3] where i > 30 {
                     print(i)
+                }
+
+                for i in [0, 1, 2, 3] {
+                  if i > 30 {
+                    print(i)
+                  } else {
+                    print(i)
+                  }
+                }
+
+                for i in [0, 1, 2, 3] {
+                  if i > 30 {
+                    print(i)
+                  } else if i > 40 {
+                    print(i)
+                  }
                 }
 
                 for i in [0, 1, 2, 3] {

--- a/Tests/SwiftFormatTests/SyntaxValidatingVisitorTests.swift
+++ b/Tests/SwiftFormatTests/SyntaxValidatingVisitorTests.swift
@@ -28,7 +28,7 @@ final class SyntaxValidatingVisitorTests: XCTestCase {
         var bar = 0
       }
       """
-    assertInvalidSyntax(in: input, atLine: 1, column: 1)
+    assertInvalidSyntax(in: input, atLine: 1, column: 7)
 
     input =
       """


### PR DESCRIPTION
This PR cherry-picks recent changes that are compatible with Swift 5.7 and updates the package manifest to point to the `swift-5.7-RELEASE` tag of swift-syntax. I will push another change later to update that to the 0.50700.0 semver tag once it is published in that repository.

Because the tag above doesn't have a binary distribution of the parser library, any `swift build/test` commands must have the `SWIFT_SYNTAX_PARSER_LIB_SEARCH_PATH` environment variable set; for example, `SWIFT_SYNTAX_PARSER_LIB_SEARCH_PATH=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx swift build`. This should no longer be necessary when the official 0.50700.0 swift-syntax release is created.