### PR TITLE
Remove macro special cases

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1209,18 +1209,6 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     return .skipChildren
   }
 
-  override func visit(_ node: ObjectLiteralExprSyntax) -> SyntaxVisitorContinueKind {
-    // TODO: Remove this; it has been subsumed by `MacroExpansionDeclSyntax`. But that feature is
-    // still in flux and this node type is still present in the API, even though nothing in the
-    // parser currently creates it.
-    arrangeFunctionCallArgumentList(
-      node.arguments,
-      leftDelimiter: node.leftParen,
-      rightDelimiter: node.rightParen,
-      forcesBreakBeforeRightDelimiter: false)
-    return .visitChildren
-  }
-
   override func visit(_ node: MacroExpansionDeclSyntax) -> SyntaxVisitorContinueKind {
     arrangeFunctionCallArgumentList(
       node.argumentList,

--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1995,14 +1995,6 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     return .visitChildren
   }
 
-  override func visit(_ node: PoundFileExprSyntax) -> SyntaxVisitorContinueKind {
-    return .visitChildren
-  }
-
-  override func visit(_ node: PoundLineExprSyntax) -> SyntaxVisitorContinueKind {
-    return .visitChildren
-  }
-
   override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
     arrangeAttributeList(node.attributes)
 
@@ -2038,10 +2030,6 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: NilLiteralExprSyntax) -> SyntaxVisitorContinueKind {
-    return .visitChildren
-  }
-
-  override func visit(_ node: PoundErrorDeclSyntax) -> SyntaxVisitorContinueKind {
     return .visitChildren
   }
 
@@ -2094,10 +2082,6 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     return .visitChildren
   }
 
-  override func visit(_ node: PoundColumnExprSyntax) -> SyntaxVisitorContinueKind {
-    return .visitChildren
-  }
-
   override func visit(_ node: WildcardPatternSyntax) -> SyntaxVisitorContinueKind {
     return .visitChildren
   }
@@ -2131,10 +2115,6 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     return .visitChildren
   }
 
-  override func visit(_ node: PoundWarningDeclSyntax) -> SyntaxVisitorContinueKind {
-    return .visitChildren
-  }
-
   override func visit(_ node: ExpressionPatternSyntax) -> SyntaxVisitorContinueKind {
     return .visitChildren
   }
@@ -2156,10 +2136,6 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     if node.parent == nil || !node.parent!.is(PatternBindingSyntax.self) {
       after(node.equal, tokens: .break)
     }
-    return .visitChildren
-  }
-
-  override func visit(_ node: PoundFunctionExprSyntax) -> SyntaxVisitorContinueKind {
     return .visitChildren
   }
 
@@ -2225,10 +2201,6 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: IntegerLiteralExprSyntax) -> SyntaxVisitorContinueKind {
-    return .visitChildren
-  }
-
-  override func visit(_ node: PoundDsohandleExprSyntax) -> SyntaxVisitorContinueKind {
     return .visitChildren
   }
 

--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1209,10 +1209,6 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     return .skipChildren
   }
 
-  override func visit(_ node: ObjcKeyPathExprSyntax) -> SyntaxVisitorContinueKind {
-    return .visitChildren
-  }
-
   override func visit(_ node: ObjectLiteralExprSyntax) -> SyntaxVisitorContinueKind {
     // TODO: Remove this; it has been subsumed by `MacroExpansionDeclSyntax`. But that feature is
     // still in flux and this node type is still present in the API, even though nothing in the
@@ -1405,12 +1401,6 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       arrangeParameterClause(associatedValue, forcesBreakBeforeRightParen: false)
     }
 
-    return .visitChildren
-  }
-
-  override func visit(_ node: ObjcSelectorExprSyntax) -> SyntaxVisitorContinueKind {
-    after(node.leftParen, tokens: .break(.open, size: 0), .open)
-    before(node.rightParen, tokens: .break(.close(mustBreak: false), size: 0), .close)
     return .visitChildren
   }
 
@@ -2002,10 +1992,6 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
   override func visit(_ node: IsTypePatternSyntax) -> SyntaxVisitorContinueKind {
     after(node.isKeyword, tokens: .space)
-    return .visitChildren
-  }
-
-  override func visit(_ node: ObjcNamePieceSyntax) -> SyntaxVisitorContinueKind {
     return .visitChildren
   }
 

--- a/Tests/SwiftFormatPrettyPrintTests/DeclNameArgumentTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/DeclNameArgumentTests.swift
@@ -19,12 +19,15 @@ final class DeclNameArgumentTests: PrettyPrintTestCase {
           thirdArg:
           fourthArg:
           fifthArg:
-        ))
+        )
+      )
       let selector = #selector(
-        FooClass.method(firstArg:secondArg:))
+        FooClass.method(firstArg:secondArg:)
+      )
       let selector = #selector(
         FooClass.VeryDeeply.NestedInner.Member
-          .foo(firstArg:secondArg:))
+          .foo(firstArg:secondArg:)
+      )
       let selector = #selector(
         FooClass.VeryDeeply.NestedInner.Member
           .foo(
@@ -33,7 +36,8 @@ final class DeclNameArgumentTests: PrettyPrintTestCase {
             thirdArg:
             fourthArg:
             fifthArg:
-          ))
+          )
+      )
 
       """
 


### PR DESCRIPTION
Remove special-case logic for a number of expressions that will be subsumed by `MacroExpansionExprSyntax` and `MacroExpansionDeclSyntax`: `#selector`, `#keyPath`, `#file`, `#line`, `#column`, `#function`, `#warning`, `#error`, `#dsohandle`.

The one formatting change corresponds to the swift-syntax change in https://github.com/apple/swift-syntax/pull/1132 to use `MacroExpansionExprSyntax` for `#selector`. That PR also removes the syntax nodes we stop using here.