### PR TITLE
Fix swift-format after https://github.com/apple/swift-syntax/pull/1010.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -397,7 +397,12 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     before(node.result.firstToken, tokens: .break)
 
     if let accessorOrCodeBlock = node.accessor {
-      arrangeAccessorOrCodeBlock(accessorOrCodeBlock)
+      switch accessorOrCodeBlock {
+      case .accessors(let accessorBlock):
+        arrangeBracesAndContents(of: accessorBlock)
+      case .getter(let codeBlock):
+        arrangeBracesAndContents(of: codeBlock, contentsKeyPath: \.statements)
+      }
     }
 
     after(node.lastToken, tokens: .close)
@@ -405,26 +410,6 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     arrangeParameterClause(node.indices, forcesBreakBeforeRightParen: true)
 
     return .visitChildren
-  }
-
-  /// Applies formatting tokens to the given syntax node, assuming that it is either an
-  /// `AccessorBlockSyntax` or a `CodeBlockSyntax`.
-  ///
-  /// - Parameter node: The syntax node to arrange.
-  private func arrangeAccessorOrCodeBlock(_ node: Syntax) {
-    switch node.as(SyntaxEnum.self) {
-    case .accessorBlock(let accessorBlock):
-      arrangeBracesAndContents(of: accessorBlock)
-    case .codeBlock(let codeBlock):
-      arrangeBracesAndContents(of: codeBlock, contentsKeyPath: \.statements)
-    default:
-      preconditionFailure(
-        """
-        This should be unreachable; we expected an AccessorBlockSyntax or a CodeBlockSyntax, but \
-        found: \(type(of: node))
-        """
-      )
-    }
   }
 
   /// Applies formatting tokens to the tokens in the given function or function-like declaration
