### PR TITLE
Adjustment for removed `with<childName>` functions

### DIFF
--- a/Sources/SwiftFormatCore/LegacyTriviaBehavior.swift
+++ b/Sources/SwiftFormatCore/LegacyTriviaBehavior.swift
@@ -17,7 +17,7 @@ private final class LegacyTriviaBehaviorRewriter: SyntaxRewriter {
   override func visit(_ token: TokenSyntax) -> TokenSyntax {
     var token = token
     if let pendingLeadingTrivia = pendingLeadingTrivia {
-      token = token.withLeadingTrivia(pendingLeadingTrivia + token.leadingTrivia)
+      token = token.with(\.leadingTrivia, pendingLeadingTrivia + token.leadingTrivia)
       self.pendingLeadingTrivia = nil
     }
     if token.nextToken != nil,
@@ -25,7 +25,7 @@ private final class LegacyTriviaBehaviorRewriter: SyntaxRewriter {
     {
       pendingLeadingTrivia = Trivia(pieces: Array(token.trailingTrivia[firstIndexToMove...]))
       token =
-        token.withTrailingTrivia(Trivia(pieces: Array(token.trailingTrivia[..<firstIndexToMove])))
+        token.with(\.trailingTrivia, Trivia(pieces: Array(token.trailingTrivia[..<firstIndexToMove])))
     }
     return token
   }

--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -3483,7 +3483,7 @@ class CommentMovingRewriter: SyntaxRewriter {
 
   override func visit(_ token: TokenSyntax) -> TokenSyntax {
     if let rewrittenTrivia = rewriteTokenTriviaMap[token] {
-      return token.withLeadingTrivia(rewrittenTrivia)
+      return token.with(\.leadingTrivia, rewrittenTrivia)
     }
     return token
   }

--- a/Sources/SwiftFormatRules/AddModifierRewriter.swift
+++ b/Sources/SwiftFormatRules/AddModifierRewriter.swift
@@ -33,7 +33,7 @@ fileprivate final class AddModifierRewriter: SyntaxRewriter {
 
     // Put accessor keyword before the first modifier keyword in the declaration
     let newModifiers = modifiers.prepend(modifier: modifierKeyword)
-    return DeclSyntax(node.withModifiers(newModifiers))
+    return DeclSyntax(node.with(\.modifiers, newModifiers))
   }
 
   override func visit(_ node: FunctionDeclSyntax) -> DeclSyntax {
@@ -46,7 +46,7 @@ fileprivate final class AddModifierRewriter: SyntaxRewriter {
     }
     guard modifiers.accessLevelModifier == nil else { return DeclSyntax(node) }
     let newModifiers = modifiers.prepend(modifier: modifierKeyword)
-    return DeclSyntax(node.withModifiers(newModifiers))
+    return DeclSyntax(node.with(\.modifiers, newModifiers))
   }
 
   override func visit(_ node: AssociatedtypeDeclSyntax) -> DeclSyntax {
@@ -59,7 +59,7 @@ fileprivate final class AddModifierRewriter: SyntaxRewriter {
     }
     guard modifiers.accessLevelModifier == nil else { return DeclSyntax(node) }
     let newModifiers = modifiers.prepend(modifier: modifierKeyword)
-    return DeclSyntax(node.withModifiers(newModifiers))
+    return DeclSyntax(node.with(\.modifiers, newModifiers))
   }
 
   override func visit(_ node: ClassDeclSyntax) -> DeclSyntax {
@@ -72,7 +72,7 @@ fileprivate final class AddModifierRewriter: SyntaxRewriter {
     }
     guard modifiers.accessLevelModifier == nil else { return DeclSyntax(node) }
     let newModifiers = modifiers.prepend(modifier: modifierKeyword)
-    return DeclSyntax(node.withModifiers(newModifiers))
+    return DeclSyntax(node.with(\.modifiers, newModifiers))
   }
 
   override func visit(_ node: EnumDeclSyntax) -> DeclSyntax {
@@ -85,7 +85,7 @@ fileprivate final class AddModifierRewriter: SyntaxRewriter {
     }
     guard modifiers.accessLevelModifier == nil else { return DeclSyntax(node) }
     let newModifiers = modifiers.prepend(modifier: modifierKeyword)
-    return DeclSyntax(node.withModifiers(newModifiers))
+    return DeclSyntax(node.with(\.modifiers, newModifiers))
   }
 
   override func visit(_ node: ProtocolDeclSyntax) -> DeclSyntax {
@@ -98,7 +98,7 @@ fileprivate final class AddModifierRewriter: SyntaxRewriter {
     }
     guard modifiers.accessLevelModifier == nil else { return DeclSyntax(node) }
     let newModifiers = modifiers.prepend(modifier: modifierKeyword)
-    return DeclSyntax(node.withModifiers(newModifiers))
+    return DeclSyntax(node.with(\.modifiers, newModifiers))
   }
 
   override func visit(_ node: StructDeclSyntax) -> DeclSyntax {
@@ -111,7 +111,7 @@ fileprivate final class AddModifierRewriter: SyntaxRewriter {
     }
     guard modifiers.accessLevelModifier == nil else { return DeclSyntax(node) }
     let newModifiers = modifiers.prepend(modifier: modifierKeyword)
-    return DeclSyntax(node.withModifiers(newModifiers))
+    return DeclSyntax(node.with(\.modifiers, newModifiers))
   }
 
   override func visit(_ node: TypealiasDeclSyntax) -> DeclSyntax {
@@ -124,7 +124,7 @@ fileprivate final class AddModifierRewriter: SyntaxRewriter {
     }
     guard modifiers.accessLevelModifier == nil else { return DeclSyntax(node) }
     let newModifiers = modifiers.prepend(modifier: modifierKeyword)
-    return DeclSyntax(node.withModifiers(newModifiers))
+    return DeclSyntax(node.with(\.modifiers, newModifiers))
   }
 
   override func visit(_ node: InitializerDeclSyntax) -> DeclSyntax {
@@ -137,7 +137,7 @@ fileprivate final class AddModifierRewriter: SyntaxRewriter {
     }
     guard modifiers.accessLevelModifier == nil else { return DeclSyntax(node) }
     let newModifiers = modifiers.prepend(modifier: modifierKeyword)
-    return DeclSyntax(node.withModifiers(newModifiers))
+    return DeclSyntax(node.with(\.modifiers, newModifiers))
   }
 
   override func visit(_ node: SubscriptDeclSyntax) -> DeclSyntax {
@@ -150,7 +150,7 @@ fileprivate final class AddModifierRewriter: SyntaxRewriter {
     }
     guard modifiers.accessLevelModifier == nil else { return DeclSyntax(node) }
     let newModifiers = modifiers.prepend(modifier: modifierKeyword)
-    return DeclSyntax(node.withModifiers(newModifiers))
+    return DeclSyntax(node.with(\.modifiers, newModifiers))
   }
 
   /// Moves trivia in the given node to correct the placement of potentially displaced trivia in the

--- a/Sources/SwiftFormatRules/DoNotUseSemicolons.swift
+++ b/Sources/SwiftFormatRules/DoNotUseSemicolons.swift
@@ -87,7 +87,7 @@ public final class DoNotUseSemicolons: SyntaxFormatRule {
 
         // This discards any trailingTrivia from the semicolon. That trivia is at most some spaces,
         // and the pretty printer adds any necessary spaces so it's safe to discard.
-        newItem = newItem.withSemicolon(nil)
+        newItem = newItem.with(\.semicolon, nil)
         if idx < node.count - 1 {
           diagnose(.removeSemicolonAndMove, on: semicolon)
         } else {

--- a/Sources/SwiftFormatRules/FileScopedDeclarationPrivacy.swift
+++ b/Sources/SwiftFormatRules/FileScopedDeclarationPrivacy.swift
@@ -24,7 +24,7 @@ import SwiftSyntax
 public final class FileScopedDeclarationPrivacy: SyntaxFormatRule {
   public override func visit(_ node: SourceFileSyntax) -> SourceFileSyntax {
     let newStatements = rewrittenCodeBlockItems(node.statements)
-    return node.withStatements(newStatements)
+    return node.with(\.statements, newStatements)
   }
 
   /// Returns a list of code block items equivalent to the given list, but where any file-scoped
@@ -40,7 +40,7 @@ public final class FileScopedDeclarationPrivacy: SyntaxFormatRule {
     let newCodeBlockItems = codeBlockItems.map { codeBlockItem -> CodeBlockItemSyntax in
       switch codeBlockItem.item {
       case .decl(let decl):
-        return codeBlockItem.withItem(.decl(rewrittenDecl(decl)))
+        return codeBlockItem.with(\.item, .decl(rewrittenDecl(decl)))
       default:
         return codeBlockItem
       }
@@ -59,43 +59,43 @@ public final class FileScopedDeclarationPrivacy: SyntaxFormatRule {
       return DeclSyntax(rewrittenDecl(
           functionDecl,
           modifiers: functionDecl.modifiers,
-          factory: functionDecl.withModifiers))
+          factory: { functionDecl.with(\.modifiers, $0) }))
 
     case .variableDecl(let variableDecl):
       return DeclSyntax(rewrittenDecl(
           variableDecl,
           modifiers: variableDecl.modifiers,
-          factory: variableDecl.withModifiers))
+          factory: { variableDecl.with(\.modifiers, $0) }))
 
     case .classDecl(let classDecl):
       return DeclSyntax(rewrittenDecl(
           classDecl,
           modifiers: classDecl.modifiers,
-          factory: classDecl.withModifiers))
+          factory: { classDecl.with(\.modifiers, $0) }))
 
     case .structDecl(let structDecl):
       return DeclSyntax(rewrittenDecl(
           structDecl,
           modifiers: structDecl.modifiers,
-          factory: structDecl.withModifiers))
+          factory: { structDecl.with(\.modifiers, $0) }))
 
     case .enumDecl(let enumDecl):
       return DeclSyntax(rewrittenDecl(
           enumDecl,
           modifiers: enumDecl.modifiers,
-          factory: enumDecl.withModifiers))
+          factory: { enumDecl.with(\.modifiers, $0) }))
 
     case .protocolDecl(let protocolDecl):
       return DeclSyntax(rewrittenDecl(
           protocolDecl,
           modifiers: protocolDecl.modifiers,
-          factory: protocolDecl.withModifiers))
+          factory: { protocolDecl.with(\.modifiers, $0) }))
 
     case .typealiasDecl(let typealiasDecl):
       return DeclSyntax(rewrittenDecl(
           typealiasDecl,
           modifiers: typealiasDecl.modifiers,
-          factory: typealiasDecl.withModifiers))
+          factory: { typealiasDecl.with(\.modifiers, $0) }))
 
     default:
       return decl
