### PR TITLE
Use newer equivalents of deprecated nodes names

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -248,7 +248,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
     arrangeAttributeList(node.attributes)
 
-    let hasArguments = !node.signature.input.parameterList.isEmpty
+    let hasArguments = !node.signature.parameterClause.parameterList.isEmpty
 
     // Prioritize keeping ") -> <return_type>" together. We can only do this if the macro has
     // arguments.
@@ -257,8 +257,8 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       after(node.signature.lastToken(viewMode: .sourceAccurate), tokens: .close)
     }
 
-    let mustBreak = node.signature.output != nil || node.definition != nil
-    arrangeParameterClause(node.signature.input, forcesBreakBeforeRightParen: mustBreak)
+    let mustBreak = node.signature.returnClause != nil || node.definition != nil
+    arrangeParameterClause(node.signature.parameterClause, forcesBreakBeforeRightParen: mustBreak)
 
     // Prioritize keeping "<modifiers> macro <name>(" together. Also include the ")" if the
     // parameter list is empty.
@@ -267,9 +267,9 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     before(firstTokenAfterAttributes, tokens: .open)
     after(node.macroKeyword, tokens: .break)
     if hasArguments || node.genericParameterClause != nil {
-      after(node.signature.input.leftParen, tokens: .close)
+      after(node.signature.parameterClause.leftParen, tokens: .close)
     } else {
-      after(node.signature.input.rightParen, tokens: .close)
+      after(node.signature.parameterClause.rightParen, tokens: .close)
     }
 
     if let genericWhereClause = node.genericWhereClause {
@@ -327,7 +327,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   // MARK: - Function and function-like declaration nodes (initializers, deinitializers, subscripts)
 
   override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
-    let hasArguments = !node.signature.input.parameterList.isEmpty
+    let hasArguments = !node.signature.parameterClause.parameterList.isEmpty
 
     // Prioritize keeping ") throws -> <return_type>" together. We can only do this if the function
     // has arguments.
@@ -336,8 +336,8 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       after(node.signature.lastToken(viewMode: .sourceAccurate), tokens: .close)
     }
 
-    let mustBreak = node.body != nil || node.signature.output != nil
-    arrangeParameterClause(node.signature.input, forcesBreakBeforeRightParen: mustBreak)
+    let mustBreak = node.body != nil || node.signature.returnClause != nil
+    arrangeParameterClause(node.signature.parameterClause, forcesBreakBeforeRightParen: mustBreak)
 
     // Prioritize keeping "<modifiers> func <name>(" together. Also include the ")" if the parameter
     // list is empty.
@@ -345,9 +345,9 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     before(firstTokenAfterAttributes, tokens: .open)
     after(node.funcKeyword, tokens: .break)
     if hasArguments || node.genericParameterClause != nil {
-      after(node.signature.input.leftParen, tokens: .close)
+      after(node.signature.parameterClause.leftParen, tokens: .close)
     } else {
-      after(node.signature.input.rightParen, tokens: .close)
+      after(node.signature.parameterClause.rightParen, tokens: .close)
     }
 
     // Add a non-breaking space after the identifier if it's an operator, to separate it visually
@@ -369,7 +369,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
-    let hasArguments = !node.signature.input.parameterList.isEmpty
+    let hasArguments = !node.signature.parameterClause.parameterList.isEmpty
 
     // Prioritize keeping ") throws" together. We can only do this if the function
     // has arguments.
@@ -378,16 +378,16 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       after(node.signature.lastToken(viewMode: .sourceAccurate), tokens: .close)
     }
 
