### PR TITLE
Fix deprecated warnings regarding swift-syntax changes

### DIFF
--- a/Sources/SwiftFormatRules/DoNotUseSemicolons.swift
+++ b/Sources/SwiftFormatRules/DoNotUseSemicolons.swift
@@ -74,10 +74,11 @@ public final class DoNotUseSemicolons: SyntaxFormatRule {
         // 'while' statement.
         if Syntax(item).as(CodeBlockItemSyntax.self)?
           .children(viewMode: .sourceAccurate).first?.is(DoStmtSyntax.self) == true,
-          idx < node.count - 1
+          idx < node.count - 1,
+          let childrenIdx = node.index(of: item)
         {
           let children = node.children(viewMode: .sourceAccurate)
-          let nextItem = children[children.index(after: item.index)]
+          let nextItem = children[children.index(after: childrenIdx)]
           if Syntax(nextItem).as(CodeBlockItemSyntax.self)?
             .children(viewMode: .sourceAccurate).first?.is(WhileStmtSyntax.self) == true
           {

--- a/Sources/SwiftFormatRules/UseWhereClausesInForLoops.swift
+++ b/Sources/SwiftFormatRules/UseWhereClausesInForLoops.swift
@@ -85,7 +85,7 @@ public final class UseWhereClausesInForLoops: SyntaxFormatRule {
       return updateWithWhereCondition(
         node: forInStmt,
         condition: condition,
-        statements: forInStmt.body.statements.removingFirst()
+        statements: CodeBlockItemListSyntax(forInStmt.body.statements.dropFirst())
       )
 
     default:


### PR DESCRIPTION
Applied below changes to fix deprecated warnings
- [x] Pound keyword suffix
- [x] CollectionType method