### PR TITLE
Change version dependency on `swift-argument-parser` to from `upToNextMinor` to `upToNextMajor`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -213,10 +213,8 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   // Building standalone.
   package.dependencies += [
     .package(
-      url: "https://github.com/apple/swift-argument-parser.git",
-      // This should be kept in sync with the same dependency used by
-      // swift-syntax.
-      .upToNextMinor(from: "1.2.2")
+      url: "https://github.com/apple/swift-argument-parser.git", 
+      from: "1.2.2"
     ),
     .package(
       url: "https://github.com/apple/swift-syntax.git",


### PR DESCRIPTION
This will make swift-format more tolerant with regard to which swift-argument-parser version it needs, resulting in fewer version conflicts for packages that depend on swift-format.