@@ -1985,7 +1970,12 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     }
 
     if let accessorOrCodeBlock = node.accessor {
-      arrangeAccessorOrCodeBlock(accessorOrCodeBlock)
+      switch accessorOrCodeBlock {
+      case .accessors(let accessorBlock):
+        arrangeBracesAndContents(of: accessorBlock)
+      case .getter(let codeBlock):
+        arrangeBracesAndContents(of: codeBlock, contentsKeyPath: \.statements)
+      }
     } else if let trailingComma = node.trailingComma {
       // If this is one of multiple comma-delimited bindings, move any pending close breaks to
       // follow the comma so that it doesn't get separated from the tokens before it.

--- a/Sources/SwiftFormatRules/FileScopedDeclarationPrivacy.swift
+++ b/Sources/SwiftFormatRules/FileScopedDeclarationPrivacy.swift
@@ -38,66 +38,68 @@ public final class FileScopedDeclarationPrivacy: SyntaxFormatRule {
     -> CodeBlockItemListSyntax
   {
     let newCodeBlockItems = codeBlockItems.map { codeBlockItem -> CodeBlockItemSyntax in
-      switch codeBlockItem.item.as(SyntaxEnum.self) {
-      case .ifConfigDecl(let ifConfigDecl):
-        // We need to look through `#if/#elseif/#else` blocks because the decls directly inside
-        // them are still considered file-scope for our purposes.
-        return codeBlockItem.withItem(Syntax(rewrittenIfConfigDecl(ifConfigDecl)))
-
-      case .functionDecl(let functionDecl):
-        return codeBlockItem.withItem(
-          Syntax(rewrittenDecl(
-            functionDecl,
-            modifiers: functionDecl.modifiers,
-            factory: functionDecl.withModifiers)))
-
-      case .variableDecl(let variableDecl):
-        return codeBlockItem.withItem(
-          Syntax(rewrittenDecl(
-            variableDecl,
-            modifiers: variableDecl.modifiers,
-            factory: variableDecl.withModifiers)))
-
-      case .classDecl(let classDecl):
-        return codeBlockItem.withItem(
-          Syntax(rewrittenDecl(
-            classDecl,
-            modifiers: classDecl.modifiers,
-            factory: classDecl.withModifiers)))
-
-      case .structDecl(let structDecl):
-        return codeBlockItem.withItem(
-          Syntax(rewrittenDecl(
-            structDecl,
-            modifiers: structDecl.modifiers,
-            factory: structDecl.withModifiers)))
-
-      case .enumDecl(let enumDecl):
-        return codeBlockItem.withItem(
-          Syntax(rewrittenDecl(
-            enumDecl,
-            modifiers: enumDecl.modifiers,
-            factory: enumDecl.withModifiers)))
-
-      case .protocolDecl(let protocolDecl):
-        return codeBlockItem.withItem(
-          Syntax(rewrittenDecl(
-            protocolDecl,
-            modifiers: protocolDecl.modifiers,
-            factory: protocolDecl.withModifiers)))
-
-      case .typealiasDecl(let typealiasDecl):
-        return codeBlockItem.withItem(
-          Syntax(rewrittenDecl(
-            typealiasDecl,
-            modifiers: typealiasDecl.modifiers,
-            factory: typealiasDecl.withModifiers)))
-
+      switch codeBlockItem.item {
+      case .decl(let decl):
+        return codeBlockItem.withItem(.decl(rewrittenDecl(decl)))
       default:
         return codeBlockItem
       }
     }
     return CodeBlockItemListSyntax(newCodeBlockItems)
+  }
+
+  private func rewrittenDecl(_ decl: DeclSyntax) -> DeclSyntax {
+    switch Syntax(decl).as(SyntaxEnum.self) {
+    case .ifConfigDecl(let ifConfigDecl):
+      // We need to look through `#if/#elseif/#else` blocks because the decls directly inside
+      // them are still considered file-scope for our purposes.
+      return DeclSyntax(rewrittenIfConfigDecl(ifConfigDecl))
+
+    case .functionDecl(let functionDecl):
+      return DeclSyntax(rewrittenDecl(
+          functionDecl,
+          modifiers: functionDecl.modifiers,
+          factory: functionDecl.withModifiers))
+
+    case .variableDecl(let variableDecl):
+      return DeclSyntax(rewrittenDecl(
+          variableDecl,
+          modifiers: variableDecl.modifiers,
+          factory: variableDecl.withModifiers))
+
+    case .classDecl(let classDecl):
+      return DeclSyntax(rewrittenDecl(
+          classDecl,
+          modifiers: classDecl.modifiers,
+          factory: classDecl.withModifiers))
+
+    case .structDecl(let structDecl):
+      return DeclSyntax(rewrittenDecl(
+          structDecl,
+          modifiers: structDecl.modifiers,
+          factory: structDecl.withModifiers))
+
+    case .enumDecl(let enumDecl):
+      return DeclSyntax(rewrittenDecl(
+          enumDecl,
+          modifiers: enumDecl.modifiers,
+          factory: enumDecl.withModifiers))
+
+    case .protocolDecl(let protocolDecl):
+      return DeclSyntax(rewrittenDecl(
+          protocolDecl,
+          modifiers: protocolDecl.modifiers,
+          factory: protocolDecl.withModifiers))
+
+    case .typealiasDecl(let typealiasDecl):
+      return DeclSyntax(rewrittenDecl(
+          typealiasDecl,
+          modifiers: typealiasDecl.modifiers,
+          factory: typealiasDecl.withModifiers))
+
+    default:
+      return decl
+    }
   }
 
   /// Returns a new `IfConfigDeclSyntax` equivalent to the given node, but where any file-scoped
@@ -109,9 +111,9 @@ public final class FileScopedDeclarationPrivacy: SyntaxFormatRule {
   /// - Returns: A new `IfConfigDeclSyntax` that has possibly been rewritten.
   private func rewrittenIfConfigDecl(_ ifConfigDecl: IfConfigDeclSyntax) -> IfConfigDeclSyntax {
     let newClauses = ifConfigDecl.clauses.map { clause -> IfConfigClauseSyntax in
-      switch clause.elements?.as(SyntaxEnum.self) {
-      case .codeBlockItemList(let codeBlockItemList)?:
-        return clause.withElements(Syntax(rewrittenCodeBlockItems(codeBlockItemList)))
+      switch clause.elements {
+      case .statements(let codeBlockItemList)?:
+        return clause.withElements(.statements(rewrittenCodeBlockItems(codeBlockItemList)))
       default:
         return clause
       }

--- a/Sources/SwiftFormatRules/NoParensAroundConditions.swift
+++ b/Sources/SwiftFormatRules/NoParensAroundConditions.swift
@@ -69,7 +69,7 @@ public final class NoParensAroundConditions: SyntaxFormatRule {
     else {
       return super.visit(node)
     }
-    return node.withCondition(Syntax(extractExpr(tup)))
+    return node.withCondition(.expression(extractExpr(tup)))
   }
 
   /// FIXME(hbh): Parsing for SwitchStmtSyntax is not implemented.

--- a/Sources/SwiftFormatRules/OneVariableDeclarationPerLine.swift
+++ b/Sources/SwiftFormatRules/OneVariableDeclarationPerLine.swift
@@ -50,7 +50,7 @@ public final class OneVariableDeclarationPerLine: SyntaxFormatRule {
       let visitedDecl = super.visit(varDecl).as(VariableDeclSyntax.self)!
       var splitter = VariableDeclSplitter {
         CodeBlockItemSyntax(
-          item: Syntax($0),
+          item: .decl(DeclSyntax($0)),
           semicolon: nil,
           errorTokens: nil)
       }

--- a/Sources/SwiftFormatRules/ReturnVoidInsteadOfEmptyTuple.swift
+++ b/Sources/SwiftFormatRules/ReturnVoidInsteadOfEmptyTuple.swift
@@ -64,13 +64,14 @@ public final class ReturnVoidInsteadOfEmptyTuple: SyntaxFormatRule {
       return super.visit(node)
     }
 
-    let input: Syntax?
-    if let parameterClause = node.input?.as(ParameterClauseSyntax.self) {
+    let input: ClosureSignatureSyntax.Input?
+    switch node.input {
+    case .input(let parameterClause)?:
       // If the closure input is a complete parameter clause (variables and types), make sure that
       // nested function types are also rewritten (for example, `label: (Int -> ()) -> ()` should
       // become `label: (Int -> Void) -> Void`).
-      input = Syntax(visit(parameterClause))
-    } else {
+      input = .input(visit(parameterClause))
+    default:
       // Otherwise, it's a simple signature (just variable names, no types), so there is nothing to
       // rewrite.
       input = node.input

--- a/Sources/SwiftFormatRules/UseEarlyExits.swift
+++ b/Sources/SwiftFormatRules/UseEarlyExits.swift
@@ -76,10 +76,12 @@ public final class UseEarlyExits: SyntaxFormatRule {
           elseKeyword: TokenSyntax.elseKeyword(trailingTrivia: .spaces(1)),
           body: elseBody)
 
-        return [
-          CodeBlockItemSyntax(item: Syntax(guardStatement), semicolon: nil, errorTokens: nil),
-          CodeBlockItemSyntax(item: Syntax(trueBlock), semicolon: nil, errorTokens: nil),
+        var items = [
+          CodeBlockItemSyntax(
+            item: .stmt(StmtSyntax(guardStatement)), semicolon: nil, errorTokens: nil),
         ]
+        items.append(contentsOf: trueBlock.statements)
+        return items
       })
     return result
   }
@@ -89,9 +91,14 @@ public final class UseEarlyExits: SyntaxFormatRule {
   private func codeBlockEndsWithEarlyExit(_ codeBlock: CodeBlockSyntax) -> Bool {
     guard let lastStatement = codeBlock.statements.last else { return false }
 
-    switch lastStatement.item.as(SyntaxEnum.self) {
-    case .returnStmt, .throwStmt, .breakStmt, .continueStmt:
-      return true
+    switch lastStatement.item {
+    case .stmt(let stmt):
+      switch Syntax(stmt).as(SyntaxEnum.self) {
+      case .returnStmt, .throwStmt, .breakStmt, .continueStmt:
+        return true
+      default:
+        return false
+      }
     default:
       return false
     }

--- a/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
+++ b/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
@@ -311,7 +311,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
     ])
     return DictionaryExprSyntax(
       leftSquare: leftSquareBracket,
-      content: Syntax(dictElementList),
+      content: .elements(dictElementList),
       rightSquare: rightSquareBracket)
   }
 

--- a/Sources/SwiftFormatRules/UseSingleLinePropertyGetter.swift
+++ b/Sources/SwiftFormatRules/UseSingleLinePropertyGetter.swift
@@ -38,7 +38,7 @@ public final class UseSingleLinePropertyGetter: SyntaxFormatRule {
     let newBlock = CodeBlockSyntax(
       leftBrace: accessorBlock.leftBrace, statements: body.statements,
       rightBrace: accessorBlock.rightBrace)
-    return node.withAccessor(Syntax(newBlock))
+    return node.withAccessor(.getter(newBlock))
   }
 }
 

--- a/Sources/SwiftFormatRules/UseWhereClausesInForLoops.swift
+++ b/Sources/SwiftFormatRules/UseWhereClausesInForLoops.swift
@@ -28,7 +28,7 @@ public final class UseWhereClausesInForLoops: SyntaxFormatRule {
   public override func visit(_ node: ForInStmtSyntax) -> StmtSyntax {
     // Extract IfStmt node if it's the only node in the function's body.
     guard !node.body.statements.isEmpty else { return StmtSyntax(node) }
-    let stmt = node.body.statements.first!
+    let firstStatement = node.body.statements.first!
 
     // Ignore for-loops with a `where` clause already.
     // FIXME: Create an `&&` expression with both conditions?
@@ -39,39 +39,53 @@ public final class UseWhereClausesInForLoops: SyntaxFormatRule {
     //    condition.
     //  - If the for loop has 1 or more statement, and the first is a GuardStmt
     //    with a single condition whose body is just `continue`.
-    switch stmt.item.as(SyntaxEnum.self) {
+    switch firstStatement.item {
+    case .stmt(let statement):
+      return StmtSyntax(diagnoseAndUpdateForInStatement(firstStmt: statement, forInStmt: node))
+    default:
+      return StmtSyntax(node)
+    }
+  }
+
+  private func diagnoseAndUpdateForInStatement(
+    firstStmt: StmtSyntax,
+    forInStmt: ForInStmtSyntax
+  ) -> ForInStmtSyntax {
+    switch Syntax(firstStmt).as(SyntaxEnum.self) {
     case .ifStmt(let ifStmt)
-    where ifStmt.conditions.count == 1 && ifStmt.elseKeyword == nil
-      && node.body.statements.count == 1:
+    where ifStmt.conditions.count == 1
+      && ifStmt.elseKeyword == nil
+      && forInStmt.body.statements.count == 1:
       // Extract the condition of the IfStmt.
       let conditionElement = ifStmt.conditions.first!
       guard let condition = conditionElement.condition.as(ExprSyntax.self) else {
-        return StmtSyntax(node)
+        return forInStmt
       }
       diagnose(.useWhereInsteadOfIf, on: ifStmt)
-      let result = updateWithWhereCondition(
-        node: node,
+      return updateWithWhereCondition(
+        node: forInStmt,
         condition: condition,
         statements: ifStmt.body.statements
       )
-      return StmtSyntax(result)
+
     case .guardStmt(let guardStmt)
-    where guardStmt.conditions.count == 1 && guardStmt.body.statements.count == 1 && guardStmt.body
-      .statements.first!.item.is(ContinueStmtSyntax.self):
+    where guardStmt.conditions.count == 1
+      && guardStmt.body.statements.count == 1
+      && guardStmt.body.statements.first!.item.is(ContinueStmtSyntax.self):
       // Extract the condition of the GuardStmt.
       let conditionElement = guardStmt.conditions.first!
       guard let condition = conditionElement.condition.as(ExprSyntax.self) else {
-        return StmtSyntax(node)
+        return forInStmt
       }
       diagnose(.useWhereInsteadOfGuard, on: guardStmt)
-      let result = updateWithWhereCondition(
-        node: node,
+      return updateWithWhereCondition(
+        node: forInStmt,
         condition: condition,
-        statements: node.body.statements.removingFirst()
+        statements: forInStmt.body.statements.removingFirst()
       )
-      return StmtSyntax(result)
+
     default:
-      return StmtSyntax(node)
+      return forInStmt
     }
   }
 }


### PR DESCRIPTION
That swift-syntax change switched many accessors that degraded to `Syntax` type to return enums of their possibilities instead.
