### PR TITLE
Use `where` instead of filter for `for` loops

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -744,7 +744,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
     // An if-configuration clause around a switch-case encloses the case's node, so an
     // if-configuration clause requires a break here in order to be allowed on a new line.
-    for ifConfigDecl in node.cases.filter({ $0.is(IfConfigDeclSyntax.self) }) {
+    for ifConfigDecl in node.cases where ifConfigDecl.is(IfConfigDeclSyntax.self) {
       if config.indentSwitchCaseLabels {
         before(ifConfigDecl.firstToken(viewMode: .sourceAccurate), tokens: .break(.open))
         after(ifConfigDecl.lastToken(viewMode: .sourceAccurate), tokens: .break(.close, size: 0))


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1958

With https://github.com/apple/swift-syntax/pull/1958, `node.filter` will return a new `SyntaxCollection` that has the filtered elements removed (instead of the array it’s currently returning). Since that node has elements removed, it will have a new parent and thus all the nodes inside of it have new IDs. Use `where` after `for` to get the elements with the same IDs and just don’t iterate the elements that don’t satisfy the condition. This is also more performant because it doesn’t create an intermediate array.
