### PR TITLE
Remove `prefixPeriod`

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -3321,7 +3321,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
         if case .postfixOperator? = token.previousToken(viewMode: .all)?.tokenKind { return true }
 
         switch token.nextToken(viewMode: .all)?.tokenKind {
-        case .prefixOperator?, .prefixPeriod?: return true
+        case .prefixOperator?, .period?: return true
         default: return false
         }
       }


### PR DESCRIPTION
Removed by swift-syntax in https://github.com/apple/swift-syntax/pull/1077.