### PR TITLE
Fix absolute path in lint output

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
@@ -786,7 +786,7 @@ public class PrettyPrinter {
     context.findingEmitter.emit(
       message,
       category: category,
-      location: Finding.Location(file: context.fileURL.path, line: lineNumber, column: column))
+      location: Finding.Location(file: context.fileURL.relativePath, line: lineNumber, column: column))
   }
 }
 


### PR DESCRIPTION
Currently `swift lint` output is inconsistent. It returns a mix of absolute and relative paths.
For example:
```
.build/checkouts/swift-argument-parser/Package@swift-5.6.swift:104:1: warning: [Indentation] unindent by 2 spaces
.build/checkouts/swift-argument-parser/Package@swift-5.6.swift:105:1: warning: [Indentation] unindent by 2 spaces
.build/checkouts/swift-argument-parser/Package@swift-5.6.swift:106:1: warning: [Indentation] unindent by 2 spaces
/Users/ikvyatkovskiy/swift-format/.build/checkouts/swift-argument-parser/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift:171:52: warning: [TrailingComma] add trailing comma to the last element in multiline collection literal
```
This can be frustrating while processing the lint output.

The problems appear only with TrailingComma and EndOfLineComment findings.

I suspected PrettyPrinter was causing the problem. When I changed the Finding location, the issue was fixed.
I'd appreciate any ideas on how to test paths.