### PR TITLE
Update to reflect changes on swift-syntax/main

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -48,6 +48,7 @@ let package = Package(
         .product(name: "SwiftSyntax", package: "swift-syntax"),
         .product(name: "SwiftOperators", package: "swift-syntax"),
         .product(name: "SwiftParser", package: "swift-syntax"),
+        .product(name: "SwiftParserDiagnostics", package: "swift-syntax"),
       ]
     ),
     .target(

--- a/Sources/SwiftFormat/Parsing.swift
+++ b/Sources/SwiftFormat/Parsing.swift
@@ -15,6 +15,7 @@ import SwiftDiagnostics
 import SwiftFormatCore
 import SwiftOperators
 import SwiftParser
+import SwiftParserDiagnostics
 import SwiftSyntax
 
 /// Parses the given source code and returns a valid `SourceFileSyntax` node.

--- a/Sources/SwiftFormatCore/LegacyTriviaBehavior.swift
+++ b/Sources/SwiftFormatCore/LegacyTriviaBehavior.swift
@@ -6,7 +6,7 @@ import SwiftSyntax
 /// Eventually we should get rid of this and update the core formatting code to adjust to the new
 /// behavior, but this workaround lets us keep the current implementation without larger changes.
 public func restoringLegacyTriviaBehavior(_ sourceFile: SourceFileSyntax) -> SourceFileSyntax {
-  return LegacyTriviaBehaviorRewriter().visit(sourceFile).as(SourceFileSyntax.self)!
+  return LegacyTriviaBehaviorRewriter().visit(sourceFile)
 }
 
 private final class LegacyTriviaBehaviorRewriter: SyntaxRewriter {


### PR DESCRIPTION
Adapt to two changes from swift-syntax `main`:
* `SyntaxRewriter` now provides stronger result types on its methods, due to https://github.com/apple/swift-syntax/pull/1003
* Swift parser diagnostics have moved into a separate module, due to https://github.com/apple/swift-syntax/pull/849