### PR TITLE
Remove References to Unknown Syntax

### DIFF
--- a/Documentation/PrettyPrinter.md
+++ b/Documentation/PrettyPrinter.md
@@ -233,7 +233,7 @@ Tokens = [docBlock(" Doc Block comment\n  * Second line *")]
 Verbatim tokens are used to print text verbatim without any formatting apart
 from applying a global indentation. They have a length set to the maximum line
 width. They are typically used to handle syntax types that are classed as
-"unknown" by SwiftSyntax. In these cases, we don't have access to the
+"unexpected" by SwiftSyntax. In these cases, we don't have access to the
 substructure of the syntax node a manner useful for formatting, so we print them
 verbatim. The indentation for verbatim tokens is applied to the first line of
 the text. The relative indentation of subsequent lines is preserved unless they
@@ -241,7 +241,7 @@ have less indentation than the first line, in which case we set the indentation
 of those lines equal to the first.
 
 ```
-// Consider "ifnt", an unknown syntax structure:
+// Consider "ifnt", an unexpected syntax structure:
 
 if someCondition {
     ifnt anotherCondition {

--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -2411,39 +2411,9 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     return .visitChildren
   }
 
-  // MARK: - Nodes representing unknown or malformed syntax
+  // MARK: - Nodes representing unexpected or malformed syntax
 
   override func visit(_ node: UnexpectedNodesSyntax) -> SyntaxVisitorContinueKind {
-    verbatimToken(Syntax(node))
-    return .skipChildren
-  }
-
-  override func visit(_ node: UnknownDeclSyntax) -> SyntaxVisitorContinueKind {
-    verbatimToken(Syntax(node))
-    return .skipChildren
-  }
-
-  override func visit(_ node: UnknownExprSyntax) -> SyntaxVisitorContinueKind {
-    verbatimToken(Syntax(node))
-    return .skipChildren
-  }
-
-  override func visit(_ node: UnknownPatternSyntax) -> SyntaxVisitorContinueKind {
-    verbatimToken(Syntax(node))
-    return .skipChildren
-  }
-
-  override func visit(_ node: UnknownStmtSyntax) -> SyntaxVisitorContinueKind {
-    verbatimToken(Syntax(node))
-    return .skipChildren
-  }
-
-  override func visit(_ node: UnknownSyntax) -> SyntaxVisitorContinueKind {
-    verbatimToken(Syntax(node))
-    return .skipChildren
-  }
-
-  override func visit(_ node: UnknownTypeSyntax) -> SyntaxVisitorContinueKind {
     verbatimToken(Syntax(node))
     return .skipChildren
   }


### PR DESCRIPTION
The new Swift parser in SwiftSyntax does not ever construct Unknown*Syntax nodes. These are a relic of the C++, which would use these nodes as stand-ins for cases where the legacy parser did not known how to build a node, or built one incorrectly. Simultaneously, the formatter was relying on unknown nodes containing verbatim text it would leave untouched. The general replacement for that case is UnexpectedSyntax. Drop the Unknown*Syntax entrypoints in the visitors, and replace refernces to "unknown syntax" with "unexpected syntax".

See also https://github.com/apple/swift-syntax/pull/1131