### PR TITLE
Correctly identify XCTest-like methods in `#if` blocks.

### DIFF
--- a/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
+++ b/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
@@ -29,20 +29,9 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
   }
 
   public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-    // Check if this class is an `XCTestCase`, otherwise it cannot contain any test cases.
     guard context.importsXCTest == .importsXCTest else { return .visitChildren }
 
-    // Identify and store all of the function decls that are test cases.
-    let testCases = node.members.members.compactMap {
-      $0.decl.as(FunctionDeclSyntax.self)
-    }.filter {
-      // Filter out non-test methods using the same heuristics as XCTest to identify tests.
-      // Test methods are methods that start with "test", have no arguments, and void return type.
-      $0.identifier.text.starts(with: "test")
-        && $0.signature.input.parameterList.isEmpty
-        && $0.signature.output.map { $0.isVoid } ?? true
-    }
-    testCaseFuncs.formUnion(testCases)
+    collectTestMethods(from: node.members.members, into: &testCaseFuncs)
     return .visitChildren
   }
 
@@ -133,6 +122,33 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
     diagnoseLowerCamelCaseViolations(
       node.identifier, allowUnderscores: false, description: identifierDescription(for: node))
     return .skipChildren
+  }
+
+  /// Collects methods that look like XCTest test case methods from the given member list, inserting
+  /// them into the given set.
+  private func collectTestMethods(
+    from members: MemberDeclListSyntax,
+    into set: inout Set<FunctionDeclSyntax>
+  ) {
+    for member in members {
+      if let ifConfigDecl = member.decl.as(IfConfigDeclSyntax.self) {
+        // Recurse into any conditional member lists and collect their test methods as well.
+        for clause in ifConfigDecl.clauses {
+          if let clauseMembers = clause.elements.as(MemberDeclListSyntax.self) {
+            collectTestMethods(from: clauseMembers, into: &set)
+          }
+        }
+      } else if let functionDecl = member.decl.as(FunctionDeclSyntax.self) {
+        // Identify test methods using the same heuristics as XCTest: name starts with "test", has
+        // no arguments, and returns a void type.
+        if functionDecl.identifier.text.starts(with: "test")
+          && functionDecl.signature.input.parameterList.isEmpty
+          && (functionDecl.signature.output.map(\.isVoid) ?? true)
+        {
+          set.insert(functionDecl)
+        }
+      }
+    }
   }
 
   private func diagnoseLowerCamelCaseViolations(

--- a/Tests/SwiftFormatRulesTests/AlwaysUseLowerCamelCaseTests.swift
+++ b/Tests/SwiftFormatRulesTests/AlwaysUseLowerCamelCaseTests.swift
@@ -172,6 +172,72 @@ final class AlwaysUseLowerCamelCaseTests: LintOrFormatRuleTestCase {
       .nameMustBeLowerCamelCase("test_HappyPath_Through_GoodCode_Throws", description: "function"))
   }
 
+  func testIgnoresUnderscoresInConditionalTestNames() {
+    let input =
+      """
+      import XCTest
+
+      let Test = 1
+      class UnitTests: XCTestCase {
+        #if SOME_FEATURE_FLAG
+          static let My_Constant_Value = 0
+          func test_HappyPath_Through_GoodCode() {}
+          private func FooFunc() {}
+          private func helperFunc_For_HappyPath_Setup() {}
+          private func testLikeMethod_With_Underscores(_ arg1: ParamType) {}
+          private func testLikeMethod_With_Underscores2() -> ReturnType {}
+          func test_HappyPath_Through_GoodCode_ReturnsVoid() -> Void {}
+          func test_HappyPath_Through_GoodCode_ReturnsShortVoid() -> () {}
+          func test_HappyPath_Through_GoodCode_Throws() throws {}
+        #else
+          func testBadMethod_HasNonVoidReturn() -> ReturnType {}
+          func testGoodMethod_HasVoidReturn() {}
+          #if SOME_OTHER_FEATURE_FLAG
+            func testBadMethod_HasNonVoidReturn2() -> ReturnType {}
+            func testGoodMethod_HasVoidReturn2() {}
+          #endif
+        #endif
+      }
+      #endif
+      """
+    performLint(AlwaysUseLowerCamelCase.self, input: input)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("Test", description: "constant"), line: 3, column: 5)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("My_Constant_Value", description: "constant"), line: 6, column: 16)
+    XCTAssertNotDiagnosed(
+      .nameMustBeLowerCamelCase("test_HappyPath_Through_GoodCode", description: "function"))
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("FooFunc", description: "function"), line: 8, column: 18)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("helperFunc_For_HappyPath_Setup", description: "function"),
+      line: 9, column: 18)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("testLikeMethod_With_Underscores", description: "function"),
+      line: 10, column: 18)
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("testLikeMethod_With_Underscores2", description: "function"),
+      line: 11, column: 18)
+    XCTAssertNotDiagnosed(
+      .nameMustBeLowerCamelCase(
+        "test_HappyPath_Through_GoodCode_ReturnsVoid", description: "function"))
+    XCTAssertNotDiagnosed(
+      .nameMustBeLowerCamelCase(
+        "test_HappyPath_Through_GoodCode_ReturnsShortVoid", description: "function"))
+    XCTAssertNotDiagnosed(
+      .nameMustBeLowerCamelCase("test_HappyPath_Through_GoodCode_Throws", description: "function"))
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("testBadMethod_HasNonVoidReturn", description: "function"),
+      line: 16, column: 10)
+    XCTAssertNotDiagnosed(
+      .nameMustBeLowerCamelCase("testGoodMethod_HasVoidReturn", description: "function"))
+    XCTAssertDiagnosed(
+      .nameMustBeLowerCamelCase("testBadMethod_HasNonVoidReturn2", description: "function"),
+      line: 19, column: 12)
+    XCTAssertNotDiagnosed(
+      .nameMustBeLowerCamelCase("testGoodMethod_HasVoidReturn2", description: "function"))
+  }
+
   func testIgnoresFunctionOverrides() {
     let input =
       """


### PR DESCRIPTION
The original implementation was only looking for direct members of a `ClassDecl` that were of type `FunctionDecl`, which excluded indirect children nested inside `IfConfigDecl`s.