### PR TITLE
Add XCTest exclusion comment for lint rules

### DIFF
--- a/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
+++ b/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
@@ -16,6 +16,9 @@ import SwiftSyntax
 /// All values should be written in lower camel-case (`lowerCamelCase`).
 /// Underscores (except at the beginning of an identifier) are disallowed.
 ///
+/// This rule does not apply to test code, defined as code which:
+///   * Contains the line `import XCTest`
+///
 /// Lint: If an identifier contains underscores or begins with a capital letter, a lint error is
 ///       raised.
 public final class AlwaysUseLowerCamelCase: SyntaxLintRule {

--- a/Sources/SwiftFormatRules/NeverForceUnwrap.swift
+++ b/Sources/SwiftFormatRules/NeverForceUnwrap.swift
@@ -15,6 +15,9 @@ import SwiftSyntax
 
 /// Force-unwraps are strongly discouraged and must be documented.
 ///
+/// This rule does not apply to test code, defined as code which:
+///   * Contains the line `import XCTest`
+///
 /// Lint: If a force unwrap is used, a lint warning is raised.
 public final class NeverForceUnwrap: SyntaxLintRule {
 


### PR DESCRIPTION
Added a rule exclusion of XCTest to docs just like https://github.com/apple/swift-format/blob/main/Sources/SwiftFormatRules/NeverUseForceTry.swift#L18:L19