### PR TITLE
Adjustments to split `FunctionParameterSyntax` into multiple nodes for function parameters, closure parameters and enum parameters

### DIFF
--- a/Sources/SwiftFormat/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Pipelines+Generated.swift
@@ -55,6 +55,11 @@ class LintPipeline: SyntaxVisitor {
     return .visitChildren
   }
 
+  override func visit(_ node: ClosureParameterSyntax) -> SyntaxVisitorContinueKind {
+    visitIfEnabled(NoLeadingUnderscores.visit, for: node)
+    return .visitChildren
+  }
+
   override func visit(_ node: ClosureSignatureSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(AlwaysUseLowerCamelCase.visit, for: node)
     visitIfEnabled(ReturnVoidInsteadOfEmptyTuple.visit, for: node)
@@ -88,6 +93,11 @@ class LintPipeline: SyntaxVisitor {
 
   override func visit(_ node: EnumCaseElementSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(AlwaysUseLowerCamelCase.visit, for: node)
+    visitIfEnabled(NoLeadingUnderscores.visit, for: node)
+    return .visitChildren
+  }
+
+  override func visit(_ node: EnumCaseParameterSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
     return .visitChildren
   }

--- a/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
+++ b/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
@@ -73,12 +73,30 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
           diagnoseLowerCamelCaseViolations(
             param.name, allowUnderscores: false, description: identifierDescription(for: node))
         }
-      } else if let parameterClause = input.as(ParameterClauseSyntax.self) {
+      } else if let parameterClause = input.as(ClosureParameterClauseSyntax.self) {
+        for param in parameterClause.parameterList {
+          diagnoseLowerCamelCaseViolations(
+            param.firstName, allowUnderscores: false, description: identifierDescription(for: node))
+          if let secondName = param.secondName {
+            diagnoseLowerCamelCaseViolations(
+              secondName, allowUnderscores: false, description: identifierDescription(for: node))
+          }
+        }
+      } else if let parameterClause = input.as(EnumCaseParameterClauseSyntax.self) {
         for param in parameterClause.parameterList {
           if let firstName = param.firstName {
             diagnoseLowerCamelCaseViolations(
               firstName, allowUnderscores: false, description: identifierDescription(for: node))
           }
+          if let secondName = param.secondName {
+            diagnoseLowerCamelCaseViolations(
+              secondName, allowUnderscores: false, description: identifierDescription(for: node))
+          }
+        }
+      } else if let parameterClause = input.as(ParameterClauseSyntax.self) {
+        for param in parameterClause.parameterList {
+          diagnoseLowerCamelCaseViolations(
+            param.firstName, allowUnderscores: false, description: identifierDescription(for: node))
           if let secondName = param.secondName {
             diagnoseLowerCamelCaseViolations(
               secondName, allowUnderscores: false, description: identifierDescription(for: node))
@@ -106,10 +124,8 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
     for param in node.signature.input.parameterList {
       // These identifiers aren't described using `identifierDescription(for:)` because no single
       // node can disambiguate the argument label from the parameter name.
-      if let label = param.firstName {
-        diagnoseLowerCamelCaseViolations(
-          label, allowUnderscores: false, description: "argument label")
-      }
+      diagnoseLowerCamelCaseViolations(
+        param.firstName, allowUnderscores: false, description: "argument label")
       if let paramName = param.secondName {
         diagnoseLowerCamelCaseViolations(
           paramName, allowUnderscores: false, description: "function parameter")

--- a/Sources/SwiftFormatRules/AmbiguousTrailingClosureOverload.swift
+++ b/Sources/SwiftFormatRules/AmbiguousTrailingClosureOverload.swift
@@ -41,7 +41,7 @@ public final class AmbiguousTrailingClosureOverload: SyntaxLintRule {
     for fn in functions {
       let params = fn.signature.input.parameterList
       guard let firstParam = params.firstAndOnly else { continue }
-      guard let type = firstParam.type, type.is(FunctionTypeSyntax.self) else { continue }
+      guard firstParam.type.is(FunctionTypeSyntax.self) else { continue }
       if let mods = fn.modifiers, mods.has(modifier: "static") || mods.has(modifier: "class") {
         staticOverloads[fn.identifier.text, default: []].append(fn)
       } else {

--- a/Sources/SwiftFormatRules/FunctionDeclSyntax+Convenience.swift
+++ b/Sources/SwiftFormatRules/FunctionDeclSyntax+Convenience.swift
@@ -16,7 +16,7 @@ extension FunctionDeclSyntax {
   /// Constructs a name for a function that includes parameter labels, i.e. `foo(_:bar:)`.
   var fullDeclName: String {
     let params = signature.input.parameterList.map { param in
-      "\(param.firstName?.text ?? "_"):"
+      "\(param.firstName.text):"
     }
     return "\(identifier.text)(\(params.joined()))"
   }

--- a/Sources/SwiftFormatRules/NoLeadingUnderscores.swift
+++ b/Sources/SwiftFormatRules/NoLeadingUnderscores.swift
@@ -56,13 +56,29 @@ public final class NoLeadingUnderscores: SyntaxLintRule {
     return .visitChildren
   }
 
-  public override func visit(_ node: FunctionParameterSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: ClosureParameterSyntax) -> SyntaxVisitorContinueKind {
+    // If both names are provided, we want to check `secondName`, which will be the parameter name
+    // (in that case, `firstName` is the label). If only one name is present, then it is recorded in
+    // `firstName`, and it is both the label and the parameter name.
+    diagnoseIfNameStartsWithUnderscore(node.secondName ?? node.firstName)
+    return .visitChildren
+  }
+
+  public override func visit(_ node: EnumCaseParameterSyntax) -> SyntaxVisitorContinueKind {
     // If both names are provided, we want to check `secondName`, which will be the parameter name
     // (in that case, `firstName` is the label). If only one name is present, then it is recorded in
     // `firstName`, and it is both the label and the parameter name.
     if let variableIdentifier = node.secondName ?? node.firstName {
       diagnoseIfNameStartsWithUnderscore(variableIdentifier)
     }
+    return .visitChildren
+  }
+
+  public override func visit(_ node: FunctionParameterSyntax) -> SyntaxVisitorContinueKind {
+    // If both names are provided, we want to check `secondName`, which will be the parameter name
+    // (in that case, `firstName` is the label). If only one name is present, then it is recorded in
+    // `firstName`, and it is both the label and the parameter name.
+    diagnoseIfNameStartsWithUnderscore(node.secondName ?? node.firstName)
     return .visitChildren
   }
 

--- a/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
+++ b/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
@@ -106,8 +106,7 @@ public final class UseSynthesizedInitializer: SyntaxLintRule {
     guard parameters.count == properties.count else { return false }
     for (idx, parameter) in parameters.enumerated() {
 
-      guard let paramId = parameter.firstName, parameter.secondName == nil else { return false }
-      guard let paramType = parameter.type else { return false }
+      guard parameter.secondName == nil else { return false }
 
       let property = properties[idx]
       let propertyId = property.firstIdentifier
@@ -124,9 +123,9 @@ public final class UseSynthesizedInitializer: SyntaxLintRule {
         return false
       }
 
-      if propertyId.identifier.text != paramId.text
+      if propertyId.identifier.text != parameter.firstName.text
         || propertyType.description.trimmingCharacters(
-          in: .whitespaces) != paramType.description.trimmingCharacters(in: .whitespacesAndNewlines)
+          in: .whitespaces) != parameter.type.description.trimmingCharacters(in: .whitespacesAndNewlines)
       { return false }
     }
     return true

--- a/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
@@ -139,9 +139,7 @@ fileprivate func funcParametersIdentifiers(in paramList: FunctionParameterListSy
     // If there is a label and an identifier, then the identifier (`secondName`) is the name that
     // should be documented. Otherwise, the label and identifier are the same, occupying
     // `firstName`.
-    guard let parameterIdentifier = parameter.secondName ?? parameter.firstName else {
-      continue
-    }
+    let parameterIdentifier = parameter.secondName ?? parameter.firstName
     funcParameters.append(parameterIdentifier.text)
   }
   return funcParameters

--- a/Sources/generate-pipeline/RuleCollector.swift
+++ b/Sources/generate-pipeline/RuleCollector.swift
@@ -126,7 +126,7 @@ final class RuleCollector {
         guard let function = member.decl.as(FunctionDeclSyntax.self) else { continue }
         guard function.identifier.text == "visit" else { continue }
         let params = function.signature.input.parameterList
-        guard let firstType = params.firstAndOnly?.type?.as(SimpleTypeIdentifierSyntax.self) else {
+        guard let firstType = params.firstAndOnly?.type.as(SimpleTypeIdentifierSyntax.self) else {
           continue
         }
         visitedNodes.append(firstType.name.text)


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1455