-    arrangeParameterClause(node.signature.input, forcesBreakBeforeRightParen: node.body != nil)
+    arrangeParameterClause(node.signature.parameterClause, forcesBreakBeforeRightParen: node.body != nil)
 
     // Prioritize keeping "<modifiers> init<punctuation>" together.
     let firstTokenAfterAttributes = node.modifiers?.firstToken(viewMode: .sourceAccurate) ?? node.initKeyword
     before(firstTokenAfterAttributes, tokens: .open)
 
     if hasArguments || node.genericParameterClause != nil {
-      after(node.signature.input.leftParen, tokens: .close)
+      after(node.signature.parameterClause.leftParen, tokens: .close)
     } else {
-      after(node.signature.input.rightParen, tokens: .close)
+      after(node.signature.parameterClause.rightParen, tokens: .close)
     }
 
     arrangeFunctionLikeDecl(
@@ -411,7 +411,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: SubscriptDeclSyntax) -> SyntaxVisitorContinueKind {
-    let hasArguments = !node.indices.parameterList.isEmpty
+    let hasArguments = !node.parameterClause.parameterList.isEmpty
 
     before(node.firstToken(viewMode: .sourceAccurate), tokens: .open)
 
@@ -420,9 +420,9 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       before(firstModifierToken, tokens: .open)
 
       if hasArguments || node.genericParameterClause != nil {
-        after(node.indices.leftParen, tokens: .close)
+        after(node.parameterClause.leftParen, tokens: .close)
       } else {
-        after(node.indices.rightParen, tokens: .close)
+        after(node.parameterClause.rightParen, tokens: .close)
       }
     }
 
@@ -430,7 +430,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     // arguments.
     if hasArguments && config.prioritizeKeepingFunctionOutputTogether {
       // Due to visitation order, the matching .open break is added in ParameterClauseSyntax.
-      after(node.result.lastToken(viewMode: .sourceAccurate), tokens: .close)
+      after(node.returnClause.lastToken(viewMode: .sourceAccurate), tokens: .close)
     }
 
     arrangeAttributeList(node.attributes)
@@ -440,7 +440,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       after(genericWhereClause.lastToken(viewMode: .sourceAccurate), tokens: .close)
     }
 
-    before(node.result.firstToken(viewMode: .sourceAccurate), tokens: .break)
+    before(node.returnClause.firstToken(viewMode: .sourceAccurate), tokens: .break)
 
     if let accessorOrCodeBlock = node.accessor {
       switch accessorOrCodeBlock {
@@ -453,7 +453,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
     after(node.lastToken(viewMode: .sourceAccurate), tokens: .close)
 
-    arrangeParameterClause(node.indices, forcesBreakBeforeRightParen: true)
+    arrangeParameterClause(node.parameterClause, forcesBreakBeforeRightParen: true)
 
     return .visitChildren
   }
@@ -1185,22 +1185,22 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     before(node.firstToken(viewMode: .sourceAccurate), tokens: .open)
 
     arrangeAttributeList(
-      node.attributes, suppressFinalBreak: node.input == nil && node.capture == nil)
+      node.attributes, suppressFinalBreak: node.parameterClause == nil && node.capture == nil)
 
