### PR TITLE
Fix parallel mode on larger projects

### DIFF
--- a/Sources/swift-format/Frontend/Frontend.swift
+++ b/Sources/swift-format/Frontend/Frontend.swift
@@ -131,9 +131,11 @@ class Frontend {
       "processURLs(_:) should only be called when 'urls' is non-empty.")
 
     if parallel {
-      let filesToProcess = FileIterator(urls: urls).compactMap(openAndPrepareFile)
+      let filesToProcess = Array(FileIterator(urls: urls))
       DispatchQueue.concurrentPerform(iterations: filesToProcess.count) { index in
-        processFile(filesToProcess[index])
+        if let file = openAndPrepareFile(at: filesToProcess[index]) {
+          processFile(file)
+        }
       }
     } else {
       FileIterator(urls: urls).lazy.compactMap(openAndPrepareFile).forEach(processFile)


### PR DESCRIPTION
Since the parallel mode requires the count of the files that it's going
to process, the application of `openAndPrepareFile` was not lazy, this
meant that swift-format immediately opened all the files in the project,
which because of macOS's low open file limit quickly results in "too
many open files". This changes the logic to only open the file as
needed instead. This shouldn't be any different from before as far as
file discovery, since we were already resolving everything to fetch the
count.
