### PR TITLE
Ensure there is a break between closure attributes and a capture list.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1103,7 +1103,8 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   override func visit(_ node: ClosureSignatureSyntax) -> SyntaxVisitorContinueKind {
     before(node.firstToken, tokens: .open)
 
-    arrangeAttributeList(node.attributes, suppressFinalBreak: node.input == nil)
+    arrangeAttributeList(
+      node.attributes, suppressFinalBreak: node.input == nil && node.capture == nil)
 
     if let input = node.input {
       // We unconditionally put a break before the `in` keyword below, so we should only put a break

--- a/Tests/SwiftFormatPrettyPrintTests/ClosureExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ClosureExprTests.swift
@@ -492,6 +492,7 @@ final class ClosureExprTests: PrettyPrintTestCase {
       let b = { @MainActor in print("hello world") }
       let c = { @MainActor param in print("hi") }
       let d = { @MainActor (a: Int) async -> Int in print("hi") }
+      let e = { @MainActor [weak self] in print("hi") }
       """
 
     let expected =
@@ -505,6 +506,9 @@ final class ClosureExprTests: PrettyPrintTestCase {
       }
       let d = {
         @MainActor (a: Int) async -> Int in
+        print("hi")
+      }
+      let e = { @MainActor [weak self] in
         print("hi")
       }
 


### PR DESCRIPTION
Fixes #404.