### PR TITLE
Update based on recent changes to swift-syntax main branch.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1229,8 +1229,20 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: ObjectLiteralExprSyntax) -> SyntaxVisitorContinueKind {
+    // TODO: Remove this; it has been subsumed by `MacroExpansionDeclSyntax`. But that feature is
+    // still in flux and this node type is still present in the API, even though nothing in the
+    // parser currently creates it.
     arrangeFunctionCallArgumentList(
       node.arguments,
+      leftDelimiter: node.leftParen,
+      rightDelimiter: node.rightParen,
+      forcesBreakBeforeRightDelimiter: false)
+    return .visitChildren
+  }
+
+  override func visit(_ node: MacroExpansionDeclSyntax) -> SyntaxVisitorContinueKind {
+    arrangeFunctionCallArgumentList(
+      node.argumentList,
       leftDelimiter: node.leftParen,
       rightDelimiter: node.rightParen,
       forcesBreakBeforeRightDelimiter: false)
@@ -1307,7 +1319,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     // Unlike other code blocks, where we may want a single statement to be laid out on the same
     // line as a parent construct, the content of an `#if` block must always be on its own line;
     // the newline token inserted at the end enforces this.
-    if let lastElemTok = node.elements.lastToken {
+    if let lastElemTok = node.elements?.lastToken {
       after(lastElemTok, tokens: .break(breakKindClose, newlines: .soft), .close)
     } else {
       before(tokenToOpenWith.nextToken(viewMode: .all), tokens: .break(breakKindClose, newlines: .soft), .close)

--- a/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
+++ b/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
@@ -134,7 +134,7 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
       if let ifConfigDecl = member.decl.as(IfConfigDeclSyntax.self) {
         // Recurse into any conditional member lists and collect their test methods as well.
         for clause in ifConfigDecl.clauses {
-          if let clauseMembers = clause.elements.as(MemberDeclListSyntax.self) {
+          if let clauseMembers = clause.elements?.as(MemberDeclListSyntax.self) {
             collectTestMethods(from: clauseMembers, into: &set)
           }
         }

--- a/Sources/SwiftFormatRules/FileScopedDeclarationPrivacy.swift
+++ b/Sources/SwiftFormatRules/FileScopedDeclarationPrivacy.swift
@@ -109,8 +109,8 @@ public final class FileScopedDeclarationPrivacy: SyntaxFormatRule {
   /// - Returns: A new `IfConfigDeclSyntax` that has possibly been rewritten.
   private func rewrittenIfConfigDecl(_ ifConfigDecl: IfConfigDeclSyntax) -> IfConfigDeclSyntax {
     let newClauses = ifConfigDecl.clauses.map { clause -> IfConfigClauseSyntax in
-      switch clause.elements.as(SyntaxEnum.self) {
-      case .codeBlockItemList(let codeBlockItemList):
+      switch clause.elements?.as(SyntaxEnum.self) {
+      case .codeBlockItemList(let codeBlockItemList)?:
         return clause.withElements(Syntax(rewrittenCodeBlockItems(codeBlockItemList)))
       default:
         return clause


### PR DESCRIPTION
This gets swift-format building/tests passing again after the following changes:

https://github.com/apple/swift-syntax/pull/963 (Allow postfix #if to be empty)
https://github.com/apple/swift-syntax/pull/969 (Syntactic macro system)