-    if let input = node.input {
+    if let parameterClause = node.parameterClause {
       // We unconditionally put a break before the `in` keyword below, so we should only put a break
       // after the capture list's right bracket if there are arguments following it or we'll end up
       // with an extra space if the line doesn't wrap.
       after(node.capture?.rightSquare, tokens: .break(.same))
 
-      // When it's parenthesized, the input is a `ParameterClauseSyntax`. Otherwise, it's a
+      // When it's parenthesized, the parameterClause is a `ParameterClauseSyntax`. Otherwise, it's a
       // `ClosureParamListSyntax`. The parenthesized version is wrapped in open/close breaks so that
       // the parens create an extra level of indentation.
-      if let parameterClause = input.as(ClosureParameterClauseSyntax.self) {
+      if let closureParameterClause = parameterClause.as(ClosureParameterClauseSyntax.self) {
         // Whether we should prioritize keeping ") throws -> <return_type>" together. We can only do
         // this if the closure has arguments.
         let keepOutputTogether =
-          !parameterClause.parameterList.isEmpty && config.prioritizeKeepingFunctionOutputTogether
+          !closureParameterClause.parameterList.isEmpty && config.prioritizeKeepingFunctionOutputTogether
 
         // Keep the output together by grouping from the right paren to the end of the output.
         if keepOutputTogether {
@@ -1211,20 +1211,20 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
         } else  {
           // Group outside of the parens, so that the argument list together, preferring to break
           // between the argument list and the output.
-          before(input.firstToken(viewMode: .sourceAccurate), tokens: .open)
-          after(input.lastToken(viewMode: .sourceAccurate), tokens: .close)
+          before(parameterClause.firstToken(viewMode: .sourceAccurate), tokens: .open)
+          after(parameterClause.lastToken(viewMode: .sourceAccurate), tokens: .close)
         }
 
-        arrangeClosureParameterClause(parameterClause, forcesBreakBeforeRightParen: true)
+        arrangeClosureParameterClause(closureParameterClause, forcesBreakBeforeRightParen: true)
       } else {
         // Group around the arguments, but don't use open/close breaks because there are no parens
         // to create a new scope.
-        before(input.firstToken(viewMode: .sourceAccurate), tokens: .open(argumentListConsistency()))
-        after(input.lastToken(viewMode: .sourceAccurate), tokens: .close)
+        before(parameterClause.firstToken(viewMode: .sourceAccurate), tokens: .open(argumentListConsistency()))
+        after(parameterClause.lastToken(viewMode: .sourceAccurate), tokens: .close)
       }
     }
 
-    before(node.output?.arrow, tokens: .break)
+    before(node.returnClause?.arrow, tokens: .break)
     after(node.lastToken(viewMode: .sourceAccurate), tokens: .close)
     before(node.inKeyword, tokens: .break(.same))
     return .visitChildren
@@ -1521,7 +1521,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: OperatorDeclSyntax) -> SyntaxVisitorContinueKind {
-    after(node.fixity, tokens: .break)
+    after(node.fixitySpecifier, tokens: .break)
     after(node.operatorKeyword, tokens: .break)
     return .visitChildren
   }
@@ -1836,7 +1836,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
     arrangeAttributeList(node.attributes)
     after(node.importKeyword, tokens: .space)
-    after(node.importKind, tokens: .space)
+    after(node.importKindSpecifier, tokens: .space)
 
     after(node.lastToken(viewMode: .sourceAccurate), tokens: .printerControl(kind: .enableBreaking))
     return .visitChildren
@@ -1941,7 +1941,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: FunctionSignatureSyntax) -> SyntaxVisitorContinueKind {
-    before(node.output?.firstToken(viewMode: .sourceAccurate), tokens: .break)
+    before(node.returnClause?.firstToken(viewMode: .sourceAccurate), tokens: .break)
     return .visitChildren
   }
 
