### PR TITLE
Remove usages of functions that shouldn’t be part of SwiftSyntax’s public API

### DIFF
--- a/Sources/SwiftFormatRules/FileScopedDeclarationPrivacy.swift
+++ b/Sources/SwiftFormatRules/FileScopedDeclarationPrivacy.swift
@@ -161,7 +161,7 @@ public final class FileScopedDeclarationPrivacy: SyntaxFormatRule {
       let name = modifier.name
       if name.tokenKind == invalidAccess {
         diagnose(diagnostic, on: name)
-        return modifier.with(\.name, name.withKind(validAccess))
+        return modifier.with(\.name, name.with(\.tokenKind, validAccess))
       }
       return modifier
     }

--- a/Sources/SwiftFormatRules/ModifierListSyntax+Convenience.swift
+++ b/Sources/SwiftFormatRules/ModifierListSyntax+Convenience.swift
@@ -38,9 +38,9 @@ extension ModifierListSyntax {
   /// Returns modifier list without the given modifier.
   func remove(name: String) -> ModifierListSyntax {
     guard has(modifier: name) else { return self }
-    for mod in self {
+    for (index, mod) in self.enumerated() {
       if mod.name.text == name {
-        return removing(childAt: mod.indexInParent)
+        return removing(childAt: index)
       }
     }
     return self

--- a/Sources/SwiftFormatRules/NoAccessLevelOnExtensionDeclaration.swift
+++ b/Sources/SwiftFormatRules/NoAccessLevelOnExtensionDeclaration.swift
@@ -39,7 +39,7 @@ public final class NoAccessLevelOnExtensionDeclaration: SyntaxFormatRule {
       let accessKeywordToAdd: DeclModifierSyntax
       if keywordKind == .keyword(.private) {
         accessKeywordToAdd
-          = accessKeyword.with(\.name, accessKeyword.name.withKind(.keyword(.fileprivate)))
+          = accessKeyword.with(\.name, accessKeyword.name.with(\.tokenKind, .keyword(.fileprivate)))
       } else {
         accessKeywordToAdd = accessKeyword
       }


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1482