### PR TITLE
Update swift-format for renamed children in SwiftSyntax

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -158,7 +158,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       attributes: node.attributes,
       modifiers: node.modifiers,
       typeKeyword: node.classKeyword,
-      identifier: node.identifier,
+      identifier: node.name,
       genericParameterOrPrimaryAssociatedTypeClause: node.genericParameterClause.map(Syntax.init),
       inheritanceClause: node.inheritanceClause,
       genericWhereClause: node.genericWhereClause,
@@ -172,7 +172,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       attributes: node.attributes,
       modifiers: node.modifiers,
       typeKeyword: node.actorKeyword,
-      identifier: node.identifier,
+      identifier: node.name,
       genericParameterOrPrimaryAssociatedTypeClause: node.genericParameterClause.map(Syntax.init),
       inheritanceClause: node.inheritanceClause,
       genericWhereClause: node.genericWhereClause,
@@ -186,7 +186,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       attributes: node.attributes,
       modifiers: node.modifiers,
       typeKeyword: node.structKeyword,
-      identifier: node.identifier,
+      identifier: node.name,
       genericParameterOrPrimaryAssociatedTypeClause: node.genericParameterClause.map(Syntax.init),
       inheritanceClause: node.inheritanceClause,
       genericWhereClause: node.genericWhereClause,
@@ -200,7 +200,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       attributes: node.attributes,
       modifiers: node.modifiers,
       typeKeyword: node.enumKeyword,
-      identifier: node.identifier,
+      identifier: node.name,
       genericParameterOrPrimaryAssociatedTypeClause: node.genericParameterClause.map(Syntax.init),
       inheritanceClause: node.inheritanceClause,
       genericWhereClause: node.genericWhereClause,
@@ -214,7 +214,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       attributes: node.attributes,
       modifiers: node.modifiers,
       typeKeyword: node.protocolKeyword,
-      identifier: node.identifier,
+      identifier: node.name,
       genericParameterOrPrimaryAssociatedTypeClause:
         node.primaryAssociatedTypeClause.map(Syntax.init),
       inheritanceClause: node.inheritanceClause,
@@ -248,7 +248,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
     arrangeAttributeList(node.attributes)
 
-    let hasArguments = !node.signature.parameterClause.parameterList.isEmpty
+    let hasArguments = !node.signature.parameterClause.parameters.isEmpty
 
     // Prioritize keeping ") -> <return_type>" together. We can only do this if the macro has
     // arguments.
@@ -327,7 +327,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   // MARK: - Function and function-like declaration nodes (initializers, deinitializers, subscripts)
 
   override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
-    let hasArguments = !node.signature.parameterClause.parameterList.isEmpty
+    let hasArguments = !node.signature.parameterClause.parameters.isEmpty
 
     // Prioritize keeping ") throws -> <return_type>" together. We can only do this if the function
     // has arguments.
@@ -354,8 +354,8 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     // from the following parenthesis or generic argument list. Note that even if the function is
     // defining a prefix or postfix operator, the token kind always comes through as
     // `binaryOperator`.
