### PR TITLE
Rename `elementList` in `TupleExprSyntax` to `elements`

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -786,7 +786,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   override func visit(_ node: TupleExprSyntax) -> SyntaxVisitorContinueKind {
     // We'll do nothing if it's a zero-element tuple, because we just want to keep the empty `()`
     // together.
-    let elementCount = node.elementList.count
+    let elementCount = node.elements.count
 
     if elementCount == 1 {
       // A tuple with one element is a parenthesized expression; add a group around it to keep it
@@ -808,9 +808,9 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       after(node.leftParen, tokens: .break(.open, size: 0), .open)
       before(node.rightParen, tokens: .break(.close, size: 0), .close)
 
-      insertTokens(.break(.same), betweenElementsOf: node.elementList)
+      insertTokens(.break(.same), betweenElementsOf: node.elements)
 
-      for element in node.elementList {
+      for element in node.elements {
         arrangeAsTupleExprElement(element)
       }
     }
@@ -3261,8 +3261,8 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       return true
     case .tryExpr(let tryExpr):
       return isCompoundExpression(tryExpr.expression)
-    case .tupleExpr(let tupleExpr) where tupleExpr.elementList.count == 1:
-      return isCompoundExpression(tupleExpr.elementList.first!.expression)
+    case .tupleExpr(let tupleExpr) where tupleExpr.elements.count == 1:
+      return isCompoundExpression(tupleExpr.elements.first!.expression)
     default:
       return false
     }
@@ -3296,7 +3296,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   ///   not parenthesized.
   private func parenthesizedLeftmostExpr(of expr: ExprSyntax) -> TupleExprSyntax? {
     switch Syntax(expr).as(SyntaxEnum.self) {
-    case .tupleExpr(let tupleExpr) where tupleExpr.elementList.count == 1:
+    case .tupleExpr(let tupleExpr) where tupleExpr.elements.count == 1:
       return tupleExpr
     case .infixOperatorExpr(let infixOperatorExpr):
       return parenthesizedLeftmostExpr(of: infixOperatorExpr.leftOperand)
@@ -3442,7 +3442,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
         )
       }
 
-      if let innerExpr = parenthesizedExpr.elementList.first?.expression,
+      if let innerExpr = parenthesizedExpr.elements.first?.expression,
         let stringLiteralExpr = innerExpr.as(StringLiteralExprSyntax.self),
         stringLiteralExpr.openQuote.tokenKind == .multilineStringQuote
       {

--- a/Sources/SwiftFormatRules/NoParensAroundConditions.swift
+++ b/Sources/SwiftFormatRules/NoParensAroundConditions.swift
@@ -27,8 +27,8 @@ import SwiftSyntax
 ///         call with a trailing closure.
 public final class NoParensAroundConditions: SyntaxFormatRule {
   private func extractExpr(_ tuple: TupleExprSyntax) -> ExprSyntax {
-    assert(tuple.elementList.count == 1)
-    let expr = tuple.elementList.first!.expression
+    assert(tuple.elements.count == 1)
+    let expr = tuple.elements.first!.expression
 
     // If the condition is a function with a trailing closure or if it's an immediately called
     // closure, removing the outer set of parentheses introduces a parse ambiguity.
@@ -46,7 +46,7 @@ public final class NoParensAroundConditions: SyntaxFormatRule {
 
     guard
       let visitedTuple = visit(tuple).as(TupleExprSyntax.self),
-      let visitedExpr = visitedTuple.elementList.first?.expression
+      let visitedExpr = visitedTuple.elements.first?.expression
     else {
       return expr
     }
@@ -71,7 +71,7 @@ public final class NoParensAroundConditions: SyntaxFormatRule {
 
   public override func visit(_ node: ConditionElementSyntax) -> ConditionElementSyntax {
     guard let tup = node.condition.as(TupleExprSyntax.self),
-      tup.elementList.firstAndOnly != nil
+      tup.elements.firstAndOnly != nil
     else {
       return super.visit(node)
     }
@@ -81,7 +81,7 @@ public final class NoParensAroundConditions: SyntaxFormatRule {
   /// FIXME(hbh): Parsing for SwitchExprSyntax is not implemented.
   public override func visit(_ node: SwitchExprSyntax) -> ExprSyntax {
     guard let tup = node.expression.as(TupleExprSyntax.self),
-      tup.elementList.firstAndOnly != nil
+      tup.elements.firstAndOnly != nil
     else {
       return super.visit(node)
     }
@@ -91,7 +91,7 @@ public final class NoParensAroundConditions: SyntaxFormatRule {
 
   public override func visit(_ node: RepeatWhileStmtSyntax) -> StmtSyntax {
     guard let tup = node.condition.as(TupleExprSyntax.self),
-      tup.elementList.firstAndOnly != nil
+      tup.elements.firstAndOnly != nil
     else {
       return super.visit(node)
     }

--- a/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
+++ b/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
@@ -335,7 +335,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
       let tupleExprElementList = TupleExprElementListSyntax([tupleExprElement])
       let tupleExpr = TupleExprSyntax(
         leftParen: TokenSyntax.leftParenToken(leadingTrivia: leadingTrivia ?? []),
-        elementList: tupleExprElementList,
+        elements: tupleExprElementList,
         rightParen: TokenSyntax.rightParenToken())
       wrappedTypeExpr = ExprSyntax(tupleExpr)
     } else {
@@ -429,7 +429,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
       guard let elementExprs = expressionRepresentation(of: tupleType.elements) else { return nil }
       let result = TupleExprSyntax(
         leftParen: tupleType.leftParen,
-        elementList: elementExprs,
+        elements: elementExprs,
         rightParen: tupleType.rightParen)
       return ExprSyntax(result)
 
@@ -473,7 +473,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
 
     let tupleExpr = TupleExprSyntax(
       leftParen: leftParen,
-      elementList: argumentTypeExprs,
+      elements: argumentTypeExprs,
       rightParen: rightParen)
     let arrowExpr = ArrowExprSyntax(
       effectSpecifiers: effectSpecifiers,


### PR DESCRIPTION
To sync the change in https://github.com/apple/swift-syntax/pull/1716.

Solve the warnings of deprecation when building.