### PR TITLE
Fix formatting of import with multiple attributes (fixes #445) and ensure that imports never wrap

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/Token.swift
+++ b/Sources/SwiftFormatPrettyPrint/Token.swift
@@ -162,8 +162,10 @@ enum PrinterControlKind {
   /// control token is encountered.
   ///
   /// It's valid to nest `disableBreaking` and `enableBreaking` tokens. Breaks will be suppressed
-  /// long as there is at least 1 unmatched disable token.
-  case disableBreaking
+  /// long as there is at least 1 unmatched disable token. If `allowDiscretionary` is `true`, then
+  /// discretionary breaks aren't effected. An `allowDiscretionary` value of true never overrides a
+  /// value of false. Hard breaks are always inserted no matter what.
+  case disableBreaking(allowDiscretionary: Bool)
 
   /// A signal that break tokens should be allowed to fire following this token, as long as there
   /// are no other unmatched disable tokens.

--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1339,7 +1339,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
         ]
       )
     } else if let condition = node.condition {
-      before(condition.firstToken, tokens: .printerControl(kind: .disableBreaking))
+      before(condition.firstToken, tokens: .printerControl(kind: .disableBreaking(allowDiscretionary: true)))
       after(
         condition.lastToken,
         tokens: .printerControl(kind: .enableBreaking), .break(.reset, size: 0))
@@ -1668,9 +1668,14 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: ImportDeclSyntax) -> SyntaxVisitorContinueKind {
-    after(node.attributes?.lastToken, tokens: .space)
+    // Import declarations should never be wrapped.
+    before(node.firstToken, tokens: .printerControl(kind: .disableBreaking(allowDiscretionary: false)))
+
+    arrangeAttributeList(node.attributes)
     after(node.importTok, tokens: .space)
     after(node.importKind, tokens: .space)
+
+    after(node.lastToken, tokens: .printerControl(kind: .enableBreaking))
     return .visitChildren
   }
 

--- a/Tests/SwiftFormatPrettyPrintTests/ImportTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ImportTests.swift
@@ -7,6 +7,12 @@ final class ImportTests: PrettyPrintTestCase {
       import class MyModule.MyClass
       import struct MyModule.MyStruct
       @testable import testModule
+
+      @_spi(
+        STP
+      )
+      @testable
+      import testModule
       """
 
     let expected =
@@ -16,6 +22,8 @@ final class ImportTests: PrettyPrintTestCase {
       import class MyModule.MyClass
       import struct MyModule.MyStruct
       @testable import testModule
+
+      @_spi(STP) @testable import testModule
 
       """
 


### PR DESCRIPTION
#445 occurs because Swift Format simply just adds a space after the attribute list of import statements. `arrangeAttributeList` can be reused to correctly format the attributes of an import. However, when modifying the test for imports to include an import decl with multiple attributes, I found that attributes with arguments (e.g. `@_spi(STP)`) get wrapped when the import decl exceeds the line length. The comment included with the existing tests says that import decls shouldn't wrap (and I take this to also mean that discretionary breaks should be removed if present). Thus, I have made additional changes to ensure that import statements never wrap in any situation, please correct me if this is not the desired behaviour.

To achieve this  behaviour (see snippet below), I had to modify the `disableBreaking` printer control to be able to configure whether discretionary breaks should be allowed when breaks are suppressed (currently they are, but for the case of import decls this needs to be overridden to ensure that imports never wrap).

```swift
// Input
@_spi(
  STP
)
@testable
import testModule

// Output
@_spi(STP) @testable import testModule
```

I can see people wanting to be able to write code that wraps between attributes (as is sometimes done with `@resultBuilder` on struct decls, or property wrappers). Should this be made configurable, or is it bad style?

I also fixed the typo of `isBreakingSupressed` (to `isBreakingSuppressed`) because it was only used in 3 places or so, which imo makes a merge conflict very unlikely. I'm happy to revert that if requested.