### PR TITLE
Replace deprecated code of swift-syntax with the latest code to remove warning

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -201,7 +201,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       modifiers: node.modifiers,
       typeKeyword: node.enumKeyword,
       identifier: node.identifier,
-      genericParameterOrPrimaryAssociatedTypeClause: node.genericParameters.map(Syntax.init),
+      genericParameterOrPrimaryAssociatedTypeClause: node.genericParameterClause.map(Syntax.init),
       inheritanceClause: node.inheritanceClause,
       genericWhereClause: node.genericWhereClause,
       memberBlock: node.memberBlock)
@@ -2289,7 +2289,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     return .visitChildren
   }
 
-  override func visit(_ node: AccessPathComponentSyntax) -> SyntaxVisitorContinueKind {
+  override func visit(_ node: ImportPathComponentSyntax) -> SyntaxVisitorContinueKind {
     return .visitChildren
   }
 


### PR DESCRIPTION
While working on the swift-syntax repository, I came across the following warning when running `format.py`.
<img width="1361" alt="스크린샷 2023-05-25 오전 2 11 15" src="https://github.com/apple/swift-format/assets/50410213/bf16a41c-0eb6-43a3-b4e7-9b76cdc0393f">
To remove it, I replaced the deprecated code with the the latest code.
