### PR TITLE
[5.9] Update to non-optional leading/trailingTrivia swift-syntax API

### DIFF
--- a/Sources/SwiftFormatCore/SyntaxProtocol+Convenience.swift
+++ b/Sources/SwiftFormatCore/SyntaxProtocol+Convenience.swift
@@ -25,7 +25,6 @@ extension SyntaxProtocol {
   ///   be returned.
   /// - Returns: The absolute position of the trivia piece.
   public func position(ofLeadingTriviaAt index: Trivia.Index) -> AbsolutePosition {
-    let leadingTrivia = self.leadingTrivia ?? []
     guard leadingTrivia.indices.contains(index) else {
       preconditionFailure("Index was out of bounds in the node's leading trivia.")
     }

--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -876,7 +876,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     // The node's content is either a `DictionaryElementListSyntax` or a `TokenSyntax` for a colon
     // token (for an empty dictionary).
     if !(node.content.as(DictionaryElementListSyntax.self)?.isEmpty ?? true)
-      || node.content.leadingTrivia?.numberOfComments ?? 0 > 0
+      || node.content.leadingTrivia.numberOfComments > 0
       || node.rightSquare.leadingTrivia.numberOfComments > 0
     {
       after(node.leftSquare, tokens: .break(.open, size: 0), .open)
@@ -2161,7 +2161,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       appendToken(.syntax(segmentText))
     }
 
-    if node.trailingTrivia?.containsBackslashes == true {
+    if node.trailingTrivia.containsBackslashes {
       // Segments with trailing backslashes won't end with a literal newline; the backslash is
       // considered trivia. To preserve the original text and wrapping, we need to manually render
       // the backslash and a break into the token stream.

--- a/Sources/SwiftFormatRules/NoAssignmentInExpressions.swift
+++ b/Sources/SwiftFormatRules/NoAssignmentInExpressions.swift
@@ -60,7 +60,7 @@ public final class NoAssignmentInExpressions: SyntaxFormatRule {
             semicolon: nil
           )
           .with(\.leadingTrivia, 
-            (returnStmt.leadingTrivia ?? []) + (assignmentExpr.leadingTrivia ?? []))
+            (returnStmt.leadingTrivia) + (assignmentExpr.leadingTrivia))
           .with(\.trailingTrivia, []))
         newItems.append(
           CodeBlockItemSyntax(
@@ -68,7 +68,7 @@ public final class NoAssignmentInExpressions: SyntaxFormatRule {
             semicolon: nil
           )
           .with(\.leadingTrivia, [.newlines(1)])
-          .with(\.trailingTrivia, returnStmt.trailingTrivia?.withoutLeadingSpaces() ?? []))
+          .with(\.trailingTrivia, returnStmt.trailingTrivia.withoutLeadingSpaces()))
 
       default:
         newItems.append(newItem)

--- a/Sources/SwiftFormatRules/NoCasesWithOnlyFallthrough.swift
+++ b/Sources/SwiftFormatRules/NoCasesWithOnlyFallthrough.swift
@@ -139,13 +139,11 @@ public final class NoCasesWithOnlyFallthrough: SyntaxFormatRule {
     }
 
     // Check for any comments that are adjacent to the case or fallthrough statement.
-    if let leadingTrivia = switchCase.leadingTrivia,
-      leadingTrivia.drop(while: { !$0.isNewline }).contains(where: { $0.isComment })
+    if switchCase.leadingTrivia.drop(while: { !$0.isNewline }).contains(where: { $0.isComment })
     {
       return false
     }
-    if let leadingTrivia = onlyStatement.leadingTrivia,
-      leadingTrivia.drop(while: { !$0.isNewline }).contains(where: { $0.isComment })
+    if onlyStatement.leadingTrivia.drop(while: { !$0.isNewline }).contains(where: { $0.isComment })
     {
       return false
     }
@@ -194,13 +192,7 @@ public final class NoCasesWithOnlyFallthrough: SyntaxFormatRule {
 
     // Only the first violation case can have displaced trivia, because any non-whitespace
     // trivia in the other violation cases would've prevented collapsing.
-    if let displacedLeadingTrivia = cases.first!.leadingTrivia?.withoutLastLine() {
-      let existingLeadingTrivia = newCase.leadingTrivia ?? []
-      let mergedLeadingTrivia = displacedLeadingTrivia + existingLeadingTrivia
-      return newCase.with(\.leadingTrivia, mergedLeadingTrivia)
-    } else {
-      return newCase
-    }
+    return newCase.with(\.leadingTrivia, cases.first!.leadingTrivia.withoutLastLine() + newCase.leadingTrivia)
   }
 }
 

--- a/Sources/SwiftFormatRules/OrderedImports.swift
+++ b/Sources/SwiftFormatRules/OrderedImports.swift
@@ -298,23 +298,20 @@ fileprivate func generateLines(codeBlockItemList: CodeBlockItemListSyntax, conte
   }
 
   for block in codeBlockItemList {
+    afterNewline = false
 
-    if let leadingTrivia = block.leadingTrivia {
-      afterNewline = false
-
-      for piece in leadingTrivia {
-        switch piece {
-        // Create new Line objects when we encounter newlines.
-        case .newlines(let N):
-          for _ in 0..<N {
-            appendNewLine()
-          }
-        default:
-          if afterNewline || isFirstBlock {
-            currentLine.leadingTrivia.append(piece)  // This will be a standalone comment.
-          } else {
-            currentLine.trailingTrivia.append(piece)  // This will be a trailing line comment.
-          }
+    for piece in block.leadingTrivia {
+      switch piece {
+      // Create new Line objects when we encounter newlines.
+      case .newlines(let N):
+        for _ in 0..<N {
+          appendNewLine()
+        }
+      default:
+        if afterNewline || isFirstBlock {
+          currentLine.leadingTrivia.append(piece)  // This will be a standalone comment.
+        } else {
+          currentLine.trailingTrivia.append(piece)  // This will be a trailing line comment.
         }
       }
     }
@@ -491,8 +488,7 @@ fileprivate class Line {
     // description includes all leading and trailing trivia. It would be unusual to have any
     // non-whitespace trivia on the components of the import. Trim off the leading trivia, where
     // comments could be, and trim whitespace that might be after the import.
-    let leadingText = importDecl.leadingTrivia?.reduce(into: "") { $1.write(to: &$0) } ?? ""
-    return importDecl.description.dropFirst(leadingText.count)
+    return importDecl.with(\.leadingTrivia, []).description
       .trimmingCharacters(in: .whitespacesAndNewlines)
   }
 

--- a/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
+++ b/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
@@ -338,7 +338,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
         elementList: tupleExprElementList,
         rightParen: TokenSyntax.rightParenToken())
       wrappedTypeExpr = ExprSyntax(tupleExpr)
-    } else if let leadingTrivia = leadingTrivia {
+    } else {
       // Otherwise, the argument type can safely become an optional by simply appending a "?". If
       // we were given leading trivia from another node (for example, from `Optional` when
       // converting a long-form to short-form), we need to transfer it over. By doing so, something

--- a/Sources/SwiftFormatRules/UseTripleSlashForDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/UseTripleSlashForDocumentationComments.swift
@@ -73,13 +73,13 @@ public final class UseTripleSlashForDocumentationComments: SyntaxFormatRule {
   /// a docLineComment.
   private func convertDocBlockCommentToDocLineComment(_ decl: DeclSyntax) -> DeclSyntax {
     guard let commentText = decl.docComment else { return decl }
-    guard let declLeadingTrivia = decl.leadingTrivia else { return decl }
+
     let docComments = commentText.components(separatedBy: "\n")
     var pieces = [TriviaPiece]()
 
     // Ensures the documentation comment is a docLineComment.
     var hasFoundDocComment = false
-    for piece in declLeadingTrivia.reversed() {
+    for piece in decl.leadingTrivia.reversed() {
       if case .docBlockComment(_) = piece, !hasFoundDocComment {
         hasFoundDocComment = true
         diagnose(.avoidDocBlockComment, on: decl)


### PR DESCRIPTION
* Explanation: Corresponding swift-format change to update its leading/trailingTrivia API uses after swift-syntax updated to return empty rather than optional (https://github.com/apple/swift-syntax/pull/1477)
* Scope: Various formatting rules
* Risk: Extremely low, uses generally created an empty `Trivia` anyway 
* Testing: Existing tests cover this API change
* Original PR: https://github.com/apple/swift-format/pull/497

