### PR TITLE
Improve `XCTest` import detection logic.

### DIFF
--- a/Tests/SwiftFormatRulesTests/AlwaysUseLowerCamelCaseTests.swift
+++ b/Tests/SwiftFormatRulesTests/AlwaysUseLowerCamelCaseTests.swift
@@ -124,6 +124,54 @@ final class AlwaysUseLowerCamelCaseTests: LintOrFormatRuleTestCase {
       .nameMustBeLowerCamelCase("test_HappyPath_Through_GoodCode_Throws", description: "function"))
   }
 
+  func testIgnoresUnderscoresInTestNamesWhenImportedConditionally() {
+    let input =
+      """
+      #if SOME_FEATURE_FLAG
+        import XCTest
+
+        let Test = 1
+        class UnitTests: XCTestCase {
+          static let My_Constant_Value = 0
+          func test_HappyPath_Through_GoodCode() {}
+          private func FooFunc() {}
+          private func helperFunc_For_HappyPath_Setup() {}
+          private func testLikeMethod_With_Underscores(_ arg1: ParamType) {}
+          private func testLikeMethod_With_Underscores2() -> ReturnType {}
+          func test_HappyPath_Through_GoodCode_ReturnsVoid() -> Void {}
+          func test_HappyPath_Through_GoodCode_ReturnsShortVoid() -> () {}
+          func test_HappyPath_Through_GoodCode_Throws() throws {}
+        }
+      #endif
+      """
+    performLint(AlwaysUseLowerCamelCase.self, input: input)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("Test", description: "constant"), line: 4, column: 7)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("My_Constant_Value", description: "constant"), line: 6, column: 16)
+    XCTAssertNotDiagnosed(
+      .nameMustBeLowerCamelCase("test_HappyPath_Through_GoodCode", description: "function"))
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("FooFunc", description: "function"), line: 8, column: 18)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("helperFunc_For_HappyPath_Setup", description: "function"),
+      line: 9, column: 18)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("testLikeMethod_With_Underscores", description: "function"),
+      line: 10, column: 18)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("testLikeMethod_With_Underscores2", description: "function"),
+      line: 11, column: 18)
+    XCTAssertNotDiagnosed(
+      .nameMustBeLowerCamelCase(
+        "test_HappyPath_Through_GoodCode_ReturnsVoid", description: "function"))
+    XCTAssertNotDiagnosed(
+      .nameMustBeLowerCamelCase(
+        "test_HappyPath_Through_GoodCode_ReturnsShortVoid", description: "function"))
+    XCTAssertNotDiagnosed(
+      .nameMustBeLowerCamelCase("test_HappyPath_Through_GoodCode_Throws", description: "function"))
+  }
+
   func testIgnoresFunctionOverrides() {
     let input =
       """

--- a/Tests/SwiftFormatRulesTests/ImportsXCTestVisitorTests.swift
+++ b/Tests/SwiftFormatRulesTests/ImportsXCTestVisitorTests.swift
@@ -1,0 +1,57 @@
+import SwiftFormatCore
+import SwiftFormatRules
+import SwiftFormatTestSupport
+import SwiftParser
+import XCTest
+
+class ImportsXCTestVisitorTests: DiagnosingTestCase {
+  func testDoesNotImportXCTest() throws {
+    XCTAssertEqual(
+      try makeContextAndSetImportsXCTest(source: """
+        import Foundation
+        """),
+      .doesNotImportXCTest
+    )
+  }
+
+  func testImportsXCTest() throws {
+    XCTAssertEqual(
+      try makeContextAndSetImportsXCTest(source: """
+        import Foundation
+        import XCTest
+        """),
+      .importsXCTest
+    )
+  }
+
+  func testImportsSpecificXCTestDecl() throws {
+    XCTAssertEqual(
+      try makeContextAndSetImportsXCTest(source: """
+        import Foundation
+        import class XCTest.XCTestCase
+        """),
+      .importsXCTest
+    )
+  }
+
+  func testImportsXCTestInsideConditional() throws {
+    XCTAssertEqual(
+      try makeContextAndSetImportsXCTest(source: """
+        import Foundation
+        #if SOME_FEATURE_FLAG
+          import XCTest
+        #endif
+        """),
+      .importsXCTest
+    )
+  }
+
+  /// Parses the given source, makes a new `Context`, then populates and returns its `XCTest`
+  /// import state.
+  private func makeContextAndSetImportsXCTest(source: String) throws -> Context.XCTestImportState {
+    let sourceFile = try Parser.parse(source: source)
+    let context = makeContext(sourceFileSyntax: sourceFile)
+    setImportsXCTest(context: context, sourceFile: sourceFile)
+    return context.importsXCTest
+  }
+}


### PR DESCRIPTION
Specifically, this will now find imports of specific decls (e.g., `import class XCTest.XCTestCase`) and imports inside `#if` blocks.

Also add some tests specifically for this logic, instead of testing it only in the context of other rules.

Fixes #403.