@@ -113,12 +113,12 @@ public final class FileScopedDeclarationPrivacy: SyntaxFormatRule {
     let newClauses = ifConfigDecl.clauses.map { clause -> IfConfigClauseSyntax in
       switch clause.elements {
       case .statements(let codeBlockItemList)?:
-        return clause.withElements(.statements(rewrittenCodeBlockItems(codeBlockItemList)))
+        return clause.with(\.elements, .statements(rewrittenCodeBlockItems(codeBlockItemList)))
       default:
         return clause
       }
     }
-    return ifConfigDecl.withClauses(IfConfigClauseListSyntax(newClauses))
+    return ifConfigDecl.with(\.clauses, IfConfigClauseListSyntax(newClauses))
   }
 
   /// Returns a rewritten version of the given declaration if its modifier list contains `private`
@@ -161,7 +161,7 @@ public final class FileScopedDeclarationPrivacy: SyntaxFormatRule {
       let name = modifier.name
       if name.tokenKind == invalidAccess {
         diagnose(diagnostic, on: name)
-        return modifier.withName(name.withKind(validAccess))
+        return modifier.with(\.name, name.withKind(validAccess))
       }
       return modifier
     }

--- a/Sources/SwiftFormatRules/FullyIndirectEnum.swift
+++ b/Sources/SwiftFormatRules/FullyIndirectEnum.swift
@@ -44,10 +44,10 @@ public final class FullyIndirectEnum: SyntaxFormatRule {
         return member
       }
 
