### PR TITLE
Support designated types for operator declarations.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1375,10 +1375,14 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: OperatorPrecedenceAndTypesSyntax) -> SyntaxVisitorContinueKind {
-    // Despite being an `IdentifierListSyntax`, the language grammar currently only allows a single
-    // precedence group here, so we don't worry about breaks at any interior commas.
-    after(node.colon, tokens: .break(.open))
-    after(node.lastToken, tokens: .break(.close, size: 0))
+    before(node.colon, tokens: .space)
+    after(node.colon, tokens: .break(.open), .open)
+    after(node.designatedTypes.lastToken ?? node.lastToken, tokens: .break(.close, size: 0), .close)
+    return .visitChildren
+  }
+
+  override func visit(_ node: DesignatedTypeElementSyntax) -> SyntaxVisitorContinueKind {
+    after(node.leadingComma, tokens: .break(.same))
     return .visitChildren
   }
 

--- a/Tests/SwiftFormatPrettyPrintTests/OperatorDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/OperatorDeclTests.swift
@@ -15,7 +15,7 @@ final class OperatorDeclTests: PrettyPrintTestCase {
       prefix operator ^*^
       postfix operator !**!
       infix operator *%*
-      infix operator *%*:
+      infix operator *%* :
         PrecedenceGroup
 
       """
@@ -35,7 +35,7 @@ final class OperatorDeclTests: PrettyPrintTestCase {
         *%*
       infix
         operator
-        *%*:
+        *%* :
           PrecedenceGroup
 
       """
@@ -78,6 +78,37 @@ final class OperatorDeclTests: PrettyPrintTestCase {
         assignment:
           false
       }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expectedShorter, linelength: 10)
+  }
+
+  func testDesignatedTypes() {
+    let input =
+      """
+      infix operator *%*: PrecedenceGroup, Bool, Int, String
+      """
+
+    let expected =
+      """
+      infix operator *%* :
+        PrecedenceGroup, Bool,
+        Int, String
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 25)
+
+    let expectedShorter =
+      """
+      infix
+        operator
+        *%* :
+          PrecedenceGroup,
+          Bool,
+          Int,
+          String
 
       """
 


### PR DESCRIPTION
Also, add a space between the operator and the colon; it should have always been there, for consistency with `func #OP# (...)`.

Fixes #311.