### PR TITLE
Fix postfix-`#if` formatting when they come after a closing parenthesis.

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/IfConfigTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/IfConfigTests.swift
@@ -163,25 +163,25 @@ final class IfConfigTests: PrettyPrintTestCase {
 
   func testInvalidDiscretionaryLineBreaksRemoved() {
     let input =
-         """
-         #if (canImport(SwiftUI) &&
-         !(os(iOS) &&
-          arch(arm)) &&
-            ((canImport(AppKit) ||
-         canImport(UIKit)) && !os(watchOS)))
-         conditionalFunc(foo, bar, baz)
-           #endif
-         """
+      """
+      #if (canImport(SwiftUI) &&
+      !(os(iOS) &&
+       arch(arm)) &&
+         ((canImport(AppKit) ||
+      canImport(UIKit)) && !os(watchOS)))
+      conditionalFunc(foo, bar, baz)
+        #endif
+      """
 
-       let expected =
-         """
-         #if (canImport(SwiftUI) && !(os(iOS) && arch(arm)) && ((canImport(AppKit) || canImport(UIKit)) && !os(watchOS)))
-           conditionalFunc(foo, bar, baz)
-         #endif
+    let expected =
+      """
+      #if (canImport(SwiftUI) && !(os(iOS) && arch(arm)) && ((canImport(AppKit) || canImport(UIKit)) && !os(watchOS)))
+        conditionalFunc(foo, bar, baz)
+      #endif
 
-         """
+      """
 
-       assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
   }
 
   func testValidDiscretionaryLineBreaksRetained() {
@@ -299,6 +299,8 @@ final class IfConfigTests: PrettyPrintTestCase {
         #if os(iOS) || os(watchOS)
           #if os(iOS)
           .iOSModifier()
+          #elseif os(tvOS)
+          .tvOSModifier()
           #else
           .watchOSModifier()
           #endif
@@ -314,6 +316,8 @@ final class IfConfigTests: PrettyPrintTestCase {
           #if os(iOS) || os(watchOS)
             #if os(iOS)
               .iOSModifier()
+            #elseif os(tvOS)
+              .tvOSModifier()
             #else
               .watchOSModifier()
             #endif
@@ -325,7 +329,6 @@ final class IfConfigTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
   }
-
 
   func testPostfixPoundIfAfterVariables() {
     let input =
@@ -398,6 +401,7 @@ final class IfConfigTests: PrettyPrintTestCase {
         .padding([.vertical])
       #if os(iOS)
         .iOSSpecificModifier()
+        .anotherIOSSpecificModifier()
       #endif
         .commonModifier()
       """
@@ -408,6 +412,7 @@ final class IfConfigTests: PrettyPrintTestCase {
         .padding([.vertical])
         #if os(iOS)
           .iOSSpecificModifier()
+          .anotherIOSSpecificModifier()
         #endif
         .commonModifier()
 
@@ -449,6 +454,63 @@ final class IfConfigTests: PrettyPrintTestCase {
               }
           )
         #endif
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
+  }
+
+  func testPostfixPoundIfNotIndentedIfClosingParenOnOwnLine() {
+    let input =
+      """
+      SomeFunction(
+        foo,
+        bar
+      )
+      #if os(iOS)
+      .iOSSpecificModifier()
+      #endif
+      .commonModifier()
+      """
+
+    let expected =
+      """
+      SomeFunction(
+        foo,
+        bar
+      )
+      #if os(iOS)
+        .iOSSpecificModifier()
+      #endif
+      .commonModifier()
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
+  }
+
+  func testPostfixPoundIfForcesPrecedingClosingParenOntoNewLine() {
+    let input =
+      """
+      SomeFunction(
+        foo,
+        bar)
+        #if os(iOS)
+        .iOSSpecificModifier()
+        #endif
+        .commonModifier()
+      """
+
+    let expected =
+      """
+      SomeFunction(
+        foo,
+        bar
+      )
+      #if os(iOS)
+        .iOSSpecificModifier()
+      #endif
+      .commonModifier()
 
       """
 


### PR DESCRIPTION
A previous change caused the following formatting, which is less than ideal:

```swift
SomeView(
  args
)
  #if os(iOS)
    .someModifier()
  #endif
```

In this case, the `#if` block should be at the same identation level as the closing parenthesis, similar to how we handle closing braces (`}`).

This change moves the treatment of breaks for postfix-`#if` out of the visitor for `#if` clauses and instead uses the same contextual break previsition we use for other member access expressions. The result handles more cases correctly, and is a simpler, less special-casey implementation.