### PR TITLE
Allow exceptions to `NoAssignmentInExpressions`.

### DIFF
--- a/Tests/SwiftFormatRulesTests/NoAssignmentInExpressionsTests.swift
+++ b/Tests/SwiftFormatRulesTests/NoAssignmentInExpressionsTests.swift
@@ -180,4 +180,35 @@ final class NoAssignmentInExpressionsTests: LintOrFormatRuleTestCase {
     )
     XCTAssertNotDiagnosed(.moveAssignmentToOwnStatement)
   }
+
+  func testAssignmentExpressionsInAllowedFunctions() {
+    XCTAssertFormatting(
+      NoAssignmentInExpressions.self,
+      input: """
+        // These should not diagnose.
+        XCTAssertNoThrow(a = try b())
+        XCTAssertNoThrow { a = try b() }
+        XCTAssertNoThrow({ a = try b() })
+        someRegularFunction({ a = b })
+        someRegularFunction { a = b }
+
+        // This should be diagnosed.
+        someRegularFunction(a = b)
+        """,
+      expected: """
+        // These should not diagnose.
+        XCTAssertNoThrow(a = try b())
+        XCTAssertNoThrow { a = try b() }
+        XCTAssertNoThrow({ a = try b() })
+        someRegularFunction({ a = b })
+        someRegularFunction { a = b }
+
+        // This should be diagnosed.
+        someRegularFunction(a = b)
+        """
+    )
+    XCTAssertDiagnosed(.moveAssignmentToOwnStatement, line: 9, column: 21)
+    // Make sure no other expressions were diagnosed.
+    XCTAssertNotDiagnosed(.moveAssignmentToOwnStatement)
+  }
 }


### PR DESCRIPTION
This is mostly intended to carve out a really useful exception for testing: `XCTAssertNoThrow(x = try ...)` is quite a bit clearer about intent than `x = try XCTUnwrap(try? ...)` if you need the value `x` later in the test.

In an effort to not be *too* specific in this rule, I've opted to make this a configurable list of exceptions that by default contains `XCTAssertNoThrow`. So it only handles function calls right now, but this could be made more flexible in the future.