-      let newCase = caseMember.withModifiers(modifiers.remove(name: "indirect"))
+      let newCase = caseMember.with(\.modifiers, modifiers.remove(name: "indirect"))
       let formattedCase = formatCase(
         unformattedCase: newCase, leadingTrivia: firstModifier.leadingTrivia)
-      return member.withDecl(DeclSyntax(formattedCase))
+      return member.with(\.decl, DeclSyntax(formattedCase))
     }
 
     // If the `indirect` keyword being added would be the first token in the decl, we need to move
@@ -70,8 +70,8 @@ public final class FullyIndirectEnum: SyntaxFormatRule {
       name: TokenSyntax.identifier(
         "indirect", leadingTrivia: leadingTrivia, trailingTrivia: .spaces(1)), detail: nil)
 
-    let newMemberBlock = node.members.withMembers(MemberDeclListSyntax(newMembers))
-    return DeclSyntax(newEnumDecl.addModifier(newModifier).withMembers(newMemberBlock))
+    let newMemberBlock = node.members.with(\.members, MemberDeclListSyntax(newMembers))
+    return DeclSyntax(newEnumDecl.addModifier(newModifier).with(\.members, newMemberBlock))
   }
 
   /// Returns a value indicating whether all enum cases in the given list are indirect.

--- a/Sources/SwiftFormatRules/GroupNumericLiterals.swift
+++ b/Sources/SwiftFormatRules/GroupNumericLiterals.swift
@@ -59,7 +59,7 @@ public final class GroupNumericLiterals: SyntaxFormatRule {
     }
 
     newDigits = isNegative ? "-" + newDigits : newDigits
