### PR TITLE
Pass `SwiftFormatRules` sources as inputs to `generate-pipeline-plugin`.

### DIFF
--- a/Plugins/generate-pipeline-plugin/GeneratePipelinePlugin.swift
+++ b/Plugins/generate-pipeline-plugin/GeneratePipelinePlugin.swift
@@ -49,6 +49,10 @@ struct GeneratePipelinePlugin: BuildToolPlugin {
       .appending("GeneratedSources")
       .appending(generatedSourceName)
 
+    let rulesSources =
+      (try context.package.targets(named: ["SwiftFormatRules"]).first as? SwiftSourceModuleTarget)?
+      .sourceFiles.map(\.path) ?? []
+
     return [
       .buildCommand(
         displayName: "Generating \(generatedSourceName) for \(target.name)",
@@ -61,6 +65,7 @@ struct GeneratePipelinePlugin: BuildToolPlugin {
           "--target",
           target.name,
         ],
+        inputFiles: rulesSources,
         outputFiles: [outputFile]
       )
     ]


### PR DESCRIPTION
This will cause the plug-in to only rerun when the rules files change (without this, it was rerunning on every build).