### PR TITLE
Fix pretty printing of multi-statement closures (issue #494)

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1073,7 +1073,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
   override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
     let newlineBehavior: NewlineBehavior
-    if forcedBreakingClosures.remove(node.id) != nil {
+    if forcedBreakingClosures.remove(node.id) != nil || node.statements.count > 1 {
       newlineBehavior = .soft
     } else {
       newlineBehavior = .elective

--- a/Tests/SwiftFormatPrettyPrintTests/ClosureExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ClosureExprTests.swift
@@ -516,4 +516,24 @@ final class ClosureExprTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
   }
+
+  func testClosureWithSignatureAndMultipleStatements() {
+    let input =
+      """
+      { a in a + 1
+        a + 2
+      }
+      """
+
+    let expected =
+      """
+      { a in
+        a + 1
+        a + 2
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
+  }
 }


### PR DESCRIPTION
Issue #494 is related to pretty printing of multi-statement closures, and can be reproduced on `main` by formatting the following input:

```swift
{ a in a + 1
  a + 2
}
```

The pretty printer just spits out the snippet as is. This is because the first break is made elective instead of soft. Note that the closure is formatted correctly if `a in` is removed.

The fix that I propose (and have implemented) is forcing the break before the first statement to be `soft` if the closure contains multiple statements. I believe this is reasonable because there is no situation that I know of where Swift Format should format a multi-statement closure as a single-line closure (`{ a + 1; a + 2 }` is pretty un-idiomatic).

I have added a test for this change that fails on main and succeeds after my change.

This is my first contribution to Swift Format, so please let me know if there's anything I should change about this PR or future PRs (e.g. test style).