### PR TITLE
Workaround new trivia behavior in SwiftSyntax.

### DIFF
--- a/Sources/SwiftFormat/Parsing.swift
+++ b/Sources/SwiftFormat/Parsing.swift
@@ -12,6 +12,7 @@
 
 import Foundation
 import SwiftDiagnostics
+import SwiftFormatCore
 import SwiftOperators
 import SwiftParser
 import SwiftSyntax
@@ -54,5 +55,5 @@ func parseAndEmitDiagnostics(
     throw SwiftFormatError.fileContainsInvalidSyntax
   }
 
-  return sourceFile
+  return restoringLegacyTriviaBehavior(sourceFile)
 }

--- a/Sources/SwiftFormatCore/LegacyTriviaBehavior.swift
+++ b/Sources/SwiftFormatCore/LegacyTriviaBehavior.swift
@@ -1,0 +1,44 @@
+import SwiftSyntax
+
+/// Rewrites the trivia on tokens in the given source file to restore the legacy trivia behavior
+/// before https://github.com/apple/swift-syntax/pull/985 was merged.
+///
+/// Eventually we should get rid of this and update the core formatting code to adjust to the new
+/// behavior, but this workaround lets us keep the current implementation without larger changes.
+public func restoringLegacyTriviaBehavior(_ sourceFile: SourceFileSyntax) -> SourceFileSyntax {
+  return LegacyTriviaBehaviorRewriter().visit(sourceFile).as(SourceFileSyntax.self)!
+}
+
+private final class LegacyTriviaBehaviorRewriter: SyntaxRewriter {
+  /// Trivia that was extracted from the trailing trivia of a token to be prepended to the leading
+  /// trivia of the next token.
+  private var pendingLeadingTrivia: Trivia?
+
+  override func visit(_ token: TokenSyntax) -> TokenSyntax {
+    var token = token
+    if let pendingLeadingTrivia = pendingLeadingTrivia {
+      token = token.withLeadingTrivia(pendingLeadingTrivia + token.leadingTrivia)
+      self.pendingLeadingTrivia = nil
+    }
+    if token.nextToken != nil,
+      let firstIndexToMove = token.trailingTrivia.firstIndex(where: shouldTriviaPieceBeMoved)
+    {
+      pendingLeadingTrivia = Trivia(pieces: Array(token.trailingTrivia[firstIndexToMove...]))
+      token =
+        token.withTrailingTrivia(Trivia(pieces: Array(token.trailingTrivia[..<firstIndexToMove])))
+    }
+    return token
+  }
+}
+
+/// Returns a value indicating whether the given trivia piece should be moved from a token's
+/// trailing trivia to the leading trivia of the following token to restore the legacy trivia
+/// behavior.
+private func shouldTriviaPieceBeMoved(_ piece: TriviaPiece) -> Bool {
+  switch piece {
+  case .spaces, .tabs, .unexpectedText:
+    return false
+  default:
+    return true
+  }
+}

--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1249,6 +1249,15 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     return .visitChildren
   }
 
