### PR TITLE
Add `Token.break` after fixity in operator declaration

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1471,6 +1471,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: OperatorDeclSyntax) -> SyntaxVisitorContinueKind {
+    after(node.fixity, tokens: .break)
     after(node.operatorKeyword, tokens: .break)
     return .visitChildren
   }


### PR DESCRIPTION
In https://github.com/apple/swift-syntax/pull/1448, the children of `OperatorDeclSyntax` are changed. To keep the consistency in format, I add a `Token.break` in `TokenStreamCreator.swift` when visiting `OperatorDeclSyntax`.