### PR TITLE
[5.8] Relax version requirement for swift-argument-parser

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -215,7 +215,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   package.dependencies += [
     .package(
       url: "https://github.com/apple/swift-argument-parser.git",
-      Version("1.0.1")..<Version("1.2.0")
+      from: "1.0.1"
     ),
     .package(
       url: "https://github.com/apple/swift-syntax.git",


### PR DESCRIPTION
This will make swift-format more tolerant with regard to which swift-argument-parser version it needs, resulting in fewer version conflicts for packages that depend on swift-format.