### PR TITLE
Remove the compiler condition guarding `DerivativeRegistrationAttributeArgumentsSyntax`.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -2561,26 +2561,23 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     return .visitChildren
   }
 
-  // `DerivativeRegistrationAttributeArguments` was added after the Swift 5.2 release was cut.
-  #if HAS_DERIVATIVE_REGISTRATION_ATTRIBUTE
-    override func rewrite(_ node: DerivativeRegistrationAttributeArgumentsSyntax)
-      -> SyntaxVisitorContinueKind
-    {
-      // This node encapsulates the entire list of arguments in a `@derivative(...)` or
-      // `@transpose(...)` attribute.
-      before(node.ofLabel, tokens: .open)
-      after(node.colon, tokens: .break(.continue, newlines: .elective(ignoresDiscretionary: true)))
-      // The comma after originalDeclName is optional and is only present if there are diffParams.
-      after(node.comma ?? node.originalDeclName.lastToken, tokens: .close)
+  override func visit(_ node: DerivativeRegistrationAttributeArgumentsSyntax)
+    -> SyntaxVisitorContinueKind
+  {
+    // This node encapsulates the entire list of arguments in a `@derivative(...)` or
+    // `@transpose(...)` attribute.
+    before(node.ofLabel, tokens: .open)
+    after(node.colon, tokens: .break(.continue, newlines: .elective(ignoresDiscretionary: true)))
+    // The comma after originalDeclName is optional and is only present if there are diffParams.
+    after(node.comma ?? node.originalDeclName.lastToken(viewMode: .sourceAccurate), tokens: .close)
 
-      if let diffParams = node.diffParams {
-        before(diffParams.firstToken, tokens: .break(.same), .open)
-        after(diffParams.lastToken, tokens: .close)
-      }
-
-      return .visitChildren
+    if let diffParams = node.diffParams {
+      before(diffParams.firstToken(viewMode: .sourceAccurate), tokens: .break(.same), .open)
+      after(diffParams.lastToken(viewMode: .sourceAccurate), tokens: .close)
     }
-  #endif
+
+    return .visitChildren
+  }
 
   override func visit(_ node: DifferentiabilityParamsClauseSyntax) -> SyntaxVisitorContinueKind {
     // This node encapsulates the `wrt:` label and value/variable in a `@differentiable`,

--- a/Tests/SwiftFormatPrettyPrintTests/DifferentiationAttributeTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/DifferentiationAttributeTests.swift
@@ -96,84 +96,80 @@ final class DifferentiationAttributeTests: PrettyPrintTestCase {
   }
 
   func testDerivative() {
-    #if HAS_DERIVATIVE_REGISTRATION_ATTRIBUTE
-      let input =
-        """
-        @derivative(of: foo)
-        func deriv<T>() {}
+    let input =
+      """
+      @derivative(of: foo)
+      func deriv<T>() {}
 
-        @derivative(of: foo, wrt: x)
-        func deriv<T>(_ x: T) {}
+      @derivative(of: foo, wrt: x)
+      func deriv<T>(_ x: T) {}
 
-        @derivative(of: foobar, wrt: x)
-        func deriv<T>(_ x: T) {}
+      @derivative(of: foobar, wrt: x)
+      func deriv<T>(_ x: T) {}
 
-        @derivative(of: foobarbaz, wrt: theVariableNamedX)
-        func deriv<T>(_ theVariableNamedX: T) {}
-        """
+      @derivative(of: foobarbaz, wrt: theVariableNamedX)
+      func deriv<T>(_ theVariableNamedX: T) {}
+      """
 
-      let expected =
-        """
-        @derivative(of: foo)
-        func deriv<T>() {}
+    let expected =
+      """
+      @derivative(of: foo)
+      func deriv<T>() {}
 
-        @derivative(of: foo, wrt: x)
-        func deriv<T>(_ x: T) {}
+      @derivative(of: foo, wrt: x)
+      func deriv<T>(_ x: T) {}
 
-        @derivative(
-          of: foobar, wrt: x
-        )
-        func deriv<T>(_ x: T) {}
+      @derivative(
+        of: foobar, wrt: x
+      )
+      func deriv<T>(_ x: T) {}
 
-        @derivative(
-          of: foobarbaz,
-          wrt: theVariableNamedX
-        )
-        func deriv<T>(
-          _ theVariableNamedX: T
-        ) {}
+      @derivative(
+        of: foobarbaz,
+        wrt: theVariableNamedX
+      )
+      func deriv<T>(
+        _ theVariableNamedX: T
+      ) {}
 
-        """
+      """
 
-      assertPrettyPrintEqual(input: input, expected: expected, linelength: 28)
-    #endif
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 28)
   }
 
   func testTranspose() {
-    #if HAS_DERIVATIVE_REGISTRATION_ATTRIBUTE
-      let input =
-        """
-        @transpose(of: foo, wrt: 0)
-        func trans<T>(_ v: T) {}
+    let input =
+      """
+      @transpose(of: foo, wrt: 0)
+      func trans<T>(_ v: T) {}
 
-        @transpose(of: foobar, wrt: 0)
-        func trans<T>(_ v: T) {}
+      @transpose(of: foobar, wrt: 0)
+      func trans<T>(_ v: T) {}
 
-        @transpose(of: someReallyLongName, wrt: 0)
-        func trans<T>(_ theVariableNamedV: T) {}
-        """
+      @transpose(of: someReallyLongName, wrt: 0)
+      func trans<T>(_ theVariableNamedV: T) {}
+      """
 
-      let expected =
-        """
-        @transpose(of: foo, wrt: 0)
-        func trans<T>(_ v: T) {}
+    let expected =
+      """
+      @transpose(of: foo, wrt: 0)
+      func trans<T>(_ v: T) {}
 
-        @transpose(
-          of: foobar, wrt: 0
-        )
-        func trans<T>(_ v: T) {}
+      @transpose(
+        of: foobar, wrt: 0
+      )
+      func trans<T>(_ v: T) {}
 
-        @transpose(
-          of: someReallyLongName,
-          wrt: 0
-        )
-        func trans<T>(
-          _ theVariableNamedV: T
-        ) {}
+      @transpose(
+        of: someReallyLongName,
+        wrt: 0
+      )
+      func trans<T>(
+        _ theVariableNamedV: T
+      ) {}
 
-        """
+      """
 
-      assertPrettyPrintEqual(input: input, expected: expected, linelength: 27)
-    #endif
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 27)
   }
 }


### PR DESCRIPTION
This hasn't been relevant since... Swift 5.2.