### PR TITLE
Remove `--strict` option from LintPlugin so that it doesn't constantly crash.

### DIFF
--- a/Plugins/LintPlugin/plugin.swift
+++ b/Plugins/LintPlugin/plugin.swift
@@ -9,13 +9,15 @@ struct LintPlugin {
     var arguments: [String] = ["lint"]
     
     arguments.append(contentsOf: targetDirectories)
-    
-    arguments.append(contentsOf: ["--recursive", "--parallel", "--strict"])
+    arguments.append(contentsOf: ["--recursive", "--parallel"])
     
     if let configurationFilePath = configurationFilePath {
       arguments.append(contentsOf: ["--configuration", configurationFilePath])
     }
-    
+
+    // Make sure that we don't have `--strict` anywhere in the args as it causes non-0 exits.
+    arguments = arguments.filter { $0 != "--strict" }
+
     let process = try Process.run(swiftFormatExec, arguments: arguments)
     process.waitUntilExit()
     
@@ -44,7 +46,7 @@ extension LintPlugin: CommandPlugin {
     let configurationFilePath = argExtractor.extractOption(named: "configuration").first
     
     let sourceCodeTargets = targetsToFormat.compactMap { $0 as? SourceModuleTarget }
-    
+
     try lint(
       tool: swiftFormatTool,
       targetDirectories: sourceCodeTargets.map(\.directory.string),

--- a/Plugins/LintPlugin/plugin.swift
+++ b/Plugins/LintPlugin/plugin.swift
@@ -9,7 +9,6 @@ struct LintPlugin {
     var arguments: [String] = ["lint"]
     
     arguments.append(contentsOf: targetDirectories)
-    print(arguments)
     arguments.append(contentsOf: ["--recursive", "--parallel"])
     
     if let configurationFilePath = configurationFilePath {


### PR DESCRIPTION
The `LintPlugin` command plugin has default settings that include `--strict` in the arguments. This causes any lint run to exit with a 1 and report as an error.

I removed the default inclusion of `--strict` and added a filter to make sure that it isn't passed in a plugin run.

[No tests were added because SPM Plugin targets don't currently support tests](https://forums.swift.org/t/how-can-we-tests-spm-plugin/61279).