### PR TITLE
Adjustments for merging `AttributeSyntax` and `CustomAttributeSyntax`

### DIFF
--- a/Sources/SwiftFormatRules/NeverUseImplicitlyUnwrappedOptionals.swift
+++ b/Sources/SwiftFormatRules/NeverUseImplicitlyUnwrappedOptionals.swift
@@ -42,7 +42,7 @@ public final class NeverUseImplicitlyUnwrappedOptionals: SyntaxLintRule {
     // Ignores IBOutlet variables
     if let attributes = node.attributes {
       for attribute in attributes {
-        if (attribute.as(AttributeSyntax.self))?.attributeName.text == "IBOutlet" {
+        if (attribute.as(AttributeSyntax.self))?.attributeName.as(SimpleTypeIdentifierSyntax.self)?.name.text == "IBOutlet" {
           return .skipChildren
         }
       }

--- a/Tests/SwiftFormatPrettyPrintTests/AttributeTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/AttributeTests.swift
@@ -316,9 +316,6 @@ final class AttributeTests: PrettyPrintTestCase {
   }
 
   func testPropertyWrappers() {
-    // Property wrappers are `CustomAttributeSyntax` nodes (not `AttributeSyntax`) and their
-    // arguments are `TupleExprElementListSyntax` (like regular function call argument lists), so
-    // make sure that those are formatted properly.
     let input =
       """
       struct X {


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1176