### PR TITLE
Adjustments for node renames in swift-syntax

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -3360,8 +3360,8 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   private func maybeGroupAroundSubexpression(
     _ expr: ExprSyntax, combiningOperator operatorExpr: ExprSyntax? = nil
   ) {
-    switch Syntax(expr).as(SyntaxEnum.self) {
-    case .memberAccessExpr, .subscriptExpr:
+    switch Syntax(expr).kind {
+    case .memberAccessExpr, .subscriptCallExpr:
       before(expr.firstToken(viewMode: .sourceAccurate), tokens: .open)
       after(expr.lastToken(viewMode: .sourceAccurate), tokens: .close)
     default:
@@ -3458,19 +3458,19 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       return leftmostExpr(of: asExpr.expression, ifMatching: predicate)
     case .isExpr(let isExpr):
       return leftmostExpr(of: isExpr.expression, ifMatching: predicate)
-    case .forcedValueExpr(let forcedValueExpr):
+    case .forceUnwrapExpr(let forcedValueExpr):
       return leftmostExpr(of: forcedValueExpr.expression, ifMatching: predicate)
     case .optionalChainingExpr(let optionalChainingExpr):
       return leftmostExpr(of: optionalChainingExpr.expression, ifMatching: predicate)
-    case .postfixUnaryExpr(let postfixUnaryExpr):
+    case .postfixOperatorExpr(let postfixUnaryExpr):
       return leftmostExpr(of: postfixUnaryExpr.expression, ifMatching: predicate)
     case .prefixOperatorExpr(let prefixOperatorExpr):
-      return leftmostExpr(of: prefixOperatorExpr.base, ifMatching: predicate)
+      return leftmostExpr(of: prefixOperatorExpr.expression, ifMatching: predicate)
     case .ternaryExpr(let ternaryExpr):
       return leftmostExpr(of: ternaryExpr.condition, ifMatching: predicate)
     case .functionCallExpr(let functionCallExpr):
       return leftmostExpr(of: functionCallExpr.calledExpression, ifMatching: predicate)
-    case .subscriptExpr(let subscriptExpr):
+    case .subscriptCallExpr(let subscriptExpr):
       return leftmostExpr(of: subscriptExpr.calledExpression, ifMatching: predicate)
     case .memberAccessExpr(let memberAccessExpr):
       return memberAccessExpr.base.flatMap { leftmostExpr(of: $0, ifMatching: predicate) }

--- a/Sources/SwiftFormatRules/DontRepeatTypeInStaticProperties.swift
+++ b/Sources/SwiftFormatRules/DontRepeatTypeInStaticProperties.swift
@@ -46,9 +46,9 @@ public final class DontRepeatTypeInStaticProperties: SyntaxLintRule {
     let members = node.memberBlock.members
 
     switch Syntax(node.extendedType).as(SyntaxEnum.self) {
-    case .simpleTypeIdentifier(let simpleType):
+    case .identifierType(let simpleType):
       diagnoseStaticMembers(members, endingWith: simpleType.name.text)
-    case .memberTypeIdentifier(let memberType):
+    case .memberType(let memberType):
       // We don't need to drill recursively into this structure because types with more than two
       // components are constructed left-heavy; that is, `A.B.C.D` is structured as `((A.B).C).D`,
       // and the final component of the top type is what we want.

--- a/Sources/SwiftFormatRules/FileScopedDeclarationPrivacy.swift
+++ b/Sources/SwiftFormatRules/FileScopedDeclarationPrivacy.swift
@@ -91,7 +91,7 @@ public final class FileScopedDeclarationPrivacy: SyntaxFormatRule {
           modifiers: protocolDecl.modifiers,
           factory: { protocolDecl.with(\.modifiers, $0) }))
 
-    case .typealiasDecl(let typealiasDecl):
+    case .typeAliasDecl(let typealiasDecl):
       return DeclSyntax(rewrittenDecl(
           typealiasDecl,
           modifiers: typealiasDecl.modifiers,

--- a/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
+++ b/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
@@ -241,7 +241,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
       // otherwise the "?" applies to the return type instead of the function type. Attach the
       // leading trivia to the left-paren that we're adding in this case.
       let tupleTypeElement = TupleTypeElementSyntax(
-        inoutKeyword: nil, name: nil, secondName: nil, colon: nil, type: TypeSyntax(functionType),
+        inoutKeyword: nil, firstName: nil, secondName: nil, colon: nil, type: TypeSyntax(functionType),
         ellipsis: nil, initializer: nil, trailingComma: nil)
       let tupleTypeElementList = TupleTypeElementListSyntax([tupleTypeElement])
       let tupleType = TupleTypeSyntax(
@@ -360,7 +360,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
   /// written `Array<Int>.Index` to compile correctly.
   private func expressionRepresentation(of type: TypeSyntax) -> ExprSyntax? {
     switch Syntax(type).as(SyntaxEnum.self) {
-    case .simpleTypeIdentifier(let simpleTypeIdentifier):
+    case .identifierType(let simpleTypeIdentifier):
       let identifierExpr = IdentifierExprSyntax(
         identifier: simpleTypeIdentifier.name,
         declNameArguments: nil)
@@ -378,7 +378,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
         return ExprSyntax(identifierExpr)
       }
 
-    case .memberTypeIdentifier(let memberTypeIdentifier):
+    case .memberType(let memberTypeIdentifier):
       guard let baseType = expressionRepresentation(of: memberTypeIdentifier.baseType) else {
         return nil
       }


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1949