### PR TITLE
Fix `async throws` function types when they appear in an expression context.

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/ArrayDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ArrayDeclTests.swift
@@ -70,17 +70,70 @@ final class ArrayDeclTests: PrettyPrintTestCase {
     let input =
       """
       let A = [(Int, Double) -> Bool]()
+      let A = [(Int, Double) async -> Bool]()
       let A = [(Int, Double) throws -> Bool]()
+      let A = [(Int, Double) async throws -> Bool]()
       """
 
-    let expected =
+    let expected46 =
       """
       let A = [(Int, Double) -> Bool]()
+      let A = [(Int, Double) async -> Bool]()
       let A = [(Int, Double) throws -> Bool]()
+      let A = [(Int, Double) async throws -> Bool]()
 
       """
+    assertPrettyPrintEqual(input: input, expected: expected46, linelength: 46)
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
+    let expected43 =
+      """
+      let A = [(Int, Double) -> Bool]()
+      let A = [(Int, Double) async -> Bool]()
+      let A = [(Int, Double) throws -> Bool]()
+      let A = [
+        (Int, Double) async throws -> Bool
+      ]()
+
+      """
+    assertPrettyPrintEqual(input: input, expected: expected43, linelength: 43)
+
+    let expected35 =
+      """
+      let A = [(Int, Double) -> Bool]()
+      let A = [
+        (Int, Double) async -> Bool
+      ]()
+      let A = [
+        (Int, Double) throws -> Bool
+      ]()
+      let A = [
+        (Int, Double) async throws
+          -> Bool
+      ]()
+
+      """
+    assertPrettyPrintEqual(input: input, expected: expected35, linelength: 35)
+
+    let expected27 =
+      """
+      let A = [
+        (Int, Double) -> Bool
+      ]()
+      let A = [
+        (Int, Double) async
+          -> Bool
+      ]()
+      let A = [
+        (Int, Double) throws
+          -> Bool
+      ]()
+      let A = [
+        (Int, Double)
+          async throws -> Bool
+      ]()
+
+      """
+    assertPrettyPrintEqual(input: input, expected: expected27, linelength: 27)
   }
 
   func testNoTrailingCommasInTypes() {

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionTypeTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionTypeTests.swift
@@ -60,6 +60,127 @@ final class FunctionTypeTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 60)
   }
 
+  func testFunctionTypeAsync() {
+    let input =
+      """
+      func f(g: (_ somevalue: Int) async -> String?) {
+        let a = 123
+        let b = "abc"
+      }
+      func f(g: (currentLevel: Int) async -> String?) {
+        let a = 123
+        let b = "abc"
+      }
+      func f(g: (currentLevel: inout Int) async -> String?) {
+        let a = 123
+        let b = "abc"
+      }
+      func f(g: (variable1: Int, variable2: Double, variable3: Bool) async -> Double) {
+        let a = 123
+        let b = "abc"
+      }
+      func f(g: (variable1: Int, variable2: Double, variable3: Bool, variable4: String) async -> Double) {
+        let a = 123
+        let b = "abc"
+      }
+      """
+
+    let expected =
+      """
+      func f(g: (_ somevalue: Int) async -> String?) {
+        let a = 123
+        let b = "abc"
+      }
+      func f(g: (currentLevel: Int) async -> String?) {
+        let a = 123
+        let b = "abc"
+      }
+      func f(g: (currentLevel: inout Int) async -> String?) {
+        let a = 123
+        let b = "abc"
+      }
+      func f(
+        g: (variable1: Int, variable2: Double, variable3: Bool) async ->
+          Double
+      ) {
+        let a = 123
+        let b = "abc"
+      }
+      func f(
+        g: (
+          variable1: Int, variable2: Double, variable3: Bool,
+          variable4: String
+        ) async -> Double
+      ) {
+        let a = 123
+        let b = "abc"
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 66)
+  }
+
+  func testFunctionTypeAsyncThrows() {
+    let input =
+      """
+      func f(g: (_ somevalue: Int) async throws -> String?) {
+        let a = 123
+        let b = "abc"
+      }
+      func f(g: (currentLevel: Int) async throws -> String?) {
+        let a = 123
+        let b = "abc"
+      }
+      func f(g: (currentLevel: inout Int) async throws -> String?) {
+        let a = 123
+        let b = "abc"
+      }
+      func f(g: (variable1: Int, variable2: Double, variable3: Bool) async throws -> Double) {
+        let a = 123
+        let b = "abc"
+      }
+      func f(g: (variable1: Int, variable2: Double, variable3: Bool, variable4: String) async throws -> Double) {
+        let a = 123
+        let b = "abc"
+      }
+      """
+
+    let expected =
+      """
+      func f(g: (_ somevalue: Int) async throws -> String?) {
+        let a = 123
+        let b = "abc"
+      }
+      func f(g: (currentLevel: Int) async throws -> String?) {
+        let a = 123
+        let b = "abc"
+      }
+      func f(g: (currentLevel: inout Int) async throws -> String?) {
+        let a = 123
+        let b = "abc"
+      }
+      func f(
+        g: (variable1: Int, variable2: Double, variable3: Bool) async throws ->
+          Double
+      ) {
+        let a = 123
+        let b = "abc"
+      }
+      func f(
+        g: (
+          variable1: Int, variable2: Double, variable3: Bool, variable4: String
+        ) async throws -> Double
+      ) {
+        let a = 123
+        let b = "abc"
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 73)
+  }
+
   func testFunctionTypeThrows() {
     let input =
       """
@@ -84,7 +205,7 @@ final class FunctionTypeTests: PrettyPrintTestCase {
         let b = "abc"
       }
       """
-    
+
     let expected =
       """
       func f(g: (_ somevalue: Int) throws -> String?) {
@@ -117,7 +238,7 @@ final class FunctionTypeTests: PrettyPrintTestCase {
       }
 
       """
-    
+
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 67)
   }
 


### PR DESCRIPTION
Also unify the way we handle `async throws` now that they are all contained inside effect specifier nodes that share a common `EffectSpecifiersSyntax` protocol conformance.

Fixes #538.