### PR TITLE
Fix `try`/`await` expressions in `NoAssignmentInExpressions`.

### DIFF
--- a/Tests/SwiftFormatRulesTests/NoAssignmentInExpressionsTests.swift
+++ b/Tests/SwiftFormatRulesTests/NoAssignmentInExpressionsTests.swift
@@ -161,4 +161,23 @@ final class NoAssignmentInExpressionsTests: LintOrFormatRuleTestCase {
     )
     XCTAssertDiagnosed(.moveAssignmentToOwnStatement, line: 2, column: 29)
   }
+
+  func testTryAndAwaitAssignmentExpressionsAreUnchanged() {
+    XCTAssertFormatting(
+      NoAssignmentInExpressions.self,
+      input: """
+        func foo() {
+          try a.b = c
+          await a.b = c
+        }
+        """,
+      expected: """
+        func foo() {
+          try a.b = c
+          await a.b = c
+        }
+        """
+    )
+    XCTAssertNotDiagnosed(.moveAssignmentToOwnStatement)
+  }
 }


### PR DESCRIPTION
This rule only checked whether the _immediate_ parent of an expression like `x = y` was a `CodeBlockItem`. In cases like `try x = y`, the `try` wraps the entire expression and the `CodeBlockItem` would be the parent of that. So we look through any `TryExpr`s or `AwaitExpr`s we see when searching for the `CodeBlockItem`.