### PR TITLE
Replace deprecated code from swift-syntax

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1751,7 +1751,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     before(node.firstToken(viewMode: .sourceAccurate), tokens: .printerControl(kind: .disableBreaking(allowDiscretionary: false)))
 
     arrangeAttributeList(node.attributes)
-    after(node.importTok, tokens: .space)
+    after(node.importKeyword, tokens: .space)
     after(node.importKind, tokens: .space)
 
     after(node.lastToken(viewMode: .sourceAccurate), tokens: .printerControl(kind: .enableBreaking))

--- a/Sources/SwiftFormatRules/ReturnVoidInsteadOfEmptyTuple.swift
+++ b/Sources/SwiftFormatRules/ReturnVoidInsteadOfEmptyTuple.swift
@@ -39,12 +39,12 @@ public final class ReturnVoidInsteadOfEmptyTuple: SyntaxFormatRule {
       return super.visit(node)
     }
 
-    // Make sure that function types nested in the argument list are also rewritten (for example,
+    // Make sure that function types nested in the parameter list are also rewritten (for example,
     // `(Int -> ()) -> ()` should become `(Int -> Void) -> Void`).
-    let arguments = visit(node.arguments)
+    let parameters = visit(node.parameters)
     let voidKeyword = makeVoidIdentifierType(toReplace: returnType)
     var rewrittenNode = node
-    rewrittenNode.arguments = arguments
+    rewrittenNode.parameters = parameters
     rewrittenNode.output.returnType = TypeSyntax(voidKeyword)
     return TypeSyntax(rewrittenNode)
   }

--- a/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
+++ b/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
@@ -417,7 +417,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
     case .functionType(let functionType):
       let result = makeFunctionTypeExpression(
         leftParen: functionType.leftParen,
-        argumentTypes: functionType.arguments,
+        parameters: functionType.parameters,
         rightParen: functionType.rightParen,
         effectSpecifiers: functionType.effectSpecifiers,
         arrow: functionType.output.arrow,
@@ -458,14 +458,14 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
 
   private func makeFunctionTypeExpression(
     leftParen: TokenSyntax,
-    argumentTypes: TupleTypeElementListSyntax,
+    parameters: TupleTypeElementListSyntax,
     rightParen: TokenSyntax,
     effectSpecifiers: TypeEffectSpecifiersSyntax?,
     arrow: TokenSyntax,
     returnType: TypeSyntax
   ) -> SequenceExprSyntax? {
     guard
-      let argumentTypeExprs = expressionRepresentation(of: argumentTypes),
+      let parameterExprs = expressionRepresentation(of: parameters),
       let returnTypeExpr = expressionRepresentation(of: returnType)
     else {
       return nil
@@ -473,7 +473,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
 
     let tupleExpr = TupleExprSyntax(
       leftParen: leftParen,
-      elements: argumentTypeExprs,
+      elements: parameterExprs,
       rightParen: rightParen)
     let arrowExpr = ArrowExprSyntax(
       effectSpecifiers: effectSpecifiers,


### PR DESCRIPTION
Replaced the deprecated code and also made contextual modifications to the related code.
Due to the changes in https://github.com/apple/swift-syntax/pull/1722 and https://github.com/apple/swift-syntax/pull/1728.