### PR TITLE
[5.7] Require at least swift-syntax 0.50700.1.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -183,7 +183,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     ),
     .package(
       url: "https://github.com/apple/swift-syntax",
-      .upToNextMinor(from: "0.50700.0")
+      .upToNextMinor(from: "0.50700.1")
     ),
     .package(
       url: "https://github.com/apple/swift-tools-support-core.git",

--- a/Sources/swift-format/VersionOptions.swift
+++ b/Sources/swift-format/VersionOptions.swift
@@ -20,7 +20,7 @@ struct VersionOptions: ParsableArguments {
   func validate() throws {
     if version {
       // TODO: Automate updates to this somehow.
-      print("0.50700.0")
+      print("0.50700.1")
       throw ExitCode.success
     }
   }


### PR DESCRIPTION
That release contains fixes for new `if let` shorthand.