### PR TITLE
Adjustment for SwiftSyntax rename `members` -> `memberBlock`

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -162,7 +162,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       genericParameterOrPrimaryAssociatedTypeClause: node.genericParameterClause.map(Syntax.init),
       inheritanceClause: node.inheritanceClause,
       genericWhereClause: node.genericWhereClause,
-      members: node.members)
+      memberBlock: node.memberBlock)
     return .visitChildren
   }
 
@@ -176,7 +176,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       genericParameterOrPrimaryAssociatedTypeClause: node.genericParameterClause.map(Syntax.init),
       inheritanceClause: node.inheritanceClause,
       genericWhereClause: node.genericWhereClause,
-      members: node.members)
+      memberBlock: node.memberBlock)
     return .visitChildren
   }
 
@@ -190,7 +190,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       genericParameterOrPrimaryAssociatedTypeClause: node.genericParameterClause.map(Syntax.init),
       inheritanceClause: node.inheritanceClause,
       genericWhereClause: node.genericWhereClause,
-      members: node.members)
+      memberBlock: node.memberBlock)
     return .visitChildren
   }
 
@@ -204,7 +204,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       genericParameterOrPrimaryAssociatedTypeClause: node.genericParameters.map(Syntax.init),
       inheritanceClause: node.inheritanceClause,
       genericWhereClause: node.genericWhereClause,
-      members: node.members)
+      memberBlock: node.memberBlock)
     return .visitChildren
   }
 
@@ -219,7 +219,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
         node.primaryAssociatedTypeClause.map(Syntax.init),
       inheritanceClause: node.inheritanceClause,
       genericWhereClause: node.genericWhereClause,
-      members: node.members)
+      memberBlock: node.memberBlock)
     return .visitChildren
   }
 
@@ -236,7 +236,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       genericParameterOrPrimaryAssociatedTypeClause: nil,
       inheritanceClause: node.inheritanceClause,
       genericWhereClause: node.genericWhereClause,
-      members: node.members)
+      memberBlock: node.memberBlock)
     return .visitChildren
   }
 
@@ -251,7 +251,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     genericParameterOrPrimaryAssociatedTypeClause: Syntax?,
     inheritanceClause: TypeInheritanceClauseSyntax?,
     genericWhereClause: GenericWhereClauseSyntax?,
-    members: MemberDeclBlockSyntax
+    memberBlock: MemberDeclBlockSyntax
   ) {
     before(node.firstToken(viewMode: .sourceAccurate), tokens: .open)
 
@@ -263,11 +263,11 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     before(firstTokenAfterAttributes, tokens: .open)
     after(typeKeyword, tokens: .break)
 
-    arrangeBracesAndContents(of: members, contentsKeyPath: \.members)
+    arrangeBracesAndContents(of: memberBlock, contentsKeyPath: \.members)
 
     if let genericWhereClause = genericWhereClause {
       before(genericWhereClause.firstToken(viewMode: .sourceAccurate), tokens: .break(.same), .open)
-      after(members.leftBrace, tokens: .close)
+      after(memberBlock.leftBrace, tokens: .close)
     }
 
     let lastTokenBeforeBrace = inheritanceClause?.colon

--- a/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
+++ b/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
@@ -31,7 +31,7 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
   public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
     guard context.importsXCTest == .importsXCTest else { return .visitChildren }
 
-    collectTestMethods(from: node.members.members, into: &testCaseFuncs)
+    collectTestMethods(from: node.memberBlock.members, into: &testCaseFuncs)
     return .visitChildren
   }
 

--- a/Sources/SwiftFormatRules/DontRepeatTypeInStaticProperties.swift
+++ b/Sources/SwiftFormatRules/DontRepeatTypeInStaticProperties.swift
@@ -23,27 +23,27 @@ import SwiftSyntax
 public final class DontRepeatTypeInStaticProperties: SyntaxLintRule {
 
   public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseStaticMembers(node.members.members, endingWith: node.identifier.text)
+    diagnoseStaticMembers(node.memberBlock.members, endingWith: node.identifier.text)
     return .skipChildren
   }
 
   public override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseStaticMembers(node.members.members, endingWith: node.identifier.text)
+    diagnoseStaticMembers(node.memberBlock.members, endingWith: node.identifier.text)
     return .skipChildren
   }
 
   public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseStaticMembers(node.members.members, endingWith: node.identifier.text)
+    diagnoseStaticMembers(node.memberBlock.members, endingWith: node.identifier.text)
     return .skipChildren
   }
 
   public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseStaticMembers(node.members.members, endingWith: node.identifier.text)
+    diagnoseStaticMembers(node.memberBlock.members, endingWith: node.identifier.text)
     return .skipChildren
   }
 
   public override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