+  override func visit(_ node: MacroExpansionExprSyntax) -> SyntaxVisitorContinueKind {
+    arrangeFunctionCallArgumentList(
+      node.argumentList,
+      leftDelimiter: node.leftParen,
+      rightDelimiter: node.rightParen,
+      forcesBreakBeforeRightDelimiter: false)
+    return .visitChildren
+  }
+
   override func visit(_ node: ParameterClauseSyntax) -> SyntaxVisitorContinueKind {
     // Prioritize keeping ") throws -> <return_type>" together. We can only do this if the function
     // has arguments.
@@ -3595,11 +3604,11 @@ class CommentMovingRewriter: SyntaxRewriter {
     return super.visit(node)
   }
 
-  override func visit(_ token: TokenSyntax) -> Syntax {
+  override func visit(_ token: TokenSyntax) -> TokenSyntax {
     if let rewrittenTrivia = rewriteTokenTriviaMap[token] {
-      return Syntax(token.withLeadingTrivia(rewrittenTrivia))
+      return token.withLeadingTrivia(rewrittenTrivia)
     }
-    return Syntax(token)
+    return token
   }
 
   override func visit(_ node: InfixOperatorExprSyntax) -> ExprSyntax {

--- a/Sources/SwiftFormatRules/ReplaceTrivia.swift
+++ b/Sources/SwiftFormatRules/ReplaceTrivia.swift
@@ -26,11 +26,11 @@ fileprivate final class ReplaceTrivia: SyntaxRewriter {
     self.trailingTrivia = trailingTrivia
   }
 
-  override func visit(_ token: TokenSyntax) -> Syntax {
-    guard token == self.token else { return Syntax(token) }
-    let newNode = token.withLeadingTrivia(leadingTrivia ?? token.leadingTrivia)
+  override func visit(_ token: TokenSyntax) -> TokenSyntax {
+    guard token == self.token else { return token }
+    return token
+      .withLeadingTrivia(leadingTrivia ?? token.leadingTrivia)
       .withTrailingTrivia(trailingTrivia ?? token.trailingTrivia)
-    return Syntax(newNode)
   }
 }
 

--- a/Tests/SwiftFormatPrettyPrintTests/PrettyPrintTestCase.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/PrettyPrintTestCase.swift
@@ -67,8 +67,9 @@ class PrettyPrintTestCase: DiagnosingTestCase {
   ) -> String? {
     // Ignore folding errors for unrecognized operators so that we fallback to a reasonable default.
     let sourceFileSyntax =
-      OperatorTable.standardOperators.foldAll(Parser.parse(source: source)) { _ in }
-        .as(SourceFileSyntax.self)!
+      restoringLegacyTriviaBehavior(
+        OperatorTable.standardOperators.foldAll(Parser.parse(source: source)) { _ in }
+          .as(SourceFileSyntax.self)!)
     let context = makeContext(sourceFileSyntax: sourceFileSyntax, configuration: configuration)
     let printer = PrettyPrinter(
       context: context,

--- a/Tests/SwiftFormatRulesTests/LintOrFormatRuleTestCase.swift
+++ b/Tests/SwiftFormatRulesTests/LintOrFormatRuleTestCase.swift
@@ -19,7 +19,7 @@ class LintOrFormatRuleTestCase: DiagnosingTestCase {
     file: StaticString = #file,
     line: UInt = #line
   ) {
-    let sourceFileSyntax = Parser.parse(source: input)
+    let sourceFileSyntax = restoringLegacyTriviaBehavior(Parser.parse(source: input))
 
     // Force the rule to be enabled while we test it.
     var configuration = Configuration()
@@ -56,7 +56,7 @@ class LintOrFormatRuleTestCase: DiagnosingTestCase {
     file: StaticString = #file,
     line: UInt = #line
   ) {
-    let sourceFileSyntax = Parser.parse(source: input)
+    let sourceFileSyntax = restoringLegacyTriviaBehavior(Parser.parse(source: input))
 
     // Force the rule to be enabled while we test it.
     var configuration = configuration ?? Configuration()


### PR DESCRIPTION
As of https://github.com/apple/swift-syntax/pull/985, the parser treats all trivia following a token up to the next line break as trailing trivia, including comments. This is a change from the former logic, which treated such comments as leading trivia of the following token.

A great deal of the logic in swift-format was written in terms of that behavior, and attempts to rewrite it to use the new behavior instead have been difficult to get right in all cases. In the interest of expediency, I'm merging this workaround that shifts the trivia around to restore the old tree that we expected.

This shouldn't be considered a long-term fix; we should eventually fix the misbehavior with the new layout and drop the extra mutation.

---

This PR also includes some other fixes for API changes in SwiftSyntax:

* `visit(TokenSyntax)` now returns `TokenSyntax`
* Object literals are now `MacroExpansionExprSyntax` instead of `MacroExpansionDeclSyntax`