### PR TITLE
Update rules to use the operator-folded syntax tree.

### DIFF
--- a/Tests/SwiftFormatRulesTests/LintOrFormatRuleTestCase.swift
+++ b/Tests/SwiftFormatRulesTests/LintOrFormatRuleTestCase.swift
@@ -1,8 +1,9 @@
 import SwiftFormatConfiguration
 import SwiftFormatCore
 import SwiftFormatTestSupport
-import SwiftSyntax
+import SwiftOperators
 import SwiftParser
+import SwiftSyntax
 import XCTest
 
 class LintOrFormatRuleTestCase: DiagnosingTestCase {
@@ -19,7 +20,9 @@ class LintOrFormatRuleTestCase: DiagnosingTestCase {
     file: StaticString = #file,
     line: UInt = #line
   ) {
-    let sourceFileSyntax = restoringLegacyTriviaBehavior(Parser.parse(source: input))
+    let sourceFileSyntax = try! restoringLegacyTriviaBehavior(
+      OperatorTable.standardOperators.foldAll(Parser.parse(source: input))
+        .as(SourceFileSyntax.self)!)
 
     // Force the rule to be enabled while we test it.
     var configuration = Configuration()
@@ -56,7 +59,9 @@ class LintOrFormatRuleTestCase: DiagnosingTestCase {
     file: StaticString = #file,
     line: UInt = #line
   ) {
-    let sourceFileSyntax = restoringLegacyTriviaBehavior(Parser.parse(source: input))
+    let sourceFileSyntax = try! restoringLegacyTriviaBehavior(
+      OperatorTable.standardOperators.foldAll(Parser.parse(source: input))
+        .as(SourceFileSyntax.self)!)
 
     // Force the rule to be enabled while we test it.
     var configuration = configuration ?? Configuration()

--- a/Tests/SwiftFormatRulesTests/NeverForceUnwrapTests.swift
+++ b/Tests/SwiftFormatRulesTests/NeverForceUnwrapTests.swift
@@ -16,16 +16,14 @@ final class NeverForceUnwrapTests: LintOrFormatRuleTestCase {
     }
     """
     performLint(NeverForceUnwrap.self, input: input)
-    XCTAssertDiagnosed(.doNotForceUnwrap(name: "(someValue())"))
-    XCTAssertDiagnosed(.doNotForceUnwrap(name: "String(a)"))
+    XCTAssertDiagnosed(.doNotForceCast(name: "Int"), line: 3, column: 11)
+    XCTAssertDiagnosed(.doNotForceUnwrap(name: "(someValue())"), line: 4, column: 11)
+    XCTAssertDiagnosed(.doNotForceUnwrap(name: "String(a)"), line: 5, column: 11)
     XCTAssertNotDiagnosed(.doNotForceCast(name: "try"))
     XCTAssertNotDiagnosed(.doNotForceUnwrap(name: "try"))
-    XCTAssertDiagnosed(.doNotForceUnwrap(name: "a"))
-    XCTAssertDiagnosed(.doNotForceUnwrap(name: "[1: a, 2: b, 3: c][4]"))
-    // FIXME: These diagnostics will be emitted once NeverForceUnwrap is taught
-    // how to interpret Unresolved* components in sequence expressions.
-//    XCTAssertDiagnosed(.doNotForceCast(name: "Int"))
-//    XCTAssertDiagnosed(.doNotForceCast(name: "FooBarType"))
+    XCTAssertDiagnosed(.doNotForceUnwrap(name: "[1: a, 2: b, 3: c][4]"), line: 7, column: 35)
+    XCTAssertDiagnosed(.doNotForceCast(name: "FooBarType"), line: 8, column: 11)
+    XCTAssertDiagnosed(.doNotForceUnwrap(name: "a"), line: 9, column: 10)
   }
 
   func testIgnoreTestCode() {


### PR DESCRIPTION
These rules/tests were broken when we switched to the new parser because they operated on the unfolded tree (and we now fold before the rules pipeline, rather than just before the pretty printer), but the tests for those rules never caught the problem because they *also* weren't folding the tree.