-    let result = node.withDigits(
+    let result = node.with(\.digits,
       TokenSyntax.integerLiteral(
         newDigits,
         leadingTrivia: node.digits.leadingTrivia,

--- a/Sources/SwiftFormatRules/NeverForceUnwrap.swift
+++ b/Sources/SwiftFormatRules/NeverForceUnwrap.swift
@@ -31,7 +31,7 @@ public final class NeverForceUnwrap: SyntaxLintRule {
 
   public override func visit(_ node: ForcedValueExprSyntax) -> SyntaxVisitorContinueKind {
     guard context.importsXCTest == .doesNotImportXCTest else { return .skipChildren }
-    diagnose(.doNotForceUnwrap(name: node.expression.withoutTrivia().description), on: node)
+    diagnose(.doNotForceUnwrap(name: node.expression.with(\.leadingTrivia, []).with(\.trailingTrivia, []).description), on: node)
     return .skipChildren
   }
 
@@ -41,7 +41,7 @@ public final class NeverForceUnwrap: SyntaxLintRule {
     guard context.importsXCTest == .doesNotImportXCTest else { return .skipChildren }
     guard let questionOrExclamation = node.questionOrExclamationMark else { return .skipChildren }
     guard questionOrExclamation.tokenKind == .exclamationMark else { return .skipChildren }
-    diagnose(.doNotForceCast(name: node.typeName.withoutTrivia().description), on: node)
+    diagnose(.doNotForceCast(name: node.typeName.with(\.leadingTrivia, []).with(\.trailingTrivia, []).description), on: node)
     return .skipChildren
   }
 }

--- a/Sources/SwiftFormatRules/NeverUseImplicitlyUnwrappedOptionals.swift
+++ b/Sources/SwiftFormatRules/NeverUseImplicitlyUnwrappedOptionals.swift
@@ -59,7 +59,7 @@ public final class NeverUseImplicitlyUnwrappedOptionals: SyntaxLintRule {
     guard let violation = type.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) else { return }
     diagnose(
       .doNotUseImplicitUnwrapping(
-        identifier: violation.wrappedType.withoutTrivia().description), on: type)
+        identifier: violation.wrappedType.with(\.leadingTrivia, []).with(\.trailingTrivia, []).description), on: type)
   }
 }
 

--- a/Sources/SwiftFormatRules/NoAccessLevelOnExtensionDeclaration.swift
+++ b/Sources/SwiftFormatRules/NoAccessLevelOnExtensionDeclaration.swift
@@ -39,7 +39,7 @@ public final class NoAccessLevelOnExtensionDeclaration: SyntaxFormatRule {
       let accessKeywordToAdd: DeclModifierSyntax
       if keywordKind == .keyword(.private) {
         accessKeywordToAdd
-          = accessKeyword.withName(accessKeyword.name.withKind(.keyword(.fileprivate)))
+          = accessKeyword.with(\.name, accessKeyword.name.withKind(.keyword(.fileprivate)))
       } else {
         accessKeywordToAdd = accessKeyword
       }
@@ -52,9 +52,9 @@ public final class NoAccessLevelOnExtensionDeclaration: SyntaxFormatRule {
         on: node.extensionKeyword,
         token: node.extensionKeyword,
         leadingTrivia: accessKeyword.leadingTrivia)
-      let result = node.withMembers(newMembers)
-        .withModifiers(modifiers.remove(name: accessKeyword.name.text))
-        .withExtensionKeyword(newKeyword)
+      let result = node.with(\.members, newMembers)
+        .with(\.modifiers, modifiers.remove(name: accessKeyword.name.text))
+        .with(\.extensionKeyword, newKeyword)
       return DeclSyntax(result)
 
     // Internal keyword redundant, delete
@@ -66,8 +66,8 @@ public final class NoAccessLevelOnExtensionDeclaration: SyntaxFormatRule {
         on: node.extensionKeyword,
         token: node.extensionKeyword,
         leadingTrivia: accessKeyword.leadingTrivia)
-      let result = node.withModifiers(modifiers.remove(name: accessKeyword.name.text))
-        .withExtensionKeyword(newKeyword)
+      let result = node.with(\.modifiers, modifiers.remove(name: accessKeyword.name.text))
+        .with(\.extensionKeyword, newKeyword)
       return DeclSyntax(result)
 
     default:
@@ -94,7 +94,7 @@ public final class NoAccessLevelOnExtensionDeclaration: SyntaxFormatRule {
         let newDecl = addModifier(declaration: member, modifierKeyword: formattedKeyword)
           .as(DeclSyntax.self)
       else { continue }
-      newMembers.append(memberItem.withDecl(newDecl))
+      newMembers.append(memberItem.with(\.decl, newDecl))
     }
     return MemberDeclListSyntax(newMembers)
   }

--- a/Sources/SwiftFormatRules/NoAssignmentInExpressions.swift
+++ b/Sources/SwiftFormatRules/NoAssignmentInExpressions.swift
@@ -59,16 +59,16 @@ public final class NoAssignmentInExpressions: SyntaxFormatRule {
             item: .expr(ExprSyntax(assignmentExpr)),
             semicolon: nil
           )
-          .withLeadingTrivia(
+          .with(\.leadingTrivia, 
             (returnStmt.leadingTrivia ?? []) + (assignmentExpr.leadingTrivia ?? []))
-          .withTrailingTrivia([]))
+          .with(\.trailingTrivia, []))
         newItems.append(
           CodeBlockItemSyntax(
-            item: .stmt(StmtSyntax(returnStmt.withExpression(nil))),
+            item: .stmt(StmtSyntax(returnStmt.with(\.expression, nil))),
             semicolon: nil
           )
-          .withLeadingTrivia([.newlines(1)])
-          .withTrailingTrivia(returnStmt.trailingTrivia?.withoutLeadingSpaces() ?? []))
+          .with(\.leadingTrivia, [.newlines(1)])
+          .with(\.trailingTrivia, returnStmt.trailingTrivia?.withoutLeadingSpaces() ?? []))
 
       default:
         newItems.append(newItem)

