### PR TITLE
Fix fatal error caused by switch cases without any statements (#473)

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/SwitchStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/SwitchStmtTests.swift
@@ -78,6 +78,43 @@ final class SwitchStmtTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 35)
   }
 
+  func testSwitchEmptyCases() {
+    let input =
+      """
+      switch a {
+      case b:
+      default:
+        print("Not b")
+      }
+
+      switch a {
+      case b:
+        // Comment but no statements
+      default:
+        print("Not b")
+      }
+      """
+
+    let expected =
+      """
+      switch a {
+      case b:
+      default:
+        print("Not b")
+      }
+
+      switch a {
+      case b:
+        // Comment but no statements
+      default:
+        print("Not b")
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 35)
+  }
+
   func testSwitchCompoundCases() {
     let input =
       """


### PR DESCRIPTION
The issue can be reproduced on main by formatting the following snippet:

```swift
switch x {
case y:
default:
  print("hi")
}
```

The code isn't valid Swift of course, however it shouldn't cause a fatal error, and in my opinion it shouldn't prevent formatting of the code (because intent is clear). However, I'm not sure of the official position of this project on how invalid code should be handled.

Note that adding a comment in the `y` case doesn't effect whether a fatal error occurs.

I have added a test that covers formatting of empty cases and after my relatively minimal (and commented) changes it no longer crashes. The issue occurred because in the situation where a case is empty, the opening break and `open` token are added after the same syntax token as the closing break and `close` token. These two sets of tokens are added one after another, and because of the implementation of `after`, the two sets end up getting swapped when constructing the token stream. Thus, the closing break and `close` token end up preceding the opening break and `open` token causing the fatal error.