### PR TITLE
Remove errorTokens from `CodeBlockItem`

### DIFF
--- a/Sources/SwiftFormatRules/NoAssignmentInExpressions.swift
+++ b/Sources/SwiftFormatRules/NoAssignmentInExpressions.swift
@@ -57,8 +57,7 @@ public final class NoAssignmentInExpressions: SyntaxFormatRule {
         newItems.append(
           CodeBlockItemSyntax(
             item: .expr(ExprSyntax(assignmentExpr)),
-            semicolon: nil,
-            errorTokens: nil
+            semicolon: nil
           )
           .withLeadingTrivia(
             (returnStmt.leadingTrivia ?? []) + (assignmentExpr.leadingTrivia ?? []))
@@ -66,8 +65,7 @@ public final class NoAssignmentInExpressions: SyntaxFormatRule {
         newItems.append(
           CodeBlockItemSyntax(
             item: .stmt(StmtSyntax(returnStmt.withExpression(nil))),
-            semicolon: nil,
-            errorTokens: nil
+            semicolon: nil
           )
           .withLeadingTrivia([.newlines(1)])
           .withTrailingTrivia(returnStmt.trailingTrivia?.withoutLeadingSpaces() ?? []))

--- a/Sources/SwiftFormatRules/OneVariableDeclarationPerLine.swift
+++ b/Sources/SwiftFormatRules/OneVariableDeclarationPerLine.swift
@@ -51,8 +51,7 @@ public final class OneVariableDeclarationPerLine: SyntaxFormatRule {
       var splitter = VariableDeclSplitter {
         CodeBlockItemSyntax(
           item: .decl(DeclSyntax($0)),
-          semicolon: nil,
-          errorTokens: nil)
+          semicolon: nil)
       }
       newItems.append(contentsOf: splitter.nodes(bySplitting: visitedDecl))
     }

--- a/Sources/SwiftFormatRules/UseEarlyExits.swift
+++ b/Sources/SwiftFormatRules/UseEarlyExits.swift
@@ -78,7 +78,7 @@ public final class UseEarlyExits: SyntaxFormatRule {
 
         var items = [
           CodeBlockItemSyntax(
-            item: .stmt(StmtSyntax(guardStatement)), semicolon: nil, errorTokens: nil),
+            item: .stmt(StmtSyntax(guardStatement)), semicolon: nil),
         ]
         items.append(contentsOf: trueBlock.statements)
         return items


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1177