--- a/Sources/SwiftFormatRules/NoCasesWithOnlyFallthrough.swift
+++ b/Sources/SwiftFormatRules/NoCasesWithOnlyFallthrough.swift
@@ -178,25 +178,26 @@ public final class NoCasesWithOnlyFallthrough: SyntaxFormatRule {
       // more items.
       newCaseItems.append(contentsOf: label.caseItems.dropLast())
       newCaseItems.append(
-        label.caseItems.last!.withTrailingComma(
+        label.caseItems.last!.with(
+          \.trailingComma, 
           TokenSyntax.commaToken(trailingTrivia: .spaces(1))))
 
       // Diagnose the cases being collapsed. We do this for all but the last one in the array; the
       // last one isn't diagnosed because it will contain the body that applies to all the previous
       // cases.
-      diagnose(.collapseCase(name: label.caseItems.withoutTrivia().description), on: label)
+      diagnose(.collapseCase(name: label.caseItems.with(\.leadingTrivia, []).with(\.trailingTrivia, []).description), on: label)
     }
     newCaseItems.append(contentsOf: labels.last!.caseItems)
 
-    let newCase = cases.last!.withLabel(.case(
-      labels.last!.withCaseItems(CaseItemListSyntax(newCaseItems))))
+    let newCase = cases.last!.with(\.label, .case(
+      labels.last!.with(\.caseItems, CaseItemListSyntax(newCaseItems))))
 
     // Only the first violation case can have displaced trivia, because any non-whitespace
     // trivia in the other violation cases would've prevented collapsing.
     if let displacedLeadingTrivia = cases.first!.leadingTrivia?.withoutLastLine() {
       let existingLeadingTrivia = newCase.leadingTrivia ?? []
       let mergedLeadingTrivia = displacedLeadingTrivia + existingLeadingTrivia
-      return newCase.withLeadingTrivia(mergedLeadingTrivia)
+      return newCase.with(\.leadingTrivia, mergedLeadingTrivia)
     } else {
       return newCase
     }

--- a/Sources/SwiftFormatRules/NoEmptyTrailingClosureParentheses.swift
+++ b/Sources/SwiftFormatRules/NoEmptyTrailingClosureParentheses.swift
@@ -29,7 +29,7 @@ public final class NoEmptyTrailingClosureParentheses: SyntaxFormatRule {
     {
       return super.visit(node)
     }
-    guard let name = node.calledExpression.lastToken?.withoutTrivia() else {
+    guard let name = node.calledExpression.lastToken?.with(\.leadingTrivia, []).with(\.trailingTrivia, []) else {
       return super.visit(node)
     }
 
@@ -45,8 +45,8 @@ public final class NoEmptyTrailingClosureParentheses: SyntaxFormatRule {
       token: rewrittenCalledExpr.lastToken,
       trailingTrivia: .spaces(1))
     let formattedClosure = visit(trailingClosure).as(ClosureExprSyntax.self)
-    let result = node.withLeftParen(nil).withRightParen(nil).withCalledExpression(formattedExp)
-      .withTrailingClosure(formattedClosure)
+    let result = node.with(\.leftParen, nil).with(\.rightParen, nil).with(\.calledExpression, formattedExp)
+      .with(\.trailingClosure, formattedClosure)
     return ExprSyntax(result)
   }
 }

--- a/Sources/SwiftFormatRules/NoLabelsInCasePatterns.swift
+++ b/Sources/SwiftFormatRules/NoLabelsInCasePatterns.swift
@@ -50,23 +50,23 @@ public final class NoLabelsInCasePatterns: SyntaxFormatRule {
         }
 
         // Remove label if it's the same as the value identifier
-        let name = valueBinding.valuePattern.withoutTrivia().description
+        let name = valueBinding.valuePattern.with(\.leadingTrivia, []).with(\.trailingTrivia, []).description
         guard name == label.text else {
           newArgs.append(argument)
           continue
         }
         diagnose(.removeRedundantLabel(name: name), on: label)
-        newArgs.append(argument.withLabel(nil).withColon(nil))
+        newArgs.append(argument.with(\.label, nil).with(\.colon, nil))
       }
 
       let newArgList = TupleExprElementListSyntax(newArgs)
-      let newFuncCall = funcCall.withArgumentList(newArgList)
-      let newExpPat = expPat.withExpression(ExprSyntax(newFuncCall))
-      let newItem = item.withPattern(PatternSyntax(newExpPat))
+      let newFuncCall = funcCall.with(\.argumentList, newArgList)
+      let newExpPat = expPat.with(\.expression, ExprSyntax(newFuncCall))
+      let newItem = item.with(\.pattern, PatternSyntax(newExpPat))
       newCaseItems.append(newItem)
     }
     let newCaseItemList = CaseItemListSyntax(newCaseItems)
