### PR TITLE
Adjustments for usage of `DeclReferenceExprSyntax` as child of `MemberAccessExprSyntax`

### DIFF
--- a/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
+++ b/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
@@ -385,8 +385,8 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
       let result = MemberAccessExprSyntax(
         base: baseType,
         period: memberTypeIdentifier.period,
-        name: memberTypeIdentifier.name,
-        declNameArguments: nil)
+        name: memberTypeIdentifier.name
+      )
       return ExprSyntax(result)
 
     case .arrayType(let arrayType):


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1950