### PR TITLE
Update ArgumentParser dependency in `Package.swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -217,7 +217,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
       url: "https://github.com/apple/swift-argument-parser.git",
       // This should be kept in sync with the same dependency used by
       // swift-syntax.
-      Version("1.0.1")..<Version("1.2.0")
+      .upToNextMinor(from: "1.2.2")
     ),
     .package(
       url: "https://github.com/apple/swift-syntax.git",


### PR DESCRIPTION
Synchronized with https://github.com/apple/swift-syntax/pull/1408.

1.2.2 is the version of ArgumentParser used by the toolchain, according to the checkout config: https://github.com/apple/swift/blob/277674a642b058fe95c37e24d5c861c5b81b6a82/utils/update_checkout/update-checkout-config.json#L103

Sticking to the old versions like 1.0.x and 1.1.x has negative downstream effects, since tools using SwiftSyntax (like `swift-format`) are restricted to these versions too, which can easily conflict with other packages.

A more general solution could be to rely on SemVer and use `.upToNextMajor` instead of `.upToNextMinor`.