-    return node.withCaseItems(newCaseItemList)
+    return node.with(\.caseItems, newCaseItemList)
   }
 }
 

--- a/Sources/SwiftFormatRules/NoParensAroundConditions.swift
+++ b/Sources/SwiftFormatRules/NoParensAroundConditions.swift
@@ -54,11 +54,11 @@ public final class NoParensAroundConditions: SyntaxFormatRule {
 
   public override func visit(_ node: IfStmtSyntax) -> StmtSyntax {
     let conditions = visit(node.conditions)
-    var result = node.withIfKeyword(node.ifKeyword.withOneTrailingSpace())
-      .withConditions(conditions)
-      .withBody(visit(node.body))
+    var result = node.with(\.ifKeyword, node.ifKeyword.withOneTrailingSpace())
+      .with(\.conditions, conditions)
+      .with(\.body, visit(node.body))
     if let elseBody = node.elseBody {
-      result = result.withElseBody(visit(elseBody))
+      result = result.with(\.elseBody, visit(elseBody))
     }
     return StmtSyntax(result)
   }
@@ -69,7 +69,7 @@ public final class NoParensAroundConditions: SyntaxFormatRule {
     else {
       return super.visit(node)
     }
-    return node.withCondition(.expression(extractExpr(tup)))
+    return node.with(\.condition, .expression(extractExpr(tup)))
   }
 
   /// FIXME(hbh): Parsing for SwitchStmtSyntax is not implemented.
@@ -80,7 +80,7 @@ public final class NoParensAroundConditions: SyntaxFormatRule {
       return super.visit(node)
     }
     return StmtSyntax(
-      node.withExpression(extractExpr(tup)).withCases(visit(node.cases)))
+      node.with(\.expression, extractExpr(tup)).with(\.cases, visit(node.cases)))
   }
 
   public override func visit(_ node: RepeatWhileStmtSyntax) -> StmtSyntax {
@@ -89,9 +89,9 @@ public final class NoParensAroundConditions: SyntaxFormatRule {
     else {
       return super.visit(node)
     }
-    let newNode = node.withCondition(extractExpr(tup))
-      .withWhileKeyword(node.whileKeyword.withOneTrailingSpace())
-      .withBody(visit(node.body))
+    let newNode = node.with(\.condition, extractExpr(tup))
+      .with(\.whileKeyword, node.whileKeyword.withOneTrailingSpace())
+      .with(\.body, visit(node.body))
     return StmtSyntax(newNode)
   }
 }

