### PR TITLE
Insert white space before trailing closure of a macro expression

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1296,11 +1296,23 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: MacroExpansionExprSyntax) -> SyntaxVisitorContinueKind {
+    let arguments = node.argumentList
+
+    // If there is a trailing closure, force the right parenthesis down to the next line so it
+    // stays with the open curly brace.
+    let breakBeforeRightParen =
+      (node.trailingClosure != nil && !isCompactSingleFunctionCallArgument(arguments))
+      || mustBreakBeforeClosingDelimiter(of: node, argumentListPath: \.argumentList)
+
+    before(
+      node.trailingClosure?.leftBrace,
+      tokens: .break(.same, newlines: .elective(ignoresDiscretionary: true)))
+
     arrangeFunctionCallArgumentList(
-      node.argumentList,
+      arguments,
       leftDelimiter: node.leftParen,
       rightDelimiter: node.rightParen,
-      forcesBreakBeforeRightDelimiter: false)
+      forcesBreakBeforeRightDelimiter: breakBeforeRightParen)
     return .visitChildren
   }
 

--- a/Tests/SwiftFormatPrettyPrintTests/MacroCallTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/MacroCallTests.swift
@@ -1,0 +1,117 @@
+import SwiftFormatConfiguration
+
+final class MacroCallTests: PrettyPrintTestCase {
+  func testNoWhiteSpaceAfterMacroWithoutTrailingClosure() {
+    let input =
+      """
+      func myFunction() {
+        print("Currently running \\(#function)")
+      }
+
+      """
+
+    let expected =
+      """
+      func myFunction() {
+        print("Currently running \\(#function)")
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+  }
+
+  func testKeepWhiteSpaceBeforeTrailingClosure() {
+    let input =
+      """
+      #Preview {}
+      #Preview("MyPreview") {
+        MyView()
+      }
+      let p = #Predicate<Int> { $0 == 0 }
+      """
+
+    let expected =
+      """
+      #Preview {}
+      #Preview("MyPreview") {
+        MyView()
+      }
+      let p = #Predicate<Int> { $0 == 0 }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
+  }
+
+  func testInsertWhiteSpaceBeforeTrailingClosure() {
+    let input =
+      """
+      #Preview{}
+      #Preview("MyPreview"){
+        MyView()
+      }
+      let p = #Predicate<Int>{ $0 == 0 }
+      """
+
+    let expected =
+      """
+      #Preview {}
+      #Preview("MyPreview") {
+        MyView()
+      }
+      let p = #Predicate<Int> { $0 == 0 }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
+  }
+
+  func testDiscretionaryLineBreakBeforeTrailingClosure() {
+    let input =
+      """
+      #Preview("MyPreview")
+      {
+        MyView()
+      }
+      #Preview(
+        "MyPreview", traits: .landscapeLeft
+      )
+      {
+        MyView()
+      }
+      #Preview("MyPreview", traits: .landscapeLeft, .sizeThatFitsLayout)
+      {
+        MyView()
+      }
+      #Preview("MyPreview", traits: .landscapeLeft) {
+        MyView()
+      }
+      """
+
+    let expected =
+      """
+      #Preview("MyPreview") {
+        MyView()
+      }
+      #Preview(
+        "MyPreview", traits: .landscapeLeft
+      ) {
+        MyView()
+      }
+      #Preview(
+        "MyPreview", traits: .landscapeLeft,
+        .sizeThatFitsLayout
+      ) {
+        MyView()
+      }
+      #Preview("MyPreview", traits: .landscapeLeft)
+      {
+        MyView()
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
+  }
+}


### PR DESCRIPTION
This small PR fixes a bug causing the space before the trailing closure of a freestanding macro expression to be removed when running `swift-format`.

For example, the following line of code
```swift
let p = #Predicate<Int> { $0 == 0 }
```
would originally be formatted to
```swift
let p = #Predicate<Int>{ $0 == 0 }
```

In addition to resolving this issue, this PR adds some basic tests to ensure the correct behavior.

For more information and examples see also issue #542.