-    let members = node.members.members
+    let members = node.memberBlock.members
 
     switch Syntax(node.extendedType).as(SyntaxEnum.self) {
     case .simpleTypeIdentifier(let simpleType):

--- a/Sources/SwiftFormatRules/FullyIndirectEnum.swift
+++ b/Sources/SwiftFormatRules/FullyIndirectEnum.swift
@@ -23,7 +23,7 @@ import SwiftSyntax
 public final class FullyIndirectEnum: SyntaxFormatRule {
 
   public override func visit(_ node: EnumDeclSyntax) -> DeclSyntax {
-    let enumMembers = node.members.members
+    let enumMembers = node.memberBlock.members
     guard let enumModifiers = node.modifiers,
       !enumModifiers.has(modifier: "indirect"),
       allCasesAreIndirect(in: enumMembers)
@@ -70,8 +70,8 @@ public final class FullyIndirectEnum: SyntaxFormatRule {
       name: TokenSyntax.identifier(
         "indirect", leadingTrivia: leadingTrivia, trailingTrivia: .spaces(1)), detail: nil)
 
-    let newMemberBlock = node.members.with(\.members, MemberDeclListSyntax(newMembers))
-    return DeclSyntax(newEnumDecl.addModifier(newModifier).with(\.members, newMemberBlock))
+    let newMemberBlock = node.memberBlock.with(\.members, MemberDeclListSyntax(newMembers))
+    return DeclSyntax(newEnumDecl.addModifier(newModifier).with(\.memberBlock, newMemberBlock))
   }
 
   /// Returns a value indicating whether all enum cases in the given list are indirect.

--- a/Sources/SwiftFormatRules/NoAccessLevelOnExtensionDeclaration.swift
+++ b/Sources/SwiftFormatRules/NoAccessLevelOnExtensionDeclaration.swift
@@ -45,14 +45,14 @@ public final class NoAccessLevelOnExtensionDeclaration: SyntaxFormatRule {
       }
 
       let newMembers = MemberDeclBlockSyntax(
-        leftBrace: node.members.leftBrace,
-        members: addMemberAccessKeywords(memDeclBlock: node.members, keyword: accessKeywordToAdd),
-        rightBrace: node.members.rightBrace)
+        leftBrace: node.memberBlock.leftBrace,
+        members: addMemberAccessKeywords(memDeclBlock: node.memberBlock, keyword: accessKeywordToAdd),
+        rightBrace: node.memberBlock.rightBrace)
       let newKeyword = replaceTrivia(
         on: node.extensionKeyword,
         token: node.extensionKeyword,
         leadingTrivia: accessKeyword.leadingTrivia)
-      let result = node.with(\.members, newMembers)
+      let result = node.with(\.memberBlock, newMembers)
         .with(\.modifiers, modifiers.remove(name: accessKeyword.name.text))
         .with(\.extensionKeyword, newKeyword)
       return DeclSyntax(result)

--- a/Sources/SwiftFormatRules/OneCasePerLine.swift
+++ b/Sources/SwiftFormatRules/OneCasePerLine.swift
@@ -87,7 +87,7 @@ public final class OneCasePerLine: SyntaxFormatRule {
   public override func visit(_ node: EnumDeclSyntax) -> DeclSyntax {
     var newMembers: [MemberDeclListItemSyntax] = []
 
-    for member in node.members.members {
+    for member in node.memberBlock.members {
       // If it's not a case declaration, or it's a case declaration with only one element, leave it
       // alone.
       guard let caseDecl = member.decl.as(EnumCaseDeclSyntax.self), caseDecl.elements.count > 1 else {
@@ -123,8 +123,8 @@ public final class OneCasePerLine: SyntaxFormatRule {
       }
     }
 
-    let newMemberBlock = node.members.with(\.members, MemberDeclListSyntax(newMembers))
-    return DeclSyntax(node.with(\.members, newMemberBlock))
+    let newMemberBlock = node.memberBlock.with(\.members, MemberDeclListSyntax(newMembers))
+    return DeclSyntax(node.with(\.memberBlock, newMemberBlock))
   }
 }
 

--- a/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
+++ b/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
@@ -27,7 +27,7 @@ public final class UseSynthesizedInitializer: SyntaxLintRule {
     var storedProperties: [VariableDeclSyntax] = []
     var initializers: [InitializerDeclSyntax] = []
 
-    for memberItem in node.members.members {
+    for memberItem in node.memberBlock.members {
       let member = memberItem.decl
       // Collect all stored variables into a list
       if let varDecl = member.as(VariableDeclSyntax.self) {
@@ -67,7 +67,7 @@ public final class UseSynthesizedInitializer: SyntaxLintRule {
     // The synthesized memberwise initializer(s) are only created when there are no initializers.
     // If there are other initializers that cannot be replaced by a synthesized memberwise
     // initializer, then all of the initializers must remain.
-    let initializersCount = node.members.members.filter { $0.decl.is(InitializerDeclSyntax.self) }.count
+    let initializersCount = node.memberBlock.members.filter { $0.decl.is(InitializerDeclSyntax.self) }.count
     if extraneousInitializers.count == initializersCount {
       extraneousInitializers.forEach { diagnose(.removeRedundantInitializer, on: $0) }
     }

--- a/Sources/generate-pipeline/RuleCollector.swift
+++ b/Sources/generate-pipeline/RuleCollector.swift
@@ -88,11 +88,11 @@ final class RuleCollector {
 
     if let classDecl = statement.item.as(ClassDeclSyntax.self) {
       typeName = classDecl.identifier.text
-      members = classDecl.members.members
+      members = classDecl.memberBlock.members
       maybeInheritanceClause = classDecl.inheritanceClause
     } else if let structDecl = statement.item.as(StructDeclSyntax.self) {
       typeName = structDecl.identifier.text
-      members = structDecl.members.members
+      members = structDecl.memberBlock.members
       maybeInheritanceClause = structDecl.inheritanceClause
     } else {
       return nil


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1524