--- a/Sources/SwiftFormatRules/NoVoidReturnOnFunctionSignature.swift
+++ b/Sources/SwiftFormatRules/NoVoidReturnOnFunctionSignature.swift
@@ -26,11 +26,11 @@ public final class NoVoidReturnOnFunctionSignature: SyntaxFormatRule {
   public override func visit(_ node: FunctionSignatureSyntax) -> FunctionSignatureSyntax {
     if let ret = node.output?.returnType.as(SimpleTypeIdentifierSyntax.self), ret.name.text == "Void" {
       diagnose(.removeRedundantReturn("Void"), on: ret)
-      return node.withOutput(nil)
+      return node.with(\.output, nil)
     }
     if let tup = node.output?.returnType.as(TupleTypeSyntax.self), tup.elements.isEmpty {
       diagnose(.removeRedundantReturn("()"), on: tup)
-      return node.withOutput(nil)
+      return node.with(\.output, nil)
     }
     return node
   }

--- a/Sources/SwiftFormatRules/OneCasePerLine.swift
+++ b/Sources/SwiftFormatRules/OneCasePerLine.swift
@@ -60,7 +60,7 @@ public final class OneCasePerLine: SyntaxFormatRule {
 
       // Remove the trailing comma on the final element, if there was one.
       if last.trailingComma != nil {
-        elements[elements.count - 1] = last.withTrailingComma(nil)
+        elements[elements.count - 1] = last.with(\.trailingComma, nil)
       }
 
       defer { elements.removeAll() }
@@ -70,14 +70,14 @@ public final class OneCasePerLine: SyntaxFormatRule {
     /// Creates and returns a new `EnumCaseDeclSyntax` with the given elements, based on the current
     /// basis declaration, and updates the comment preserving state if needed.
     mutating func makeCaseDeclFromBasis(elements: [EnumCaseElementSyntax]) -> EnumCaseDeclSyntax {
-      let caseDecl = basis.withElements(EnumCaseElementListSyntax(elements))
+      let caseDecl = basis.with(\.elements, EnumCaseElementListSyntax(elements))
 
       if shouldKeepLeadingTrivia {
         shouldKeepLeadingTrivia = false
 
         // We don't bother preserving any indentation because the pretty printer will fix that up.
         // All we need to do here is ensure that there is a newline.
-        basis = basis.withLeadingTrivia(Trivia.newlines(1))
+        basis = basis.with(\.leadingTrivia, Trivia.newlines(1))
       }
 
       return caseDecl
@@ -106,12 +106,12 @@ public final class OneCasePerLine: SyntaxFormatRule {
           diagnose(.moveAssociatedOrRawValueCase(name: element.identifier.text), on: element)
 
           if let caseDeclForCollectedElements = collector.makeCaseDeclAndReset() {
-            newMembers.append(member.withDecl(DeclSyntax(caseDeclForCollectedElements)))
+            newMembers.append(member.with(\.decl, DeclSyntax(caseDeclForCollectedElements)))
           }
 
           let separatedCaseDecl =
-            collector.makeCaseDeclFromBasis(elements: [element.withTrailingComma(nil)])
-          newMembers.append(member.withDecl(DeclSyntax(separatedCaseDecl)))
+            collector.makeCaseDeclFromBasis(elements: [element.with(\.trailingComma, nil)])
+          newMembers.append(member.with(\.decl, DeclSyntax(separatedCaseDecl)))
         } else {
           collector.addElement(element)
         }
@@ -119,12 +119,12 @@ public final class OneCasePerLine: SyntaxFormatRule {
 
       // Make sure to emit any trailing collected elements.
       if let caseDeclForCollectedElements = collector.makeCaseDeclAndReset() {
-        newMembers.append(member.withDecl(DeclSyntax(caseDeclForCollectedElements)))
+        newMembers.append(member.with(\.decl, DeclSyntax(caseDeclForCollectedElements)))
       }
     }
 
-    let newMemberBlock = node.members.withMembers(MemberDeclListSyntax(newMembers))
-    return DeclSyntax(node.withMembers(newMemberBlock))
+    let newMemberBlock = node.members.with(\.members, MemberDeclListSyntax(newMembers))
+    return DeclSyntax(node.with(\.members, newMemberBlock))
   }
 }
 

--- a/Sources/SwiftFormatRules/OneVariableDeclarationPerLine.swift
+++ b/Sources/SwiftFormatRules/OneVariableDeclarationPerLine.swift
@@ -139,7 +139,7 @@ private struct VariableDeclSplitter<Node: SyntaxProtocol> {
         // it's an initializer following other un-flushed lone identifier
         // bindings, that's not valid Swift. But in either case, we'll flush
         // them as a single decl.
-        bindingQueue.append(binding.withTrailingComma(nil))
+        bindingQueue.append(binding.with(\.trailingComma, nil))
         flushRemaining()
       } else if let typeAnnotation = binding.typeAnnotation {
         bindingQueue.append(binding)
@@ -172,7 +172,7 @@ private struct VariableDeclSplitter<Node: SyntaxProtocol> {
     guard !bindingQueue.isEmpty else { return }
 
     let newDecl =
-      varDecl.withBindings(PatternBindingListSyntax(bindingQueue))
+      varDecl.with(\.bindings, PatternBindingListSyntax(bindingQueue))
     nodes.append(generator(newDecl))
 
     fixOriginalVarDeclTrivia()
@@ -191,9 +191,9 @@ private struct VariableDeclSplitter<Node: SyntaxProtocol> {
       assert(binding.initializer == nil)
 
       let newBinding =
-        binding.withTrailingComma(nil).withTypeAnnotation(typeAnnotation)
+        binding.with(\.trailingComma, nil).with(\.typeAnnotation, typeAnnotation)
       let newDecl =
-        varDecl.withBindings(PatternBindingListSyntax([newBinding]))
+        varDecl.with(\.bindings, PatternBindingListSyntax([newBinding]))
       nodes.append(generator(newDecl))
 
       fixOriginalVarDeclTrivia()

--- a/Sources/SwiftFormatRules/OrderedImports.swift
+++ b/Sources/SwiftFormatRules/OrderedImports.swift
@@ -131,7 +131,8 @@ public final class OrderedImports: SyntaxFormatRule {
       formatAndAppend(linesSection: lines[lastSliceStartIndex..<lines.endIndex])
     }
 
-    let newNode = node.withStatements(
+    let newNode = node.with(
+      \.statements, 
       CodeBlockItemListSyntax(convertToCodeBlockItems(lines: formattedLines))
     )
     return newNode

--- a/Sources/SwiftFormatRules/ReplaceTrivia.swift
+++ b/Sources/SwiftFormatRules/ReplaceTrivia.swift
@@ -29,8 +29,8 @@ fileprivate final class ReplaceTrivia: SyntaxRewriter {
   override func visit(_ token: TokenSyntax) -> TokenSyntax {
     guard token == self.token else { return token }
     return token
-      .withLeadingTrivia(leadingTrivia ?? token.leadingTrivia)
-      .withTrailingTrivia(trailingTrivia ?? token.trailingTrivia)
+      .with(\.leadingTrivia, leadingTrivia ?? token.leadingTrivia)
+      .with(\.trailingTrivia, trailingTrivia ?? token.trailingTrivia)
   }
 }
 

--- a/Sources/SwiftFormatRules/ReturnVoidInsteadOfEmptyTuple.swift
+++ b/Sources/SwiftFormatRules/ReturnVoidInsteadOfEmptyTuple.swift
@@ -80,7 +80,7 @@ public final class ReturnVoidInsteadOfEmptyTuple: SyntaxFormatRule {
       input = node.input
     }
     let voidKeyword = makeVoidIdentifierType(toReplace: returnType)
-    return node.withInput(input).withOutput(output.withReturnType(TypeSyntax(voidKeyword)))
+    return node.with(\.input, input).with(\.output, output.with(\.returnType, TypeSyntax(voidKeyword)))
   }
 
   /// Returns a value indicating whether the leading trivia of the given token contained any

--- a/Sources/SwiftFormatRules/SemicolonSyntaxProtocol.swift
+++ b/Sources/SwiftFormatRules/SemicolonSyntaxProtocol.swift
@@ -14,8 +14,7 @@ import SwiftSyntax
 
 /// Protocol that declares support for accessing and modifying a token that represents a semicolon.
 protocol SemicolonSyntaxProtocol: SyntaxProtocol {
-  var semicolon: TokenSyntax? { get }
-  func withSemicolon(_ newSemicolon: TokenSyntax?) -> Self
+  var semicolon: TokenSyntax? { get set }
 }
 
 extension MemberDeclListItemSyntax: SemicolonSyntaxProtocol {}

--- a/Sources/SwiftFormatRules/TokenSyntax+Convenience.swift
+++ b/Sources/SwiftFormatRules/TokenSyntax+Convenience.swift
@@ -15,23 +15,23 @@ import SwiftSyntax
 extension TokenSyntax {
   /// Returns this token with only one space at the end of its trailing trivia.
   func withOneTrailingSpace() -> TokenSyntax {
-    return withTrailingTrivia(trailingTrivia.withOneTrailingSpace())
+    return with(\.trailingTrivia, trailingTrivia.withOneTrailingSpace())
   }
 
   /// Returns this token with only one space at the beginning of its leading
   /// trivia.
   func withOneLeadingSpace() -> TokenSyntax {
-    return withLeadingTrivia(leadingTrivia.withOneLeadingSpace())
+    return with(\.leadingTrivia, leadingTrivia.withOneLeadingSpace())
   }
 
   /// Returns this token with only one newline at the end of its leading trivia.
   func withOneTrailingNewline() -> TokenSyntax {
-    return withTrailingTrivia(trailingTrivia.withOneTrailingNewline())
+    return with(\.trailingTrivia, trailingTrivia.withOneTrailingNewline())
   }
 
   /// Returns this token with only one newline at the beginning of its leading
   /// trivia.
   func withOneLeadingNewline() -> TokenSyntax {
-    return withLeadingTrivia(leadingTrivia.withOneLeadingNewline())
+    return with(\.leadingTrivia, leadingTrivia.withOneLeadingNewline())
   }
 }

--- a/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
+++ b/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
@@ -93,8 +93,8 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
     // Even if we don't shorten this specific type that we're visiting, we may have rewritten
     // something in the generic argument list that we recursively visited, so return the original
     // node with that swapped out.
-    let result = node.withGenericArgumentClause(
-      genericArgumentClause.withArguments(genericArgumentList))
+    let result = node.with(\.genericArgumentClause, 
+      genericArgumentClause.with(\.arguments, genericArgumentList))
     return TypeSyntax(result)
   }
 
@@ -180,8 +180,8 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
     // Even if we don't shorten this specific expression that we're visiting, we may have
     // rewritten something in the generic argument list that we recursively visited, so return the
     // original node with that swapped out.
-    let result = node.withGenericArgumentClause(
-      node.genericArgumentClause.withArguments(genericArgumentList))
+    let result = node.with(\.genericArgumentClause, 
+      node.genericArgumentClause.with(\.arguments, genericArgumentList))
     return ExprSyntax(result)
   }
 

--- a/Sources/SwiftFormatRules/UseSingleLinePropertyGetter.swift
+++ b/Sources/SwiftFormatRules/UseSingleLinePropertyGetter.swift
@@ -37,7 +37,7 @@ public final class UseSingleLinePropertyGetter: SyntaxFormatRule {
     let newBlock = CodeBlockSyntax(
       leftBrace: accessorBlock.leftBrace, statements: body.statements,
       rightBrace: accessorBlock.rightBrace)
-    return node.withAccessor(.getter(newBlock))
+    return node.with(\.accessor, .getter(newBlock))
   }
 }
 

--- a/Sources/SwiftFormatRules/UseWhereClausesInForLoops.swift
+++ b/Sources/SwiftFormatRules/UseWhereClausesInForLoops.swift
@@ -111,8 +111,8 @@ fileprivate func updateWithWhereCondition(
   )
 
   // Replace the where clause and extract the body from the IfStmt.
-  let newBody = node.body.withStatements(statements)
-  return node.withWhereClause(whereClause).withBody(newBody)
+  let newBody = node.body.with(\.statements, statements)
+  return node.with(\.whereClause, whereClause).with(\.body, newBody)
 }
 
 extension Finding.Message {


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1253