@@ -2096,14 +2096,14 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     if node.bindings.count == 1 {
       // If there is only a single binding, don't allow a break between the `let/var` keyword and
       // the identifier; there are better places to break later on.
-      after(node.bindingKeyword, tokens: .space)
+      after(node.bindingSpecifier, tokens: .space)
     } else {
       // If there is more than one binding, we permit an open-break after `let/var` so that each of
       // the comma-delimited items will potentially receive indentation. We also add a group around
       // the individual bindings to bind them together better. (This is done here, not in
       // `visit(_: PatternBindingSyntax)`, because we only want that behavior when there are
       // multiple bindings.)
-      after(node.bindingKeyword, tokens: .break(.open))
+      after(node.bindingSpecifier, tokens: .break(.open))
 
       for binding in node.bindings {
         before(binding.firstToken(viewMode: .sourceAccurate), tokens: .open)
@@ -2301,7 +2301,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: ValueBindingPatternSyntax) -> SyntaxVisitorContinueKind {
-    after(node.bindingKeyword, tokens: .break)
+    after(node.bindingSpecifier, tokens: .break)
     return .visitChildren
   }
 
@@ -2492,7 +2492,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: OptionalBindingConditionSyntax) -> SyntaxVisitorContinueKind {
-    after(node.bindingKeyword, tokens: .break)
+    after(node.bindingSpecifier, tokens: .break)
 
     if let typeAnnotation = node.typeAnnotation {
       after(
@@ -2532,20 +2532,20 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     // This node encapsulates the entire list of arguments in a `@differentiable(...)` attribute.
     var needsBreakBeforeWhereClause = false
 
-    if let diffParamsComma = node.diffParamsComma {
-      after(diffParamsComma, tokens: .break(.same))
-    } else if node.diffParams != nil {
+    if let parametersComma = node.parametersComma {
+      after(parametersComma, tokens: .break(.same))
+    } else if node.parameters != nil {
       // If there were diff params but no comma following them, then we have "wrt: foo where ..."
       // and we need a break before the where clause.
       needsBreakBeforeWhereClause = true
     }
 
-    if let whereClause = node.whereClause {
+    if let genericWhereClause = node.genericWhereClause {
       if needsBreakBeforeWhereClause {
-        before(whereClause.firstToken(viewMode: .sourceAccurate), tokens: .break(.same))
+        before(genericWhereClause.firstToken(viewMode: .sourceAccurate), tokens: .break(.same))
       }
-      before(whereClause.firstToken(viewMode: .sourceAccurate), tokens: .open)
-      after(whereClause.lastToken(viewMode: .sourceAccurate), tokens: .close)
+      before(genericWhereClause.firstToken(viewMode: .sourceAccurate), tokens: .open)
+      after(genericWhereClause.lastToken(viewMode: .sourceAccurate), tokens: .close)
     }
     return .visitChildren
   }
@@ -2571,9 +2571,9 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     // The comma after originalDeclName is optional and is only present if there are diffParams.
     after(node.comma ?? node.originalDeclName.lastToken(viewMode: .sourceAccurate), tokens: .close)
 
-    if let diffParams = node.diffParams {
-      before(diffParams.firstToken(viewMode: .sourceAccurate), tokens: .break(.same), .open)
-      after(diffParams.lastToken(viewMode: .sourceAccurate), tokens: .close)
+    if let parameters = node.parameters {
+      before(parameters.firstToken(viewMode: .sourceAccurate), tokens: .break(.same), .open)
+      after(parameters.lastToken(viewMode: .sourceAccurate), tokens: .close)
     }
 
     return .visitChildren
@@ -3069,7 +3069,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     // If we're at the end of the file, determine at which index to stop checking trivia pieces to
     // prevent trailing newlines.
     var cutoffIndex: Int? = nil
-    if token.tokenKind == TokenKind.eof {
+    if token.tokenKind == TokenKind.endOfFile {
       cutoffIndex = 0
       for (index, piece) in trivia.enumerated() {
         switch piece {

--- a/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
+++ b/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
@@ -67,14 +67,14 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
   }
 
   public override func visit(_ node: ClosureSignatureSyntax) -> SyntaxVisitorContinueKind {
-    if let input = node.input {
-      if let closureParamList = input.as(ClosureParamListSyntax.self) {
+    if let parameterClause = node.parameterClause {
+      if let closureParamList = parameterClause.as(ClosureParamListSyntax.self) {
         for param in closureParamList {
           diagnoseLowerCamelCaseViolations(
             param.name, allowUnderscores: false, description: identifierDescription(for: node))
         }
-      } else if let parameterClause = input.as(ClosureParameterClauseSyntax.self) {
-        for param in parameterClause.parameterList {
+      } else if let closureParameterClause = parameterClause.as(ClosureParameterClauseSyntax.self) {
+        for param in closureParameterClause.parameterList {
           diagnoseLowerCamelCaseViolations(
             param.firstName, allowUnderscores: false, description: identifierDescription(for: node))
           if let secondName = param.secondName {
@@ -82,8 +82,8 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
               secondName, allowUnderscores: false, description: identifierDescription(for: node))
           }
         }
-      } else if let parameterClause = input.as(EnumCaseParameterClauseSyntax.self) {
-        for param in parameterClause.parameterList {
+      } else if let enumCaseParameterClause = parameterClause.as(EnumCaseParameterClauseSyntax.self) {
+        for param in enumCaseParameterClause.parameterList {
           if let firstName = param.firstName {
             diagnoseLowerCamelCaseViolations(
               firstName, allowUnderscores: false, description: identifierDescription(for: node))
@@ -93,7 +93,7 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
               secondName, allowUnderscores: false, description: identifierDescription(for: node))
           }
         }
-      } else if let parameterClause = input.as(ParameterClauseSyntax.self) {
+      } else if let parameterClause = parameterClause.as(ParameterClauseSyntax.self) {
         for param in parameterClause.parameterList {
           diagnoseLowerCamelCaseViolations(
             param.firstName, allowUnderscores: false, description: identifierDescription(for: node))
@@ -121,7 +121,7 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
     diagnoseLowerCamelCaseViolations(
       node.identifier, allowUnderscores: allowUnderscores,
       description: identifierDescription(for: node))
-    for param in node.signature.input.parameterList {
+    for param in node.signature.parameterClause.parameterList {
       // These identifiers aren't described using `identifierDescription(for:)` because no single
       // node can disambiguate the argument label from the parameter name.
       diagnoseLowerCamelCaseViolations(
@@ -158,8 +158,8 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
         // Identify test methods using the same heuristics as XCTest: name starts with "test", has
         // no arguments, and returns a void type.
         if functionDecl.identifier.text.starts(with: "test")
-          && functionDecl.signature.input.parameterList.isEmpty
-          && (functionDecl.signature.output.map(\.isVoid) ?? true)
+            && functionDecl.signature.parameterClause.parameterList.isEmpty
+            && (functionDecl.signature.returnClause.map(\.isVoid) ?? true)
         {
           set.insert(functionDecl)
         }
@@ -189,9 +189,9 @@ fileprivate func identifierDescription<NodeType: SyntaxProtocol>(for node: NodeT
   case .enumCaseElement: return "enum case"
   case .functionDecl: return "function"
   case .optionalBindingCondition(let binding):
-    return binding.bindingKeyword.tokenKind == .keyword(.var) ? "variable" : "constant"
+    return binding.bindingSpecifier.tokenKind == .keyword(.var) ? "variable" : "constant"
   case .variableDecl(let variableDecl):
-    return variableDecl.bindingKeyword.tokenKind == .keyword(.var) ? "variable" : "constant"
+    return variableDecl.bindingSpecifier.tokenKind == .keyword(.var) ? "variable" : "constant"
   default:
     return "identifier"
   }

--- a/Sources/SwiftFormatRules/AmbiguousTrailingClosureOverload.swift
+++ b/Sources/SwiftFormatRules/AmbiguousTrailingClosureOverload.swift
@@ -39,7 +39,7 @@ public final class AmbiguousTrailingClosureOverload: SyntaxLintRule {
     var overloads = [String: [FunctionDeclSyntax]]()
     var staticOverloads = [String: [FunctionDeclSyntax]]()
     for fn in functions {
-      let params = fn.signature.input.parameterList
+      let params = fn.signature.parameterClause.parameterList
       guard let firstParam = params.firstAndOnly else { continue }
       guard firstParam.type.is(FunctionTypeSyntax.self) else { continue }
       if let mods = fn.modifiers, mods.has(modifier: "static") || mods.has(modifier: "class") {

--- a/Sources/SwiftFormatRules/FunctionDeclSyntax+Convenience.swift
+++ b/Sources/SwiftFormatRules/FunctionDeclSyntax+Convenience.swift
@@ -15,7 +15,7 @@ import SwiftSyntax
 extension FunctionDeclSyntax {
   /// Constructs a name for a function that includes parameter labels, i.e. `foo(_:bar:)`.
   var fullDeclName: String {
-    let params = signature.input.parameterList.map { param in
+    let params = signature.parameterClause.parameterList.map { param in
       "\(param.firstName.text):"
     }
     return "\(identifier.text)(\(params.joined()))"

--- a/Sources/SwiftFormatRules/NoVoidReturnOnFunctionSignature.swift
+++ b/Sources/SwiftFormatRules/NoVoidReturnOnFunctionSignature.swift
@@ -24,13 +24,13 @@ public final class NoVoidReturnOnFunctionSignature: SyntaxFormatRule {
   /// it for closure signatures, because that may introduce an ambiguity when closure signatures
   /// are inferred.
   public override func visit(_ node: FunctionSignatureSyntax) -> FunctionSignatureSyntax {
-    if let ret = node.output?.returnType.as(SimpleTypeIdentifierSyntax.self), ret.name.text == "Void" {
-      diagnose(.removeRedundantReturn("Void"), on: ret)
-      return node.with(\.output, nil)
+    if let returnType = node.returnClause?.returnType.as(SimpleTypeIdentifierSyntax.self), returnType.name.text == "Void" {
+      diagnose(.removeRedundantReturn("Void"), on: returnType)
+      return node.with(\.returnClause, nil)
     }
-    if let tup = node.output?.returnType.as(TupleTypeSyntax.self), tup.elements.isEmpty {
-      diagnose(.removeRedundantReturn("()"), on: tup)
-      return node.with(\.output, nil)
+    if let tupleReturnType = node.returnClause?.returnType.as(TupleTypeSyntax.self), tupleReturnType.elements.isEmpty {
+      diagnose(.removeRedundantReturn("()"), on: tupleReturnType)
+      return node.with(\.returnClause, nil)
     }
     return node
   }

--- a/Sources/SwiftFormatRules/OrderedImports.swift
+++ b/Sources/SwiftFormatRules/OrderedImports.swift
@@ -523,7 +523,7 @@ fileprivate class Line {
     {
       return .testableImport
     }
-    if importDecl.importKind != nil {
+    if importDecl.importKindSpecifier != nil {
       return .declImport
     }
     return .regularImport

--- a/Sources/SwiftFormatRules/ReturnVoidInsteadOfEmptyTuple.swift
+++ b/Sources/SwiftFormatRules/ReturnVoidInsteadOfEmptyTuple.swift
@@ -23,7 +23,7 @@ import SwiftSyntax
 /// Format: `-> ()` is replaced with `-> Void`
 public final class ReturnVoidInsteadOfEmptyTuple: SyntaxFormatRule {
   public override func visit(_ node: FunctionTypeSyntax) -> TypeSyntax {
-    guard let returnType = node.output.returnType.as(TupleTypeSyntax.self),
+    guard let returnType = node.returnClause.returnType.as(TupleTypeSyntax.self),
       returnType.elements.count == 0
     else {
       return super.visit(node)
@@ -45,13 +45,13 @@ public final class ReturnVoidInsteadOfEmptyTuple: SyntaxFormatRule {
     let voidKeyword = makeVoidIdentifierType(toReplace: returnType)
     var rewrittenNode = node
     rewrittenNode.parameters = parameters
-    rewrittenNode.output.returnType = TypeSyntax(voidKeyword)
+    rewrittenNode.returnClause.returnType = TypeSyntax(voidKeyword)
     return TypeSyntax(rewrittenNode)
   }
 
   public override func visit(_ node: ClosureSignatureSyntax) -> ClosureSignatureSyntax {
-    guard let output = node.output,
-      let returnType = output.returnType.as(TupleTypeSyntax.self),
+    guard let returnClause = node.returnClause,
+      let returnType = returnClause.returnType.as(TupleTypeSyntax.self),
       returnType.elements.count == 0
     else {
       return super.visit(node)
@@ -67,20 +67,20 @@ public final class ReturnVoidInsteadOfEmptyTuple: SyntaxFormatRule {
       return super.visit(node)
     }
 
-    let input: ClosureSignatureSyntax.Input?
-    switch node.input {
+    let closureParameterClause: ClosureSignatureSyntax.ParameterClause?
+    switch node.parameterClause {
     case .parameterClause(let parameterClause)?:
       // If the closure input is a complete parameter clause (variables and types), make sure that
       // nested function types are also rewritten (for example, `label: (Int -> ()) -> ()` should
       // become `label: (Int -> Void) -> Void`).
-      input = .input(visit(parameterClause))
+      closureParameterClause = .parameterClause(visit(parameterClause))
     default:
       // Otherwise, it's a simple signature (just variable names, no types), so there is nothing to
       // rewrite.
-      input = node.input
+      closureParameterClause = node.parameterClause
     }
     let voidKeyword = makeVoidIdentifierType(toReplace: returnType)
-    return node.with(\.input, input).with(\.output, output.with(\.returnType, TypeSyntax(voidKeyword)))
+    return node.with(\.parameterClause, closureParameterClause).with(\.returnClause, returnClause.with(\.returnType, TypeSyntax(voidKeyword)))
   }
 
   /// Returns a value indicating whether the leading trivia of the given token contained any

--- a/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
+++ b/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
@@ -418,8 +418,8 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
         parameters: functionType.parameters,
         rightParen: functionType.rightParen,
         effectSpecifiers: functionType.effectSpecifiers,
-        arrow: functionType.output.arrow,
-        returnType: functionType.output.returnType
+        arrow: functionType.returnClause.arrow,
+        returnType: functionType.returnClause.returnType
       )
       return ExprSyntax(result)
 
@@ -514,7 +514,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
     for accessorDecl in accessorBlock.accessors {
       // Look for accessors that indicate that this is a computed property. If none are found, then
       // it is a stored property (e.g., having only observers like `willSet/didSet`).
-      switch accessorDecl.accessorKind.tokenKind {
+      switch accessorDecl.accessorSpecifier.tokenKind {
       case .keyword(.get),
         .keyword(.set),
         .keyword(.unsafeAddress),
@@ -540,7 +540,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
       isStoredProperty(patternBinding),
       patternBinding.initializer == nil,
       let variableDecl = nearestAncestor(of: patternBinding, type: VariableDeclSyntax.self),
-      variableDecl.bindingKeyword.tokenKind == .keyword(.var)
+       variableDecl.bindingSpecifier.tokenKind == .keyword(.var)
     {
       return true
     }

--- a/Sources/SwiftFormatRules/UseSingleLinePropertyGetter.swift
+++ b/Sources/SwiftFormatRules/UseSingleLinePropertyGetter.swift
@@ -26,7 +26,7 @@ public final class UseSingleLinePropertyGetter: SyntaxFormatRule {
       let acc = accessorBlock.accessors.first,
       let body = acc.body,
       accessorBlock.accessors.count == 1,
-      acc.accessorKind.tokenKind == .keyword(.get),
+      acc.accessorSpecifier.tokenKind == .keyword(.get),
       acc.attributes == nil,
       acc.modifier == nil,
       acc.effectSpecifiers == nil

--- a/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
+++ b/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
@@ -51,7 +51,7 @@ public final class UseSynthesizedInitializer: SyntaxLintRule {
     for initializer in initializers {
       guard
         matchesPropertyList(
-          parameters: initializer.signature.input.parameterList,
+          parameters: initializer.signature.parameterClause.parameterList,
           properties: storedProperties)
       else { continue }
       guard
@@ -115,7 +115,7 @@ public final class UseSynthesizedInitializer: SyntaxLintRule {
       // Ensure that parameters that correspond to properties declared using 'var' have a default
       // argument that is identical to the property's default value. Otherwise, a default argument
       // doesn't match the memberwise initializer.
-      let isVarDecl = property.bindingKeyword.tokenKind == .keyword(.var)
+      let isVarDecl = property.bindingSpecifier.tokenKind == .keyword(.var)
       if isVarDecl, let initializer = property.firstInitializer {
         guard let defaultArg = parameter.defaultArgument else { return false }
         guard initializer.value.description == defaultArg.value.description else { return false }

--- a/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
@@ -35,7 +35,7 @@ public final class ValidateDocumentationComments: SyntaxLintRule {
   public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
     return checkFunctionLikeDocumentation(
       DeclSyntax(node), name: node.identifier.text, signature: node.signature,
-      returnClause: node.signature.output)
+      returnClause: node.signature.returnClause)
   }
 
   private func checkFunctionLikeDocumentation(
@@ -71,7 +71,7 @@ public final class ValidateDocumentationComments: SyntaxLintRule {
       name: name,
       returnsDescription: docComment.returns,
       node: node)
-    let funcParameters = funcParametersIdentifiers(in: signature.input.parameterList)
+    let funcParameters = funcParametersIdentifiers(in: signature.parameterClause.parameterList)
 
     // If the documentation of the parameters is wrong 'docCommentInfo' won't
     // parse the parameters correctly. First the documentation has to be fix

--- a/Sources/generate-pipeline/RuleCollector.swift
+++ b/Sources/generate-pipeline/RuleCollector.swift
@@ -125,7 +125,7 @@ final class RuleCollector {
       for member in members {
         guard let function = member.decl.as(FunctionDeclSyntax.self) else { continue }
         guard function.identifier.text == "visit" else { continue }
-        let params = function.signature.input.parameterList
+        let params = function.signature.parameterClause.parameterList
         guard let firstType = params.firstAndOnly?.type.as(SimpleTypeIdentifierSyntax.self) else {
           continue
         }


### PR DESCRIPTION
I have eliminated the usage of deprecated node names. All instances where deprecated names were used have been updated to their newer, current equivalents. 

I also have changed the names of some local properties to keep consistency with node names.