### PR TITLE
Remove `try` before `Parser.parse` calls.

### DIFF
--- a/Sources/SwiftFormat/Parsing.swift
+++ b/Sources/SwiftFormat/Parsing.swift
@@ -38,7 +38,7 @@ func parseAndEmitDiagnostics(
   parsingDiagnosticHandler: ((Diagnostic, SourceLocation) -> Void)? = nil
 ) throws -> SourceFileSyntax {
   let sourceFile =
-    try operatorTable.foldAll(Parser.parse(source: source)) { _ in }.as(SourceFileSyntax.self)!
+    operatorTable.foldAll(Parser.parse(source: source)) { _ in }.as(SourceFileSyntax.self)!
 
   let diagnostics = ParseDiagnosticsGenerator.diagnostics(for: sourceFile)
   if let parsingDiagnosticHandler = parsingDiagnosticHandler {

--- a/Sources/generate-pipeline/RuleCollector.swift
+++ b/Sources/generate-pipeline/RuleCollector.swift
@@ -58,7 +58,7 @@ final class RuleCollector {
 
       let fileURL = url.appendingPathComponent(baseName)
       let fileInput = try String(contentsOf: fileURL)
-      let sourceFile = try Parser.parse(source: fileInput)
+      let sourceFile = Parser.parse(source: fileInput)
 
       for statement in sourceFile.statements {
         guard let detectedRule = self.detectedRule(at: statement) else { continue }

--- a/Tests/SwiftFormatCoreTests/RuleMaskTests.swift
+++ b/Tests/SwiftFormatCoreTests/RuleMaskTests.swift
@@ -12,7 +12,7 @@ final class RuleMaskTests: XCTestCase {
   private func createMask(sourceText: String) -> RuleMask {
     let fileURL = URL(fileURLWithPath: "/tmp/test.swift")
     converter = SourceLocationConverter(file: fileURL.path, source: sourceText)
-    let syntax = try! Parser.parse(source: sourceText)
+    let syntax = Parser.parse(source: sourceText)
     return RuleMask(syntaxNode: Syntax(syntax), sourceLocationConverter: converter)
   }
 

--- a/Tests/SwiftFormatPerformanceTests/WhitespaceLinterPerformanceTests.swift
+++ b/Tests/SwiftFormatPerformanceTests/WhitespaceLinterPerformanceTests.swift
@@ -56,14 +56,7 @@ final class WhitespaceLinterPerformanceTests: DiagnosingTestCase {
   ///   - input: The user's input text.
   ///   - expected: The formatted text.
   private func performWhitespaceLint(input: String, expected: String) {
-    let sourceFileSyntax: SourceFileSyntax
-    do {
-      sourceFileSyntax = try Parser.parse(source: input)
-    } catch {
-      XCTFail("Parsing failed with error: \(error)")
-      return
-    }
-
+    let sourceFileSyntax = Parser.parse(source: input)
     let context = makeContext(sourceFileSyntax: sourceFileSyntax)
     let linter = WhitespaceLinter(user: input, formatted: expected, context: context)
     linter.lint()

--- a/Tests/SwiftFormatPrettyPrintTests/PrettyPrintTestCase.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/PrettyPrintTestCase.swift
@@ -65,18 +65,10 @@ class PrettyPrintTestCase: DiagnosingTestCase {
   private func prettyPrintedSource(
     _ source: String, configuration: Configuration, whitespaceOnly: Bool
   ) -> String? {
-    let sourceFileSyntax: SourceFileSyntax
-    do {
-      // Ignore folding errors for unrecognized operators so that we fallback to a reasonable
-      // default instead of throwing an error.
-      sourceFileSyntax =
-        try OperatorTable.standardOperators.foldAll(Parser.parse(source: source)) { _ in }
-          .as(SourceFileSyntax.self)!
-    } catch {
-      XCTFail("Parsing failed with error: \(error)")
-      return nil
-    }
-
+    // Ignore folding errors for unrecognized operators so that we fallback to a reasonable default.
+    let sourceFileSyntax =
+      OperatorTable.standardOperators.foldAll(Parser.parse(source: source)) { _ in }
+        .as(SourceFileSyntax.self)!
     let context = makeContext(sourceFileSyntax: sourceFileSyntax, configuration: configuration)
     let printer = PrettyPrinter(
       context: context,

--- a/Tests/SwiftFormatRulesTests/ImportsXCTestVisitorTests.swift
+++ b/Tests/SwiftFormatRulesTests/ImportsXCTestVisitorTests.swift
@@ -49,7 +49,7 @@ class ImportsXCTestVisitorTests: DiagnosingTestCase {
   /// Parses the given source, makes a new `Context`, then populates and returns its `XCTest`
   /// import state.
   private func makeContextAndSetImportsXCTest(source: String) throws -> Context.XCTestImportState {
-    let sourceFile = try Parser.parse(source: source)
+    let sourceFile = Parser.parse(source: source)
     let context = makeContext(sourceFileSyntax: sourceFile)
     setImportsXCTest(context: context, sourceFile: sourceFile)
     return context.importsXCTest

--- a/Tests/SwiftFormatRulesTests/LintOrFormatRuleTestCase.swift
+++ b/Tests/SwiftFormatRulesTests/LintOrFormatRuleTestCase.swift
@@ -19,13 +19,7 @@ class LintOrFormatRuleTestCase: DiagnosingTestCase {
     file: StaticString = #file,
     line: UInt = #line
   ) {
-    let sourceFileSyntax: SourceFileSyntax
-    do {
-      sourceFileSyntax = try Parser.parse(source: input)
-    } catch {
-      XCTFail("\(error)", file: file, line: line)
-      return
-    }
+    let sourceFileSyntax = Parser.parse(source: input)
 
     // Force the rule to be enabled while we test it.
     var configuration = Configuration()
@@ -62,13 +56,7 @@ class LintOrFormatRuleTestCase: DiagnosingTestCase {
     file: StaticString = #file,
     line: UInt = #line
   ) {
-    let sourceFileSyntax: SourceFileSyntax
-    do {
-      sourceFileSyntax = try Parser.parse(source: input)
-    } catch {
-      XCTFail("\(error)", file: file, line: line)
-      return
-    }
+    let sourceFileSyntax = Parser.parse(source: input)
 
     // Force the rule to be enabled while we test it.
     var configuration = configuration ?? Configuration()

--- a/Tests/SwiftFormatWhitespaceLinterTests/WhitespaceTestCase.swift
+++ b/Tests/SwiftFormatWhitespaceLinterTests/WhitespaceTestCase.swift
@@ -20,14 +20,7 @@ class WhitespaceTestCase: DiagnosingTestCase {
   ///   - expected: The formatted text.
   ///   - linelength: The maximum allowed line length of the output.
   final func performWhitespaceLint(input: String, expected: String, linelength: Int? = nil) {
-    let sourceFileSyntax: SourceFileSyntax
-    do {
-      sourceFileSyntax = try Parser.parse(source: input)
-    } catch {
-      XCTFail("Parsing failed with error: \(error)")
-      return
-    }
-
+    let sourceFileSyntax = Parser.parse(source: input)
     var configuration = Configuration()
     if let linelength = linelength {
       configuration.lineLength = linelength


### PR DESCRIPTION
As of https://github.com/apple/swift-syntax/pull/912, this call no longer throws.