### PR TITLE
[Core] Add new finding severity kinds - `refactoring` and `convention`

### DIFF
--- a/Sources/SwiftFormatCore/Finding.swift
+++ b/Sources/SwiftFormatCore/Finding.swift
@@ -17,6 +17,7 @@ public struct Finding {
     case warning
     case error
     case refactoring
+    case convention
   }
 
   /// The file path and location in that file where a finding was encountered.

--- a/Sources/SwiftFormatCore/Finding.swift
+++ b/Sources/SwiftFormatCore/Finding.swift
@@ -16,6 +16,7 @@ public struct Finding {
   public enum Severity {
     case warning
     case error
+    case refactoring
   }
 
   /// The file path and location in that file where a finding was encountered.

--- a/Sources/SwiftFormatCore/Rule.swift
+++ b/Sources/SwiftFormatCore/Rule.swift
@@ -46,6 +46,7 @@ extension Rule {
   public func diagnose<SyntaxType: SyntaxProtocol>(
     _ message: Finding.Message,
     on node: SyntaxType?,
+    severity: Finding.Severity? = nil,
     leadingTriviaIndex: Trivia.Index? = nil,
     notes: [Finding.Note] = []
   ) {
@@ -57,9 +58,10 @@ extension Rule {
       syntaxLocation = node?.startLocation(converter: context.sourceLocationConverter)
     }
 
+    let category = RuleBasedFindingCategory(ruleType: type(of: self), severity: severity)
     context.findingEmitter.emit(
         message,
-        category: RuleBasedFindingCategory(ruleType: type(of: self)),
+        category: category,
         location: syntaxLocation.flatMap(Finding.Location.init),
         notes: notes)
   }

--- a/Sources/SwiftFormatCore/RuleBasedFindingCategory.swift
+++ b/Sources/SwiftFormatCore/RuleBasedFindingCategory.swift
@@ -22,8 +22,11 @@ struct RuleBasedFindingCategory: FindingCategorizing {
 
   var description: String { ruleType.ruleName }
 
+  var severity: Finding.Severity?
+
   /// Creates a finding category that wraps the given rule type.
-  init(ruleType: Rule.Type) {
+  init(ruleType: Rule.Type, severity: Finding.Severity? = nil) {
     self.ruleType = ruleType
+    self.severity = severity
   }
 }

--- a/Sources/swift-format/Utilities/DiagnosticsEngine.swift
+++ b/Sources/swift-format/Utilities/DiagnosticsEngine.swift
@@ -116,6 +116,7 @@ final class DiagnosticsEngine {
     switch finding.severity {
     case .error: severity = .error
     case .warning: severity = .warning
+    case .refactoring: severity = .warning
     }
     return Diagnostic(
       severity: severity,

--- a/Sources/swift-format/Utilities/DiagnosticsEngine.swift
+++ b/Sources/swift-format/Utilities/DiagnosticsEngine.swift
@@ -117,6 +117,7 @@ final class DiagnosticsEngine {
     case .error: severity = .error
     case .warning: severity = .warning
     case .refactoring: severity = .warning
+    case .convention: severity = .warning
     }
     return Diagnostic(
       severity: severity,


### PR DESCRIPTION
- Refactoring identifies an actionable feedback to the developer and has higher impact than a general warning.
- Identifies programming conventions such as for naming types and functions.

If/when this lands I'll open PRs to add a few common refactoring and convention rules.