### PR TITLE
Avoid removing certain disambiguating parens from conditions (fixes #298)

### DIFF
--- a/Sources/SwiftFormatRules/NoParensAroundConditions.swift
+++ b/Sources/SwiftFormatRules/NoParensAroundConditions.swift
@@ -30,10 +30,16 @@ public final class NoParensAroundConditions: SyntaxFormatRule {
     assert(tuple.elementList.count == 1)
     let expr = tuple.elementList.first!.expression
 
-    // If the condition is a function with a trailing closure, removing the
-    // outer set of parentheses introduces a parse ambiguity.
-    if let fnCall = expr.as(FunctionCallExprSyntax.self), fnCall.trailingClosure != nil {
-      return ExprSyntax(tuple)
+    // If the condition is a function with a trailing closure or if it's an immediately called
+    // closure, removing the outer set of parentheses introduces a parse ambiguity.
+    if let fnCall = expr.as(FunctionCallExprSyntax.self) {
+      if fnCall.trailingClosure != nil {
+        // Leave parentheses around call with trailing closure.
+        return ExprSyntax(tuple)
+      } else if fnCall.calledExpression.as(ClosureExprSyntax.self) != nil {
+        // Leave parentheses around immediately called closure.
+        return ExprSyntax(tuple)
+      }
     }
 
     diagnose(.removeParensAroundExpression, on: expr)

--- a/Tests/SwiftFormatRulesTests/NoParensAroundConditionsTests.swift
+++ b/Tests/SwiftFormatRulesTests/NoParensAroundConditionsTests.swift
@@ -160,4 +160,17 @@ final class NoParensAroundConditionsTests: LintOrFormatRuleTestCase {
                 }
                 """)
   }
+
+  func testParensAroundAmbiguousConditions() {
+    XCTAssertFormatting(
+      NoParensAroundConditions.self,
+      input: """
+             if ({ true }()) {}
+             if (functionWithTrailingClosure { 5 }) {}
+             """,
+      expected: """
+                if ({ true }()) {}
+                if (functionWithTrailingClosure { 5 }) {}
+                """)
+  }
 }


### PR DESCRIPTION
Essentially, after formatting the correct code in the snippet below, you end up with invalid Swift code (because of the parsing ambiguity introduced).

```swift
// Input
if ({ true }()) {}

// Output (fails to compile)
if { true }() {}
```

My fix adds another early exit condition (to the `NoParensAroundConditions` rule) that checks if the enclosed expression is a call to a closure expression. I have added a test for this new behaviour, and in doing so I found that there wasn't a test for the (already implemented) ambiguity check; so I added that to the test too.

## Tl;dr

Merging this PR would fix the exact issue raised in #298. However, I have found that the existing ambiguity check (pre-PR) for trailing closures in conditions is purely cosmetic (and incomplete) in current Swift. Thus, I think the check for disambiguating parens should be reworked to work like so:

If a condition contains any trailing closures or immediately called closures that aren't otherwise enclosed within `()`, `[]`, or `{}` (visually), the condition requires disambiguating parens around the whole thing. It is pretty conservative, but it's guaranteed to always be correct both in terms of compilation and visual disambiguation (as long as there aren't more patterns that could be ambiguous such as if/switch expressions).

I'd love to hear your opinions on this solution.

## Caveats and complications

Although this PR fixes the issue in the most simple case, I have still managed to find some more obscure snippets that have a similar issue (which aren't fixed by this PR). A more complex recursive check would have to be implemented to fix these ambiguities, I discuss this more in the next section.

```swift
if ({ true }() && true) { print("true") }
if ({ true }() || true) { print("true") }
// etc.
```

My instinct is that if the left-most expression is an immediately called closure, parentheses are required, and otherwise they aren't (in terms of compilation). If you add a `!` operator before an ambiguous called closure, the compiler successfully parses the code with or without parentheses.

## Visual disambiguation parentheses (not required for correct parsing)

Interestingly, the existing check (pre-PR) for cases such as `if (f(1) { false }) { print("hi") }` is purely cosmetic in current Swift (it successfully compiles with or without parentheses around the condition). This begs the question, should parentheses also be left in in any of the following cases where they aren't strictly required for compilation?

```swift
if (true && f(1) { true }) {} // probably
if (f(1) { true } && true) {} // maybe?
if (!f(1) { true }) {} // the `!` makes the rule remove the parens, but it probably shouldn't
```

I believe that to truly fix this issue, we should implement a new (and probably recursive) heuristic for identifying when parens are required; which will require more clearly deciding what we count as ambiguous to humans (not just the compiler). However, these concerns are purely cosmetic and probably a separate issue, it'd be good to merge this fix before doing that because this fix is actually a functional issue not just a matter of preference. See the tldr for my proposed solution.