-    if case .binaryOperator = node.identifier.tokenKind {
-      after(node.identifier.lastToken(viewMode: .sourceAccurate), tokens: .space)
+    if case .binaryOperator = node.name.tokenKind {
+      after(node.name.lastToken(viewMode: .sourceAccurate), tokens: .space)
     }
 
     arrangeFunctionLikeDecl(
@@ -369,7 +369,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
-    let hasArguments = !node.signature.parameterClause.parameterList.isEmpty
+    let hasArguments = !node.signature.parameterClause.parameters.isEmpty
 
     // Prioritize keeping ") throws" together. We can only do this if the function
     // has arguments.
@@ -411,7 +411,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: SubscriptDeclSyntax) -> SyntaxVisitorContinueKind {
-    let hasArguments = !node.parameterClause.parameterList.isEmpty
+    let hasArguments = !node.parameterClause.parameters.isEmpty
 
     before(node.firstToken(viewMode: .sourceAccurate), tokens: .open)
 
@@ -442,7 +442,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
     before(node.returnClause.firstToken(viewMode: .sourceAccurate), tokens: .break)
 
-    if let accessorOrCodeBlock = node.accessor {
+    if let accessorOrCodeBlock = node.accessors {
       switch accessorOrCodeBlock {
       case .accessors(let accessorBlock):
         arrangeBracesAndContents(of: accessorBlock)
@@ -1030,13 +1030,13 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       }
     }
 
-    let arguments = node.argumentList
+    let arguments = node.arguments
 
     // If there is a trailing closure, force the right parenthesis down to the next line so it
     // stays with the open curly brace.
     let breakBeforeRightParen =
       (node.trailingClosure != nil && !isCompactSingleFunctionCallArgument(arguments))
-      || mustBreakBeforeClosingDelimiter(of: node, argumentListPath: \.argumentList)
+      || mustBreakBeforeClosingDelimiter(of: node, argumentListPath: \.arguments)
 
     before(
       node.trailingClosure?.leftBrace,
@@ -1200,7 +1200,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
         // Whether we should prioritize keeping ") throws -> <return_type>" together. We can only do
         // this if the closure has arguments.
         let keepOutputTogether =
-          !closureParameterClause.parameterList.isEmpty && config.prioritizeKeepingFunctionOutputTogether
+          !closureParameterClause.parameters.isEmpty && config.prioritizeKeepingFunctionOutputTogether
 
         // Keep the output together by grouping from the right paren to the end of the output.
         if keepOutputTogether {
@@ -1260,13 +1260,13 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       }
     }
 
-    let arguments = node.argumentList
+    let arguments = node.arguments
 
     // If there is a trailing closure, force the right bracket down to the next line so it stays
     // with the open curly brace.
     let breakBeforeRightBracket =
       node.trailingClosure != nil
-      || mustBreakBeforeClosingDelimiter(of: node, argumentListPath: \.argumentList)
+      || mustBreakBeforeClosingDelimiter(of: node, argumentListPath: \.arguments)
 
     before(
       node.trailingClosure?.leftBrace,
@@ -1296,7 +1296,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
   override func visit(_ node: MacroExpansionDeclSyntax) -> SyntaxVisitorContinueKind {
     arrangeFunctionCallArgumentList(
-      node.argumentList,
+      node.arguments,
       leftDelimiter: node.leftParen,
       rightDelimiter: node.rightParen,
       forcesBreakBeforeRightDelimiter: false)
@@ -1304,13 +1304,13 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: MacroExpansionExprSyntax) -> SyntaxVisitorContinueKind {
-    let arguments = node.argumentList
+    let arguments = node.arguments
 
     // If there is a trailing closure, force the right parenthesis down to the next line so it
     // stays with the open curly brace.
     let breakBeforeRightParen =
       (node.trailingClosure != nil && !isCompactSingleFunctionCallArgument(arguments))
-      || mustBreakBeforeClosingDelimiter(of: node, argumentListPath: \.argumentList)
+      || mustBreakBeforeClosingDelimiter(of: node, argumentListPath: \.arguments)
 
     before(
       node.trailingClosure?.leftBrace,
@@ -1327,7 +1327,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   override func visit(_ node: ClosureParameterClauseSyntax) -> SyntaxVisitorContinueKind {
     // Prioritize keeping ") throws -> <return_type>" together. We can only do this if the function
     // has arguments.
-    if !node.parameterList.isEmpty && config.prioritizeKeepingFunctionOutputTogether {
+    if !node.parameters.isEmpty && config.prioritizeKeepingFunctionOutputTogether {
       // Due to visitation order, this .open corresponds to a .close added in FunctionDeclSyntax
       // or SubscriptDeclSyntax.
       before(node.rightParen, tokens: .open)
@@ -1339,7 +1339,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   override func visit(_ node: EnumCaseParameterClauseSyntax) -> SyntaxVisitorContinueKind {
     // Prioritize keeping ") throws -> <return_type>" together. We can only do this if the function
     // has arguments.
-    if !node.parameterList.isEmpty && config.prioritizeKeepingFunctionOutputTogether {
+    if !node.parameters.isEmpty && config.prioritizeKeepingFunctionOutputTogether {
       // Due to visitation order, this .open corresponds to a .close added in FunctionDeclSyntax
       // or SubscriptDeclSyntax.
       before(node.rightParen, tokens: .open)
@@ -1351,7 +1351,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   override func visit(_ node: ParameterClauseSyntax) -> SyntaxVisitorContinueKind {
     // Prioritize keeping ") throws -> <return_type>" together. We can only do this if the function
     // has arguments.
-    if !node.parameterList.isEmpty && config.prioritizeKeepingFunctionOutputTogether {
+    if !node.parameters.isEmpty && config.prioritizeKeepingFunctionOutputTogether {
       // Due to visitation order, this .open corresponds to a .close added in FunctionDeclSyntax
       // or SubscriptDeclSyntax.
       before(node.rightParen, tokens: .open)
@@ -1414,16 +1414,16 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       // `ReturnClauseSyntax`. To maintain the previous formatting behavior, 
       // add a special case.
       before(node.arrow, tokens: .break)
-      before(node.returnType.firstToken(viewMode: .sourceAccurate), tokens: .break)
+      before(node.type.firstToken(viewMode: .sourceAccurate), tokens: .break)
     } else {
       after(node.arrow, tokens: .space)
     }
 
     // Member type identifier is used when the return type is a member of another type. Add a group
     // here so that the base, dot, and member type are kept together when they fit.
-    if node.returnType.is(MemberTypeIdentifierSyntax.self) {
-      before(node.returnType.firstToken(viewMode: .sourceAccurate), tokens: .open)
-      after(node.returnType.lastToken(viewMode: .sourceAccurate), tokens: .close)
+    if node.type.is(MemberTypeIdentifierSyntax.self) {
+      before(node.type.firstToken(viewMode: .sourceAccurate), tokens: .open)
+      after(node.type.lastToken(viewMode: .sourceAccurate), tokens: .close)
     }
     return .visitChildren
   }
@@ -1434,9 +1434,9 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
   override func visit(_ node: IfConfigClauseSyntax) -> SyntaxVisitorContinueKind {
     switch node.poundKeyword.tokenKind {
-    case .poundIfKeyword, .poundElseifKeyword:
+    case .poundIf, .poundElseif:
       after(node.poundKeyword, tokens: .space)
-    case .poundElseKeyword:
+    case .poundElse:
       break
     default:
       preconditionFailure()
@@ -1575,7 +1575,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
   override func visit(_ node: PrecedenceGroupDeclSyntax) -> SyntaxVisitorContinueKind {
     after(node.precedencegroupKeyword, tokens: .break)
-    after(node.identifier, tokens: .break(.reset))
+    after(node.name, tokens: .break(.reset))
     after(node.leftBrace, tokens: .break(.open, newlines: .soft))
     before(node.rightBrace, tokens: .break(.close))
     return .visitChildren
@@ -1757,7 +1757,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
   override func visit(_ node: AttributeSyntax) -> SyntaxVisitorContinueKind {
     before(node.firstToken(viewMode: .sourceAccurate), tokens: .open)
-    switch node.argument {
+    switch node.arguments {
     case .argumentList(let argumentList)?:
       if let leftParen = node.leftParen, let rightParen = node.rightParen {
         arrangeFunctionCallArgumentList(
@@ -2054,14 +2054,14 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
   override func visit(_ node: AsExprSyntax) -> SyntaxVisitorContinueKind {
     before(node.asKeyword, tokens: .break(.continue), .open)
-    before(node.typeName.firstToken(viewMode: .sourceAccurate), tokens: .space)
+    before(node.type.firstToken(viewMode: .sourceAccurate), tokens: .space)
     after(node.lastToken(viewMode: .sourceAccurate), tokens: .close)
     return .visitChildren
   }
 
   override func visit(_ node: IsExprSyntax) -> SyntaxVisitorContinueKind {
     before(node.isKeyword, tokens: .break(.continue), .open)
-    before(node.typeName.firstToken(viewMode: .sourceAccurate), tokens: .space)
+    before(node.type.firstToken(viewMode: .sourceAccurate), tokens: .space)
     after(node.lastToken(viewMode: .sourceAccurate), tokens: .close)
     return .visitChildren
   }
@@ -2160,7 +2160,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       }
     }
 
-    if let accessorOrCodeBlock = node.accessor {
+    if let accessorOrCodeBlock = node.accessors {
       switch accessorOrCodeBlock {
       case .accessors(let accessorBlock):
         arrangeBracesAndContents(of: accessorBlock)
@@ -2398,8 +2398,8 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     after(node.whereKeyword, tokens: .break(.open))
     after(node.lastToken(viewMode: .sourceAccurate), tokens: .break(.close, size: 0))
 
-    before(node.requirementList.firstToken(viewMode: .sourceAccurate), tokens: .open(genericRequirementListConsistency()))
-    after(node.requirementList.lastToken(viewMode: .sourceAccurate), tokens: .close)
+    before(node.requirements.firstToken(viewMode: .sourceAccurate), tokens: .open(genericRequirementListConsistency()))
+    after(node.requirements.lastToken(viewMode: .sourceAccurate), tokens: .close)
 
     return .visitChildren
   }
@@ -2423,8 +2423,8 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: SameTypeRequirementSyntax) -> SyntaxVisitorContinueKind {
-    before(node.equalityToken, tokens: .break)
-    after(node.equalityToken, tokens: .space)
+    before(node.equal, tokens: .break)
+    after(node.equal, tokens: .space)
 
     return .visitChildren
   }
@@ -2469,8 +2469,8 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     // Normally, the open-break is placed before the open token. In this case, it's intentionally
     // ordered differently so that the inheritance list can start on the current line and only
     // breaks if the first item in the list would overflow the column limit.
-    before(node.inheritedTypeCollection.firstToken(viewMode: .sourceAccurate), tokens: .open, .break(.open, size: 1))
-    after(node.inheritedTypeCollection.lastToken(viewMode: .sourceAccurate), tokens: .break(.close, size: 0), .close)
+    before(node.inheritedTypes.firstToken(viewMode: .sourceAccurate), tokens: .open, .break(.open, size: 1))
+    after(node.inheritedTypes.lastToken(viewMode: .sourceAccurate), tokens: .break(.close, size: 0), .close)
     return .visitChildren
   }
 
@@ -2532,20 +2532,20 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     // This node encapsulates the entire list of arguments in a `@differentiable(...)` attribute.
     var needsBreakBeforeWhereClause = false
 
-    if let parametersComma = node.parametersComma {
-      after(parametersComma, tokens: .break(.same))
+    if let diffParamsComma = node.parametersComma {
+      after(diffParamsComma, tokens: .break(.same))
     } else if node.parameters != nil {
       // If there were diff params but no comma following them, then we have "wrt: foo where ..."
       // and we need a break before the where clause.
       needsBreakBeforeWhereClause = true
     }
 
-    if let genericWhereClause = node.genericWhereClause {
+    if let whereClause = node.genericWhereClause {
       if needsBreakBeforeWhereClause {
-        before(genericWhereClause.firstToken(viewMode: .sourceAccurate), tokens: .break(.same))
+        before(whereClause.firstToken(viewMode: .sourceAccurate), tokens: .break(.same))
       }
-      before(genericWhereClause.firstToken(viewMode: .sourceAccurate), tokens: .open)
-      after(genericWhereClause.lastToken(viewMode: .sourceAccurate), tokens: .close)
+      before(whereClause.firstToken(viewMode: .sourceAccurate), tokens: .open)
+      after(whereClause.lastToken(viewMode: .sourceAccurate), tokens: .close)
     }
     return .visitChildren
   }
@@ -2571,9 +2571,9 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     // The comma after originalDeclName is optional and is only present if there are diffParams.
     after(node.comma ?? node.originalDeclName.lastToken(viewMode: .sourceAccurate), tokens: .close)
 
-    if let parameters = node.parameters {
-      before(parameters.firstToken(viewMode: .sourceAccurate), tokens: .break(.same), .open)
-      after(parameters.lastToken(viewMode: .sourceAccurate), tokens: .close)
+    if let diffParams = node.parameters {
+      before(diffParams.firstToken(viewMode: .sourceAccurate), tokens: .break(.same), .open)
+      after(diffParams.lastToken(viewMode: .sourceAccurate), tokens: .close)
     }
 
     return .visitChildren
@@ -2817,7 +2817,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   private func arrangeClosureParameterClause(
     _ parameters: ClosureParameterClauseSyntax, forcesBreakBeforeRightParen: Bool
   ) {
-    guard !parameters.parameterList.isEmpty else { return }
+    guard !parameters.parameters.isEmpty else { return }
 
     after(parameters.leftParen, tokens: .break(.open, size: 0), .open(argumentListConsistency()))
     before(
@@ -2835,7 +2835,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   private func arrangeEnumCaseParameterClause(
     _ parameters: EnumCaseParameterClauseSyntax, forcesBreakBeforeRightParen: Bool
   ) {
-    guard !parameters.parameterList.isEmpty else { return }
+    guard !parameters.parameters.isEmpty else { return }
 
     after(parameters.leftParen, tokens: .break(.open, size: 0), .open(argumentListConsistency()))
     before(
@@ -2853,7 +2853,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   private func arrangeParameterClause(
     _ parameters: ParameterClauseSyntax, forcesBreakBeforeRightParen: Bool
   ) {
-    guard !parameters.parameterList.isEmpty else { return }
+    guard !parameters.parameters.isEmpty else { return }
 
     after(parameters.leftParen, tokens: .break(.open, size: 0), .open(argumentListConsistency()))
     before(
@@ -3431,7 +3431,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     case .infixOperatorExpr(let infixOperatorExpr):
       return parenthesizedLeftmostExpr(of: infixOperatorExpr.leftOperand)
     case .ternaryExpr(let ternaryExpr):
-      return parenthesizedLeftmostExpr(of: ternaryExpr.conditionExpression)
+      return parenthesizedLeftmostExpr(of: ternaryExpr.condition)
     default:
       return nil
     }
@@ -3465,9 +3465,9 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     case .postfixUnaryExpr(let postfixUnaryExpr):
       return leftmostExpr(of: postfixUnaryExpr.expression, ifMatching: predicate)
     case .prefixOperatorExpr(let prefixOperatorExpr):
-      return leftmostExpr(of: prefixOperatorExpr.postfixExpression, ifMatching: predicate)
+      return leftmostExpr(of: prefixOperatorExpr.base, ifMatching: predicate)
     case .ternaryExpr(let ternaryExpr):
-      return leftmostExpr(of: ternaryExpr.conditionExpression, ifMatching: predicate)
+      return leftmostExpr(of: ternaryExpr.condition, ifMatching: predicate)
     case .functionCallExpr(let functionCallExpr):
       return leftmostExpr(of: functionCallExpr.calledExpression, ifMatching: predicate)
     case .subscriptExpr(let subscriptExpr):
@@ -3565,7 +3565,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       // We don't try to absorb any parens in this case, because the condition of a ternary cannot
       // be grouped with any exprs outside of the condition.
       return (
-        unindentingNode: Syntax(ternaryExpr.conditionExpression),
+        unindentingNode: Syntax(ternaryExpr.condition),
         shouldReset: false,
         breakKind: .continuation,
         shouldGroup: true

--- a/Sources/SwiftFormatRules/AllPublicDeclarationsHaveDocumentation.swift
+++ b/Sources/SwiftFormatRules/AllPublicDeclarationsHaveDocumentation.swift
@@ -45,7 +45,7 @@ public final class AllPublicDeclarationsHaveDocumentation: SyntaxLintRule {
   }
 
   public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseMissingDocComment(DeclSyntax(node), name: node.identifier.text, modifiers: node.modifiers)
+    diagnoseMissingDocComment(DeclSyntax(node), name: node.name.text, modifiers: node.modifiers)
     return .skipChildren
   }
 
@@ -56,17 +56,17 @@ public final class AllPublicDeclarationsHaveDocumentation: SyntaxLintRule {
   }
 
   public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseMissingDocComment(DeclSyntax(node), name: node.identifier.text, modifiers: node.modifiers)
+    diagnoseMissingDocComment(DeclSyntax(node), name: node.name.text, modifiers: node.modifiers)
     return .skipChildren
   }
 
   public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseMissingDocComment(DeclSyntax(node), name: node.identifier.text, modifiers: node.modifiers)
+    diagnoseMissingDocComment(DeclSyntax(node), name: node.name.text, modifiers: node.modifiers)
     return .skipChildren
   }
 
   public override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseMissingDocComment(DeclSyntax(node), name: node.identifier.text, modifiers: node.modifiers)
+    diagnoseMissingDocComment(DeclSyntax(node), name: node.name.text, modifiers: node.modifiers)
     return .skipChildren
   }
 

--- a/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
+++ b/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
@@ -70,14 +70,14 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
   }
 
   public override func visit(_ node: ClosureSignatureSyntax) -> SyntaxVisitorContinueKind {
-    if let parameterClause = node.parameterClause {
-      if let closureParamList = parameterClause.as(ClosureParamListSyntax.self) {
+    if let input = node.parameterClause {
+      if let closureParamList = input.as(ClosureParamListSyntax.self) {
         for param in closureParamList {
           diagnoseLowerCamelCaseViolations(
             param.name, allowUnderscores: false, description: identifierDescription(for: node))
         }
-      } else if let closureParameterClause = parameterClause.as(ClosureParameterClauseSyntax.self) {
-        for param in closureParameterClause.parameterList {
+      } else if let parameterClause = input.as(ClosureParameterClauseSyntax.self) {
+        for param in parameterClause.parameters {
           diagnoseLowerCamelCaseViolations(
             param.firstName, allowUnderscores: false, description: identifierDescription(for: node))
           if let secondName = param.secondName {
@@ -85,8 +85,8 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
               secondName, allowUnderscores: false, description: identifierDescription(for: node))
           }
         }
-      } else if let enumCaseParameterClause = parameterClause.as(EnumCaseParameterClauseSyntax.self) {
-        for param in enumCaseParameterClause.parameterList {
+      } else if let parameterClause = input.as(EnumCaseParameterClauseSyntax.self) {
+        for param in parameterClause.parameters {
           if let firstName = param.firstName {
             diagnoseLowerCamelCaseViolations(
               firstName, allowUnderscores: false, description: identifierDescription(for: node))
@@ -96,8 +96,8 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
               secondName, allowUnderscores: false, description: identifierDescription(for: node))
           }
         }
-      } else if let parameterClause = parameterClause.as(ParameterClauseSyntax.self) {
-        for param in parameterClause.parameterList {
+      } else if let parameterClause = input.as(ParameterClauseSyntax.self) {
+        for param in parameterClause.parameters {
           diagnoseLowerCamelCaseViolations(
             param.firstName, allowUnderscores: false, description: identifierDescription(for: node))
           if let secondName = param.secondName {
@@ -122,9 +122,9 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
     // underscores to separate phrases in very detailed test names.
     let allowUnderscores = testCaseFuncs.contains(node)
     diagnoseLowerCamelCaseViolations(
-      node.identifier, allowUnderscores: allowUnderscores,
+      node.name, allowUnderscores: allowUnderscores,
       description: identifierDescription(for: node))
-    for param in node.signature.parameterClause.parameterList {
+    for param in node.signature.parameterClause.parameters {
       // These identifiers aren't described using `identifierDescription(for:)` because no single
       // node can disambiguate the argument label from the parameter name.
       diagnoseLowerCamelCaseViolations(
@@ -139,7 +139,7 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
 
   public override func visit(_ node: EnumCaseElementSyntax) -> SyntaxVisitorContinueKind {
     diagnoseLowerCamelCaseViolations(
-      node.identifier, allowUnderscores: false, description: identifierDescription(for: node))
+      node.name, allowUnderscores: false, description: identifierDescription(for: node))
     return .skipChildren
   }
 
@@ -160,9 +160,9 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
       } else if let functionDecl = member.decl.as(FunctionDeclSyntax.self) {
         // Identify test methods using the same heuristics as XCTest: name starts with "test", has
         // no arguments, and returns a void type.
-        if functionDecl.identifier.text.starts(with: "test")
-            && functionDecl.signature.parameterClause.parameterList.isEmpty
-            && (functionDecl.signature.returnClause.map(\.isVoid) ?? true)
+        if functionDecl.name.text.starts(with: "test")
+          && functionDecl.signature.parameterClause.parameters.isEmpty
+          && (functionDecl.signature.returnClause.map(\.isVoid) ?? true)
         {
           set.insert(functionDecl)
         }
@@ -203,10 +203,10 @@ fileprivate func identifierDescription<NodeType: SyntaxProtocol>(for node: NodeT
 extension ReturnClauseSyntax {
   /// Whether this return clause specifies an explicit `Void` return type.
   fileprivate var isVoid: Bool {
-    if let returnTypeIdentifier = returnType.as(SimpleTypeIdentifierSyntax.self) {
+    if let returnTypeIdentifier = type.as(SimpleTypeIdentifierSyntax.self) {
       return returnTypeIdentifier.name.text == "Void"
     }
-    if let returnTypeTuple = returnType.as(TupleTypeSyntax.self) {
+    if let returnTypeTuple = type.as(TupleTypeSyntax.self) {
       return returnTypeTuple.elements.isEmpty
     }
     return false

--- a/Sources/SwiftFormatRules/AmbiguousTrailingClosureOverload.swift
+++ b/Sources/SwiftFormatRules/AmbiguousTrailingClosureOverload.swift
@@ -24,12 +24,12 @@ public final class AmbiguousTrailingClosureOverload: SyntaxLintRule {
       let decl = decls[0]
       diagnose(
         .ambiguousTrailingClosureOverload(decl.fullDeclName),
-        on: decl.identifier,
+        on: decl.name,
         notes: decls.dropFirst().map { decl in
           Finding.Note(
             message: .otherAmbiguousOverloadHere(decl.fullDeclName),
             location: Finding.Location(
-              decl.identifier.startLocation(converter: self.context.sourceLocationConverter))
+              decl.name.startLocation(converter: self.context.sourceLocationConverter))
           )
         })
     }
@@ -39,13 +39,13 @@ public final class AmbiguousTrailingClosureOverload: SyntaxLintRule {
     var overloads = [String: [FunctionDeclSyntax]]()
     var staticOverloads = [String: [FunctionDeclSyntax]]()
     for fn in functions {
-      let params = fn.signature.parameterClause.parameterList
+      let params = fn.signature.parameterClause.parameters
       guard let firstParam = params.firstAndOnly else { continue }
       guard firstParam.type.is(FunctionTypeSyntax.self) else { continue }
       if let mods = fn.modifiers, mods.has(modifier: "static") || mods.has(modifier: "class") {
-        staticOverloads[fn.identifier.text, default: []].append(fn)
+        staticOverloads[fn.name.text, default: []].append(fn)
       } else {
-        overloads[fn.identifier.text, default: []].append(fn)
+        overloads[fn.name.text, default: []].append(fn)
       }
     }
 

--- a/Sources/SwiftFormatRules/DontRepeatTypeInStaticProperties.swift
+++ b/Sources/SwiftFormatRules/DontRepeatTypeInStaticProperties.swift
@@ -23,22 +23,22 @@ import SwiftSyntax
 public final class DontRepeatTypeInStaticProperties: SyntaxLintRule {
 
   public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseStaticMembers(node.memberBlock.members, endingWith: node.identifier.text)
+    diagnoseStaticMembers(node.memberBlock.members, endingWith: node.name.text)
     return .skipChildren
   }
 
   public override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseStaticMembers(node.memberBlock.members, endingWith: node.identifier.text)
+    diagnoseStaticMembers(node.memberBlock.members, endingWith: node.name.text)
     return .skipChildren
   }
 
   public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseStaticMembers(node.memberBlock.members, endingWith: node.identifier.text)
+    diagnoseStaticMembers(node.memberBlock.members, endingWith: node.name.text)
     return .skipChildren
   }
 
   public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseStaticMembers(node.memberBlock.members, endingWith: node.identifier.text)
+    diagnoseStaticMembers(node.memberBlock.members, endingWith: node.name.text)
     return .skipChildren
   }
 

--- a/Sources/SwiftFormatRules/FullyIndirectEnum.swift
+++ b/Sources/SwiftFormatRules/FullyIndirectEnum.swift
@@ -31,7 +31,7 @@ public final class FullyIndirectEnum: SyntaxFormatRule {
       return DeclSyntax(node)
     }
 
-    diagnose(.moveIndirectKeywordToEnumDecl(name: node.identifier.text), on: node.identifier)
+    diagnose(.moveIndirectKeywordToEnumDecl(name: node.name.text), on: node.name)
 
     // Removes 'indirect' keyword from cases, reformats
     let newMembers = enumMembers.map {

--- a/Sources/SwiftFormatRules/FunctionDeclSyntax+Convenience.swift
+++ b/Sources/SwiftFormatRules/FunctionDeclSyntax+Convenience.swift
@@ -15,9 +15,9 @@ import SwiftSyntax
 extension FunctionDeclSyntax {
   /// Constructs a name for a function that includes parameter labels, i.e. `foo(_:bar:)`.
   var fullDeclName: String {
-    let params = signature.parameterClause.parameterList.map { param in
+    let params = signature.parameterClause.parameters.map { param in
       "\(param.firstName.text):"
     }
-    return "\(identifier.text)(\(params.joined()))"
+    return "\(name.text)(\(params.joined()))"
   }
 }

--- a/Sources/SwiftFormatRules/NeverForceUnwrap.swift
+++ b/Sources/SwiftFormatRules/NeverForceUnwrap.swift
@@ -44,7 +44,7 @@ public final class NeverForceUnwrap: SyntaxLintRule {
     guard context.importsXCTest == .doesNotImportXCTest else { return .skipChildren }
     guard let questionOrExclamation = node.questionOrExclamationMark else { return .skipChildren }
     guard questionOrExclamation.tokenKind == .exclamationMark else { return .skipChildren }
-    diagnose(.doNotForceCast(name: node.typeName.with(\.leadingTrivia, []).with(\.trailingTrivia, []).description), on: node)
+    diagnose(.doNotForceCast(name: node.type.with(\.leadingTrivia, []).with(\.trailingTrivia, []).description), on: node)
     return .skipChildren
   }
 }

--- a/Sources/SwiftFormatRules/NoEmptyTrailingClosureParentheses.swift
+++ b/Sources/SwiftFormatRules/NoEmptyTrailingClosureParentheses.swift
@@ -22,10 +22,10 @@ import SwiftSyntax
 public final class NoEmptyTrailingClosureParentheses: SyntaxFormatRule {
 
   public override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
-    guard node.argumentList.count == 0 else { return super.visit(node) }
+    guard node.arguments.count == 0 else { return super.visit(node) }
 
     guard let trailingClosure = node.trailingClosure,
-      node.argumentList.isEmpty && node.leftParen != nil else
+      node.arguments.isEmpty && node.leftParen != nil else
     {
       return super.visit(node)
     }

--- a/Sources/SwiftFormatRules/NoLabelsInCasePatterns.swift
+++ b/Sources/SwiftFormatRules/NoLabelsInCasePatterns.swift
@@ -37,7 +37,7 @@ public final class NoLabelsInCasePatterns: SyntaxFormatRule {
 
       // Search function call argument list for violations
       var newArgs: [TupleExprElementSyntax] = []
-      for argument in funcCall.argumentList {
+      for argument in funcCall.arguments {
         guard let label = argument.label else {
           newArgs.append(argument)
           continue
@@ -50,7 +50,7 @@ public final class NoLabelsInCasePatterns: SyntaxFormatRule {
         }
 
         // Remove label if it's the same as the value identifier
-        let name = valueBinding.valuePattern.with(\.leadingTrivia, []).with(\.trailingTrivia, []).description
+        let name = valueBinding.pattern.with(\.leadingTrivia, []).with(\.trailingTrivia, []).description
         guard name == label.text else {
           newArgs.append(argument)
           continue
@@ -60,7 +60,7 @@ public final class NoLabelsInCasePatterns: SyntaxFormatRule {
       }
 
       let newArgList = TupleExprElementListSyntax(newArgs)
-      let newFuncCall = funcCall.with(\.argumentList, newArgList)
+      let newFuncCall = funcCall.with(\.arguments, newArgList)
       let newExpPat = expPat.with(\.expression, ExprSyntax(newFuncCall))
       let newItem = item.with(\.pattern, PatternSyntax(newExpPat))
       newCaseItems.append(newItem)

--- a/Sources/SwiftFormatRules/NoLeadingUnderscores.swift
+++ b/Sources/SwiftFormatRules/NoLeadingUnderscores.swift
@@ -32,27 +32,27 @@ public final class NoLeadingUnderscores: SyntaxLintRule {
   public override class var isOptIn: Bool { return true }
 
   public override func visit(_ node: AssociatedtypeDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseIfNameStartsWithUnderscore(node.identifier)
+    diagnoseIfNameStartsWithUnderscore(node.name)
     return .visitChildren
   }
 
   public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseIfNameStartsWithUnderscore(node.identifier)
+    diagnoseIfNameStartsWithUnderscore(node.name)
     return .visitChildren
   }
 
   public override func visit(_ node: EnumCaseElementSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseIfNameStartsWithUnderscore(node.identifier)
+    diagnoseIfNameStartsWithUnderscore(node.name)
     return .visitChildren
   }
 
   public override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseIfNameStartsWithUnderscore(node.identifier)
+    diagnoseIfNameStartsWithUnderscore(node.name)
     return .visitChildren
   }
 
   public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseIfNameStartsWithUnderscore(node.identifier)
+    diagnoseIfNameStartsWithUnderscore(node.name)
     return .visitChildren
   }
 
@@ -93,22 +93,22 @@ public final class NoLeadingUnderscores: SyntaxLintRule {
   }
 
   public override func visit(_ node: PrecedenceGroupDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseIfNameStartsWithUnderscore(node.identifier)
+    diagnoseIfNameStartsWithUnderscore(node.name)
     return .visitChildren
   }
 
   public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseIfNameStartsWithUnderscore(node.identifier)
+    diagnoseIfNameStartsWithUnderscore(node.name)
     return .visitChildren
   }
 
   public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseIfNameStartsWithUnderscore(node.identifier)
+    diagnoseIfNameStartsWithUnderscore(node.name)
     return .visitChildren
   }
 
   public override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseIfNameStartsWithUnderscore(node.identifier)
+    diagnoseIfNameStartsWithUnderscore(node.name)
     return .visitChildren
   }
 

--- a/Sources/SwiftFormatRules/NoVoidReturnOnFunctionSignature.swift
+++ b/Sources/SwiftFormatRules/NoVoidReturnOnFunctionSignature.swift
@@ -24,11 +24,11 @@ public final class NoVoidReturnOnFunctionSignature: SyntaxFormatRule {
   /// it for closure signatures, because that may introduce an ambiguity when closure signatures
   /// are inferred.
   public override func visit(_ node: FunctionSignatureSyntax) -> FunctionSignatureSyntax {
-    if let returnType = node.returnClause?.returnType.as(SimpleTypeIdentifierSyntax.self), returnType.name.text == "Void" {
+    if let returnType = node.returnClause?.type.as(SimpleTypeIdentifierSyntax.self), returnType.name.text == "Void" {
       diagnose(.removeRedundantReturn("Void"), on: returnType)
       return node.with(\.returnClause, nil)
     }
-    if let tupleReturnType = node.returnClause?.returnType.as(TupleTypeSyntax.self), tupleReturnType.elements.isEmpty {
+    if let tupleReturnType = node.returnClause?.type.as(TupleTypeSyntax.self), tupleReturnType.elements.isEmpty {
       diagnose(.removeRedundantReturn("()"), on: tupleReturnType)
       return node.with(\.returnClause, nil)
     }

--- a/Sources/SwiftFormatRules/OneCasePerLine.swift
+++ b/Sources/SwiftFormatRules/OneCasePerLine.swift
@@ -103,7 +103,7 @@ public final class OneCasePerLine: SyntaxFormatRule {
         if element.associatedValue != nil || element.rawValue != nil {
           // Once we reach one of these, we need to write out the ones we've collected so far, then
           // emit a separate case declaration with the associated/raw value element.
-          diagnose(.moveAssociatedOrRawValueCase(name: element.identifier.text), on: element)
+          diagnose(.moveAssociatedOrRawValueCase(name: element.name.text), on: element)
 
           if let caseDeclForCollectedElements = collector.makeCaseDeclAndReset() {
             newMembers.append(member.with(\.decl, DeclSyntax(caseDeclForCollectedElements)))

--- a/Sources/SwiftFormatRules/OnlyOneTrailingClosureArgument.swift
+++ b/Sources/SwiftFormatRules/OnlyOneTrailingClosureArgument.swift
@@ -20,7 +20,7 @@ import SwiftSyntax
 public final class OnlyOneTrailingClosureArgument: SyntaxLintRule {
 
   public override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
-    guard (node.argumentList.contains { $0.expression.is(ClosureExprSyntax.self) }) else {
+    guard (node.arguments.contains { $0.expression.is(ClosureExprSyntax.self) }) else {
       return .skipChildren
     }
     guard node.trailingClosure != nil else { return .skipChildren }

--- a/Sources/SwiftFormatRules/ReturnVoidInsteadOfEmptyTuple.swift
+++ b/Sources/SwiftFormatRules/ReturnVoidInsteadOfEmptyTuple.swift
@@ -23,7 +23,7 @@ import SwiftSyntax
 /// Format: `-> ()` is replaced with `-> Void`
 public final class ReturnVoidInsteadOfEmptyTuple: SyntaxFormatRule {
   public override func visit(_ node: FunctionTypeSyntax) -> TypeSyntax {
-    guard let returnType = node.returnClause.returnType.as(TupleTypeSyntax.self),
+    guard let returnType = node.returnClause.type.as(TupleTypeSyntax.self),
       returnType.elements.count == 0
     else {
       return super.visit(node)
@@ -45,13 +45,13 @@ public final class ReturnVoidInsteadOfEmptyTuple: SyntaxFormatRule {
     let voidKeyword = makeVoidIdentifierType(toReplace: returnType)
     var rewrittenNode = node
     rewrittenNode.parameters = parameters
-    rewrittenNode.returnClause.returnType = TypeSyntax(voidKeyword)
+    rewrittenNode.returnClause.type = TypeSyntax(voidKeyword)
     return TypeSyntax(rewrittenNode)
   }
 
   public override func visit(_ node: ClosureSignatureSyntax) -> ClosureSignatureSyntax {
     guard let returnClause = node.returnClause,
-      let returnType = returnClause.returnType.as(TupleTypeSyntax.self),
+      let returnType = returnClause.type.as(TupleTypeSyntax.self),
       returnType.elements.count == 0
     else {
       return super.visit(node)
@@ -80,7 +80,7 @@ public final class ReturnVoidInsteadOfEmptyTuple: SyntaxFormatRule {
       closureParameterClause = node.parameterClause
     }
     let voidKeyword = makeVoidIdentifierType(toReplace: returnType)
-    return node.with(\.parameterClause, closureParameterClause).with(\.returnClause, returnClause.with(\.returnType, TypeSyntax(voidKeyword)))
+    return node.with(\.parameterClause, closureParameterClause).with(\.returnClause, returnClause.with(\.type, TypeSyntax(voidKeyword)))
   }
 
   /// Returns a value indicating whether the leading trivia of the given token contained any

--- a/Sources/SwiftFormatRules/UseLetInEveryBoundCaseVariable.swift
+++ b/Sources/SwiftFormatRules/UseLetInEveryBoundCaseVariable.swift
@@ -24,7 +24,7 @@ public final class UseLetInEveryBoundCaseVariable: SyntaxLintRule {
   public override func visit(_ node: ValueBindingPatternSyntax) -> SyntaxVisitorContinueKind {
     // Diagnose a pattern binding if it is a function call and the callee is a member access
     // expression (e.g., `case let .x(y)` or `case let T.x(y)`).
-    if canDistributeLetVarThroughPattern(node.valuePattern) {
+    if canDistributeLetVarThroughPattern(node.pattern) {
       diagnose(.useLetInBoundCaseVariables, on: node)
     }
     return .visitChildren

--- a/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
+++ b/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
@@ -52,7 +52,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
         break
       }
       newNode = shorthandArrayType(
-        element: typeArgument.argumentType,
+        element: typeArgument.argument,
         leadingTrivia: leadingTrivia,
         trailingTrivia: trailingTrivia)
 
@@ -62,8 +62,8 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
         break
       }
       newNode = shorthandDictionaryType(
-        key: typeArguments.0.argumentType,
-        value: typeArguments.1.argumentType,
+        key: typeArguments.0.argument,
+        value: typeArguments.1.argument,
         leadingTrivia: leadingTrivia,
         trailingTrivia: trailingTrivia)
 
@@ -77,7 +77,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
         break
       }
       newNode = shorthandOptionalType(
-        wrapping: typeArgument.argumentType,
+        wrapping: typeArgument.argument,
         leadingTrivia: leadingTrivia,
         trailingTrivia: trailingTrivia)
 
@@ -137,7 +137,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
         break
       }
       let arrayTypeExpr = makeArrayTypeExpression(
-        elementType: typeArgument.argumentType,
+        elementType: typeArgument.argument,
         leftSquare: TokenSyntax.leftSquareToken(leadingTrivia: leadingTrivia),
         rightSquare: TokenSyntax.rightSquareToken(trailingTrivia: trailingTrivia))
       newNode = ExprSyntax(arrayTypeExpr)
@@ -148,8 +148,8 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
         break
       }
       let dictTypeExpr = makeDictionaryTypeExpression(
-        keyType: typeArguments.0.argumentType,
-        valueType: typeArguments.1.argumentType,
+        keyType: typeArguments.0.argument,
+        valueType: typeArguments.1.argument,
         leftSquare: TokenSyntax.leftSquareToken(leadingTrivia: leadingTrivia),
         colon: TokenSyntax.colonToken(trailingTrivia: .spaces(1)),
         rightSquare: TokenSyntax.rightSquareToken(trailingTrivia: trailingTrivia))
@@ -161,7 +161,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
         break
       }
       let optionalTypeExpr = makeOptionalTypeExpression(
-        wrapping: typeArgument.argumentType,
+        wrapping: typeArgument.argument,
         leadingTrivia: leadingTrivia,
         questionMark: TokenSyntax.postfixQuestionMarkToken(trailingTrivia: trailingTrivia))
       newNode = ExprSyntax(optionalTypeExpr)
@@ -204,7 +204,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
   ) -> TypeSyntax {
     let result = ArrayTypeSyntax(
       leftSquare: TokenSyntax.leftSquareToken(leadingTrivia: leadingTrivia),
-      elementType: element,
+      element: element,
       rightSquare: TokenSyntax.rightSquareToken(trailingTrivia: trailingTrivia))
     return TypeSyntax(result)
   }
@@ -219,9 +219,9 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
   ) -> TypeSyntax {
     let result = DictionaryTypeSyntax(
       leftSquare: TokenSyntax.leftSquareToken(leadingTrivia: leadingTrivia),
-      keyType: key,
+      key: key,
       colon: TokenSyntax.colonToken(trailingTrivia: .spaces(1)),
-      valueType: value,
+      value: value,
       rightSquare: TokenSyntax.rightSquareToken(trailingTrivia: trailingTrivia))
     return TypeSyntax(result)
   }
@@ -302,9 +302,9 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
     }
     let dictElementList = DictionaryElementListSyntax([
       DictionaryElementSyntax(
-        keyExpression: keyTypeExpr,
+        key: keyTypeExpr,
         colon: colon,
-        valueExpression: valueTypeExpr,
+        value: valueTypeExpr,
         trailingComma: nil),
     ])
     return DictionaryExprSyntax(
@@ -391,15 +391,15 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
 
     case .arrayType(let arrayType):
       let result = makeArrayTypeExpression(
-        elementType: arrayType.elementType,
+        elementType: arrayType.element,
         leftSquare: arrayType.leftSquare,
         rightSquare: arrayType.rightSquare)
       return ExprSyntax(result)
 
     case .dictionaryType(let dictionaryType):
       let result = makeDictionaryTypeExpression(
-        keyType: dictionaryType.keyType,
-        valueType: dictionaryType.valueType,
+        keyType: dictionaryType.key,
+        valueType: dictionaryType.value,
         leftSquare: dictionaryType.leftSquare,
         colon: dictionaryType.colon,
         rightSquare: dictionaryType.rightSquare)
@@ -419,7 +419,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
         rightParen: functionType.rightParen,
         effectSpecifiers: functionType.effectSpecifiers,
         arrow: functionType.returnClause.arrow,
-        returnType: functionType.returnClause.returnType
+        returnType: functionType.returnClause.type
       )
       return ExprSyntax(result)
 
@@ -499,7 +499,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
   /// Returns true if the given pattern binding represents a stored property/variable (as opposed to
   /// a computed property/variable).
   private func isStoredProperty(_ node: PatternBindingSyntax) -> Bool {
-    guard let accessor = node.accessor else {
+    guard let accessor = node.accessors else {
       // If it has no accessors at all, it is definitely a stored property.
       return true
     }

--- a/Sources/SwiftFormatRules/UseSingleLinePropertyGetter.swift
+++ b/Sources/SwiftFormatRules/UseSingleLinePropertyGetter.swift
@@ -22,7 +22,7 @@ public final class UseSingleLinePropertyGetter: SyntaxFormatRule {
 
   public override func visit(_ node: PatternBindingSyntax) -> PatternBindingSyntax {
     guard
-      let accessorBlock = node.accessor?.as(AccessorBlockSyntax.self),
+      let accessorBlock = node.accessors?.as(AccessorBlockSyntax.self),
       let acc = accessorBlock.accessors.first,
       let body = acc.body,
       accessorBlock.accessors.count == 1,
@@ -37,7 +37,7 @@ public final class UseSingleLinePropertyGetter: SyntaxFormatRule {
     let newBlock = CodeBlockSyntax(
       leftBrace: accessorBlock.leftBrace, statements: body.statements,
       rightBrace: accessorBlock.rightBrace)
-    return node.with(\.accessor, .getter(newBlock))
+    return node.with(\.accessors, .getter(newBlock))
   }
 }
 

--- a/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
+++ b/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
@@ -51,7 +51,7 @@ public final class UseSynthesizedInitializer: SyntaxLintRule {
     for initializer in initializers {
       guard
         matchesPropertyList(
-          parameters: initializer.signature.parameterClause.parameterList,
+          parameters: initializer.signature.parameterClause.parameters,
           properties: storedProperties)
       else { continue }
       guard

--- a/Sources/SwiftFormatRules/UseWhereClausesInForLoops.swift
+++ b/Sources/SwiftFormatRules/UseWhereClausesInForLoops.swift
@@ -100,7 +100,7 @@ fileprivate func updateWithWhereCondition(
   statements: CodeBlockItemListSyntax
 ) -> ForInStmtSyntax {
   // Construct a new `where` clause with the condition.
-  let lastToken = node.sequenceExpr.lastToken(viewMode: .sourceAccurate)
+  let lastToken = node.sequence.lastToken(viewMode: .sourceAccurate)
   var whereLeadingTrivia = Trivia()
   if lastToken?.trailingTrivia.containsSpaces == false {
     whereLeadingTrivia = .spaces(1)

--- a/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
@@ -34,7 +34,7 @@ public final class ValidateDocumentationComments: SyntaxLintRule {
 
   public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
     return checkFunctionLikeDocumentation(
-      DeclSyntax(node), name: node.identifier.text, signature: node.signature,
+      DeclSyntax(node), name: node.name.text, signature: node.signature,
       returnClause: node.signature.returnClause)
   }
 
@@ -71,7 +71,7 @@ public final class ValidateDocumentationComments: SyntaxLintRule {
       name: name,
       returnsDescription: docComment.returns,
       node: node)
-    let funcParameters = funcParametersIdentifiers(in: signature.parameterClause.parameterList)
+    let funcParameters = funcParametersIdentifiers(in: signature.parameterClause.parameters)
 
     // If the documentation of the parameters is wrong 'docCommentInfo' won't
     // parse the parameters correctly. First the documentation has to be fix
@@ -106,7 +106,7 @@ public final class ValidateDocumentationComments: SyntaxLintRule {
     if returnClause == nil && returnsDescription != nil {
       diagnose(.removeReturnComment(funcName: name), on: node)
     } else if let returnClause = returnClause, returnsDescription == nil {
-      if let returnTypeIdentifier = returnClause.returnType.as(SimpleTypeIdentifierSyntax.self),
+      if let returnTypeIdentifier = returnClause.type.as(SimpleTypeIdentifierSyntax.self),
          returnTypeIdentifier.name.text == "Never"
       {
         return

--- a/Sources/generate-pipeline/RuleCollector.swift
+++ b/Sources/generate-pipeline/RuleCollector.swift
@@ -87,11 +87,11 @@ final class RuleCollector {
     let maybeInheritanceClause: TypeInheritanceClauseSyntax?
 
     if let classDecl = statement.item.as(ClassDeclSyntax.self) {
-      typeName = classDecl.identifier.text
+      typeName = classDecl.name.text
       members = classDecl.memberBlock.members
       maybeInheritanceClause = classDecl.inheritanceClause
     } else if let structDecl = statement.item.as(StructDeclSyntax.self) {
-      typeName = structDecl.identifier.text
+      typeName = structDecl.name.text
       members = structDecl.memberBlock.members
       maybeInheritanceClause = structDecl.inheritanceClause
     } else {
@@ -104,8 +104,8 @@ final class RuleCollector {
     }
 
     // Scan through the inheritance clause to find one of the protocols/types we're interested in.
-    for inheritance in inheritanceClause.inheritedTypeCollection {
-      guard let identifier = inheritance.typeName.as(SimpleTypeIdentifierSyntax.self) else {
+    for inheritance in inheritanceClause.inheritedTypes {
+      guard let identifier = inheritance.type.as(SimpleTypeIdentifierSyntax.self) else {
         continue
       }
 
@@ -124,8 +124,8 @@ final class RuleCollector {
       var visitedNodes = [String]()
       for member in members {
         guard let function = member.decl.as(FunctionDeclSyntax.self) else { continue }
-        guard function.identifier.text == "visit" else { continue }
-        let params = function.signature.parameterClause.parameterList
+        guard function.name.text == "visit" else { continue }
+        let params = function.signature.parameterClause.parameters
         guard let firstType = params.firstAndOnly?.type.as(SimpleTypeIdentifierSyntax.self) else {
           continue
         }


### PR DESCRIPTION
Fix warnings in swift-format due to renames of syntax children and make changes so it compiles with https://github.com/apple/swift-syntax/pull/1896.