### PR TITLE
Fix deprecation warnings from renamed nodes / types in SwiftSyntax

### DIFF
--- a/Sources/SwiftFormat/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Pipelines+Generated.swift
@@ -39,7 +39,7 @@ class LintPipeline: SyntaxVisitor {
     return .visitChildren
   }
 
-  override func visit(_ node: AssociatedtypeDeclSyntax) -> SyntaxVisitorContinueKind {
+  override func visit(_ node: AssociatedTypeDeclSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
     return .visitChildren
@@ -119,12 +119,12 @@ class LintPipeline: SyntaxVisitor {
     return .visitChildren
   }
 
-  override func visit(_ node: ForInStmtSyntax) -> SyntaxVisitorContinueKind {
+  override func visit(_ node: ForStmtSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(UseWhereClausesInForLoops.visit, for: node)
     return .visitChildren
   }
 
-  override func visit(_ node: ForcedValueExprSyntax) -> SyntaxVisitorContinueKind {
+  override func visit(_ node: ForceUnwrapExprSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NeverForceUnwrap.visit, for: node)
     return .visitChildren
   }
@@ -194,12 +194,12 @@ class LintPipeline: SyntaxVisitor {
     return .visitChildren
   }
 
-  override func visit(_ node: MemberDeclBlockSyntax) -> SyntaxVisitorContinueKind {
+  override func visit(_ node: MemberBlockSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(AmbiguousTrailingClosureOverload.visit, for: node)
     return .visitChildren
   }
 
-  override func visit(_ node: MemberDeclListSyntax) -> SyntaxVisitorContinueKind {
+  override func visit(_ node: MemberBlockItemListSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(DoNotUseSemicolons.visit, for: node)
     return .visitChildren
   }
@@ -228,12 +228,12 @@ class LintPipeline: SyntaxVisitor {
     return .visitChildren
   }
 
-  override func visit(_ node: RepeatWhileStmtSyntax) -> SyntaxVisitorContinueKind {
+  override func visit(_ node: RepeatStmtSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NoParensAroundConditions.visit, for: node)
     return .visitChildren
   }
 
-  override func visit(_ node: SimpleTypeIdentifierSyntax) -> SyntaxVisitorContinueKind {
+  override func visit(_ node: IdentifierTypeSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(UseShorthandTypeNames.visit, for: node)
     return .visitChildren
   }
@@ -249,7 +249,7 @@ class LintPipeline: SyntaxVisitor {
     return .visitChildren
   }
 
-  override func visit(_ node: SpecializeExprSyntax) -> SyntaxVisitorContinueKind {
+  override func visit(_ node: GenericSpecializationExprSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(UseShorthandTypeNames.visit, for: node)
     return .visitChildren
   }
@@ -296,7 +296,7 @@ class LintPipeline: SyntaxVisitor {
     return .visitChildren
   }
 
-  override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
+  override func visit(_ node: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, for: node)
     visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)

--- a/Sources/SwiftFormatCore/RuleMask.swift
+++ b/Sources/SwiftFormatCore/RuleMask.swift
@@ -165,7 +165,7 @@ fileprivate class RuleStatusCollectionVisitor: SyntaxVisitor {
     return appendRuleStatusDirectives(from: firstToken, of: Syntax(node))
   }
 
-  override func visit(_ node: MemberDeclListItemSyntax) -> SyntaxVisitorContinueKind {
+  override func visit(_ node: MemberBlockItemSyntax) -> SyntaxVisitorContinueKind {
     guard let firstToken = node.firstToken(viewMode: .sourceAccurate) else {
       return .visitChildren
     }

--- a/Sources/SwiftFormatRules/AddModifierRewriter.swift
+++ b/Sources/SwiftFormatRules/AddModifierRewriter.swift
@@ -49,7 +49,7 @@ fileprivate final class AddModifierRewriter: SyntaxRewriter {
     return DeclSyntax(node.with(\.modifiers, newModifiers))
   }
 
-  override func visit(_ node: AssociatedtypeDeclSyntax) -> DeclSyntax {
+  override func visit(_ node: AssociatedTypeDeclSyntax) -> DeclSyntax {
     // Check for modifiers, and, if none, insert the modifier and relocate trivia from the displaced
     // token.
     guard let modifiers = node.modifiers else {
@@ -114,7 +114,7 @@ fileprivate final class AddModifierRewriter: SyntaxRewriter {
     return DeclSyntax(node.with(\.modifiers, newModifiers))
   }
 
-  override func visit(_ node: TypealiasDeclSyntax) -> DeclSyntax {
+  override func visit(_ node: TypeAliasDeclSyntax) -> DeclSyntax {
     // Check for modifiers, and, if none, insert the modifier and relocate trivia from the displaced
     // token.
     guard let modifiers = node.modifiers else {
@@ -163,7 +163,7 @@ fileprivate final class AddModifierRewriter: SyntaxRewriter {
   /// - Parameter modifiersProvider: A closure that returns all modifiers for the given node.
   private func nodeByRelocatingTrivia<NodeType: DeclSyntaxProtocol>(
     in node: NodeType,
-    for modifiersProvider: (NodeType) -> ModifierListSyntax?
+    for modifiersProvider: (NodeType) -> DeclModifierListSyntax?
   ) -> NodeType {
     guard let modifier = modifiersProvider(node)?.firstAndOnly,
       let movingLeadingTrivia = modifier.nextToken(viewMode: .sourceAccurate)?.leadingTrivia

--- a/Sources/SwiftFormatRules/AllPublicDeclarationsHaveDocumentation.swift
+++ b/Sources/SwiftFormatRules/AllPublicDeclarationsHaveDocumentation.swift
@@ -65,7 +65,7 @@ public final class AllPublicDeclarationsHaveDocumentation: SyntaxLintRule {
     return .skipChildren
   }
 
-  public override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseMissingDocComment(DeclSyntax(node), name: node.name.text, modifiers: node.modifiers)
     return .skipChildren
   }
@@ -73,7 +73,7 @@ public final class AllPublicDeclarationsHaveDocumentation: SyntaxLintRule {
   private func diagnoseMissingDocComment(
     _ decl: DeclSyntax,
     name: String,
-    modifiers: ModifierListSyntax?
+    modifiers: DeclModifierListSyntax?
   ) {
     guard
       documentationCommentText(extractedFrom: decl.leadingTrivia) == nil,

--- a/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
+++ b/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
@@ -71,7 +71,7 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
 
   public override func visit(_ node: ClosureSignatureSyntax) -> SyntaxVisitorContinueKind {
     if let input = node.parameterClause {
-      if let closureParamList = input.as(ClosureParamListSyntax.self) {
+      if let closureParamList = input.as(ClosureShorthandParameterListSyntax.self) {
         for param in closureParamList {
           diagnoseLowerCamelCaseViolations(
             param.name, allowUnderscores: false, description: identifierDescription(for: node))
@@ -96,7 +96,7 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
               secondName, allowUnderscores: false, description: identifierDescription(for: node))
           }
         }
-      } else if let parameterClause = input.as(ParameterClauseSyntax.self) {
+      } else if let parameterClause = input.as(FunctionParameterClauseSyntax.self) {
         for param in parameterClause.parameters {
           diagnoseLowerCamelCaseViolations(
             param.firstName, allowUnderscores: false, description: identifierDescription(for: node))
@@ -146,14 +146,14 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
   /// Collects methods that look like XCTest test case methods from the given member list, inserting
   /// them into the given set.
   private func collectTestMethods(
-    from members: MemberDeclListSyntax,
+    from members: MemberBlockItemListSyntax,
     into set: inout Set<FunctionDeclSyntax>
   ) {
     for member in members {
       if let ifConfigDecl = member.decl.as(IfConfigDeclSyntax.self) {
         // Recurse into any conditional member lists and collect their test methods as well.
         for clause in ifConfigDecl.clauses {
-          if let clauseMembers = clause.elements?.as(MemberDeclListSyntax.self) {
+          if let clauseMembers = clause.elements?.as(MemberBlockItemListSyntax.self) {
             collectTestMethods(from: clauseMembers, into: &set)
           }
         }
@@ -203,7 +203,7 @@ fileprivate func identifierDescription<NodeType: SyntaxProtocol>(for node: NodeT
 extension ReturnClauseSyntax {
   /// Whether this return clause specifies an explicit `Void` return type.
   fileprivate var isVoid: Bool {
-    if let returnTypeIdentifier = type.as(SimpleTypeIdentifierSyntax.self) {
+    if let returnTypeIdentifier = type.as(IdentifierTypeSyntax.self) {
       return returnTypeIdentifier.name.text == "Void"
     }
     if let returnTypeTuple = type.as(TupleTypeSyntax.self) {

--- a/Sources/SwiftFormatRules/AmbiguousTrailingClosureOverload.swift
+++ b/Sources/SwiftFormatRules/AmbiguousTrailingClosureOverload.swift
@@ -65,7 +65,7 @@ public final class AmbiguousTrailingClosureOverload: SyntaxLintRule {
     return .visitChildren
   }
 
-  public override func visit(_ decls: MemberDeclBlockSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ decls: MemberBlockSyntax) -> SyntaxVisitorContinueKind {
     let functions = decls.members.compactMap { $0.decl.as(FunctionDeclSyntax.self) }
     discoverAndDiagnoseOverloads(functions)
     return .visitChildren

--- a/Sources/SwiftFormatRules/BeginDocumentationCommentWithOneLineSummary.swift
+++ b/Sources/SwiftFormatRules/BeginDocumentationCommentWithOneLineSummary.swift
@@ -75,12 +75,12 @@ public final class BeginDocumentationCommentWithOneLineSummary: SyntaxLintRule {
     return .skipChildren
   }
 
-  public override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseDocComments(in: DeclSyntax(node))
     return .skipChildren
   }
 
-  public override func visit(_ node: AssociatedtypeDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: AssociatedTypeDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseDocComments(in: DeclSyntax(node))
     return .skipChildren
   }

--- a/Sources/SwiftFormatRules/DoNotUseSemicolons.swift
+++ b/Sources/SwiftFormatRules/DoNotUseSemicolons.swift
@@ -103,8 +103,8 @@ public final class DoNotUseSemicolons: SyntaxFormatRule {
     return nodeByRemovingSemicolons(from: node, nodeCreator: CodeBlockItemListSyntax.init)
   }
 
-  public override func visit(_ node: MemberDeclListSyntax) -> MemberDeclListSyntax {
-    return nodeByRemovingSemicolons(from: node, nodeCreator: MemberDeclListSyntax.init)
+  public override func visit(_ node: MemberBlockItemListSyntax) -> MemberBlockItemListSyntax {
+    return nodeByRemovingSemicolons(from: node, nodeCreator: MemberBlockItemListSyntax.init)
   }
 }
 

--- a/Sources/SwiftFormatRules/DontRepeatTypeInStaticProperties.swift
+++ b/Sources/SwiftFormatRules/DontRepeatTypeInStaticProperties.swift
@@ -65,7 +65,7 @@ public final class DontRepeatTypeInStaticProperties: SyntaxLintRule {
   /// Iterates over the static/class properties in the given member list and diagnoses any where the
   /// name has the containing type name (excluding possible namespace prefixes, like `NS` or `UI`)
   /// as a suffix.
-  private func diagnoseStaticMembers(_ members: MemberDeclListSyntax, endingWith typeName: String) {
+  private func diagnoseStaticMembers(_ members: MemberBlockItemListSyntax, endingWith typeName: String) {
     for member in members {
       guard
         let varDecl = member.decl.as(VariableDeclSyntax.self),

--- a/Sources/SwiftFormatRules/FileScopedDeclarationPrivacy.swift
+++ b/Sources/SwiftFormatRules/FileScopedDeclarationPrivacy.swift
@@ -135,8 +135,8 @@ public final class FileScopedDeclarationPrivacy: SyntaxFormatRule {
   /// - Returns: A new node if the modifiers were rewritten, or the original node if not.
   private func rewrittenDecl<DeclType: DeclSyntaxProtocol>(
     _ decl: DeclType,
-    modifiers: ModifierListSyntax?,
-    factory: (ModifierListSyntax?) -> DeclType
+    modifiers: DeclModifierListSyntax?,
+    factory: (DeclModifierListSyntax?) -> DeclType
   ) -> DeclType {
     let invalidAccess: TokenKind
     let validAccess: TokenKind
@@ -165,7 +165,7 @@ public final class FileScopedDeclarationPrivacy: SyntaxFormatRule {
       }
       return modifier
     }
-    return factory(ModifierListSyntax(newModifiers))
+    return factory(DeclModifierListSyntax(newModifiers))
   }
 }
 

--- a/Sources/SwiftFormatRules/FullyIndirectEnum.swift
+++ b/Sources/SwiftFormatRules/FullyIndirectEnum.swift
@@ -35,7 +35,7 @@ public final class FullyIndirectEnum: SyntaxFormatRule {
 
     // Removes 'indirect' keyword from cases, reformats
     let newMembers = enumMembers.map {
-      (member: MemberDeclListItemSyntax) -> MemberDeclListItemSyntax in
+      (member: MemberBlockItemSyntax) -> MemberBlockItemSyntax in
       guard let caseMember = member.decl.as(EnumCaseDeclSyntax.self),
         let modifiers = caseMember.modifiers,
         modifiers.has(modifier: "indirect"),
@@ -70,14 +70,14 @@ public final class FullyIndirectEnum: SyntaxFormatRule {
       name: TokenSyntax.identifier(
         "indirect", leadingTrivia: leadingTrivia, trailingTrivia: .spaces(1)), detail: nil)
 
-    let newMemberBlock = node.memberBlock.with(\.members, MemberDeclListSyntax(newMembers))
+    let newMemberBlock = node.memberBlock.with(\.members, MemberBlockItemListSyntax(newMembers))
     return DeclSyntax(newEnumDecl.addModifier(newModifier).with(\.memberBlock, newMemberBlock))
   }
 
   /// Returns a value indicating whether all enum cases in the given list are indirect.
   ///
   /// Note that if the enum has no cases, this returns false.
-  private func allCasesAreIndirect(in members: MemberDeclListSyntax) -> Bool {
+  private func allCasesAreIndirect(in members: MemberBlockItemListSyntax) -> Bool {
     var hadCases = false
     for member in members {
       if let caseMember = member.decl.as(EnumCaseDeclSyntax.self) {

--- a/Sources/SwiftFormatRules/GroupNumericLiterals.swift
+++ b/Sources/SwiftFormatRules/GroupNumericLiterals.swift
@@ -27,7 +27,7 @@ import SwiftSyntax
 /// TODO: Handle floating point literals.
 public final class GroupNumericLiterals: SyntaxFormatRule {
   public override func visit(_ node: IntegerLiteralExprSyntax) -> ExprSyntax {
-    var originalDigits = node.digits.text
+    var originalDigits = node.literal.text
     guard !originalDigits.contains("_") else { return ExprSyntax(node) }
 
     let isNegative = originalDigits.first == "-"
@@ -59,11 +59,11 @@ public final class GroupNumericLiterals: SyntaxFormatRule {
     }
 
     newDigits = isNegative ? "-" + newDigits : newDigits
-    let result = node.with(\.digits,
+    let result = node.with(\.literal,
       TokenSyntax.integerLiteral(
         newDigits,
-        leadingTrivia: node.digits.leadingTrivia,
-        trailingTrivia: node.digits.trailingTrivia))
+        leadingTrivia: node.literal.leadingTrivia,
+        trailingTrivia: node.literal.trailingTrivia))
     return ExprSyntax(result)
   }
 

--- a/Sources/SwiftFormatRules/ModifierListSyntax+Convenience.swift
+++ b/Sources/SwiftFormatRules/ModifierListSyntax+Convenience.swift
@@ -12,7 +12,7 @@
 
 import SwiftSyntax
 
-extension ModifierListSyntax {
+extension DeclModifierListSyntax {
 
   func has(modifier: String) -> Bool {
     return contains { $0.name.text == modifier }
@@ -36,9 +36,9 @@ extension ModifierListSyntax {
   }
 
   /// Returns modifier list without the given modifier.
-  func remove(name: String) -> ModifierListSyntax {
+  func remove(name: String) -> DeclModifierListSyntax {
     let newModifiers = filter { $0.name.text != name }
-    return ModifierListSyntax(newModifiers)
+    return DeclModifierListSyntax(newModifiers)
   }
 
   /// Returns a formatted declaration modifier token with the given name.
@@ -53,7 +53,7 @@ extension ModifierListSyntax {
   func insert(
     modifier: DeclModifierSyntax, at index: Int,
     formatTrivia: Bool = true
-  ) -> ModifierListSyntax {
+  ) -> DeclModifierListSyntax {
     guard index >= 0, index <= count else { return self }
 
     var newModifiers: [DeclModifierSyntax] = []
@@ -68,11 +68,11 @@ extension ModifierListSyntax {
     if index == 0 {
       guard formatTrivia else {
         newModifiers.insert(modifier, at: index)
-        return ModifierListSyntax(newModifiers)
+        return DeclModifierListSyntax(newModifiers)
       }
       guard let firstMod = first, let firstTok = firstMod.firstToken(viewMode: .sourceAccurate) else {
         newModifiers.insert(modifier, at: index)
-        return ModifierListSyntax(newModifiers)
+        return DeclModifierListSyntax(newModifiers)
       }
       let formattedMod = replaceTrivia(
         on: modifier,
@@ -84,22 +84,22 @@ extension ModifierListSyntax {
         leadingTrivia: [],
         trailingTrivia: .spaces(1))
       newModifiers.insert(formattedMod, at: 0)
-      return ModifierListSyntax(newModifiers)
+      return DeclModifierListSyntax(newModifiers)
     } else {
       newModifiers.insert(modifier, at: index)
-      return ModifierListSyntax(newModifiers)
+      return DeclModifierListSyntax(newModifiers)
     }
   }
 
   /// Returns modifier list with the given modifier at the end.
   /// Trivia manipulation optional by 'formatTrivia'
-  func append(modifier: DeclModifierSyntax, formatTrivia: Bool = true) -> ModifierListSyntax {
+  func append(modifier: DeclModifierSyntax, formatTrivia: Bool = true) -> DeclModifierListSyntax {
     return insert(modifier: modifier, at: count, formatTrivia: formatTrivia)
   }
 
   /// Returns modifier list with the given modifier at the beginning.
   /// Trivia manipulation optional by 'formatTrivia'
-  func prepend(modifier: DeclModifierSyntax, formatTrivia: Bool = true) -> ModifierListSyntax {
+  func prepend(modifier: DeclModifierSyntax, formatTrivia: Bool = true) -> DeclModifierListSyntax {
     return insert(modifier: modifier, at: 0, formatTrivia: formatTrivia)
   }
 }

--- a/Sources/SwiftFormatRules/NeverForceUnwrap.swift
+++ b/Sources/SwiftFormatRules/NeverForceUnwrap.swift
@@ -32,7 +32,7 @@ public final class NeverForceUnwrap: SyntaxLintRule {
     return .visitChildren
   }
 
-  public override func visit(_ node: ForcedValueExprSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: ForceUnwrapExprSyntax) -> SyntaxVisitorContinueKind {
     guard context.importsXCTest == .doesNotImportXCTest else { return .skipChildren }
     diagnose(.doNotForceUnwrap(name: node.expression.with(\.leadingTrivia, []).with(\.trailingTrivia, []).description), on: node)
     return .skipChildren

--- a/Sources/SwiftFormatRules/NeverUseImplicitlyUnwrappedOptionals.swift
+++ b/Sources/SwiftFormatRules/NeverUseImplicitlyUnwrappedOptionals.swift
@@ -42,7 +42,7 @@ public final class NeverUseImplicitlyUnwrappedOptionals: SyntaxLintRule {
     // Ignores IBOutlet variables
     if let attributes = node.attributes {
       for attribute in attributes {
-        if (attribute.as(AttributeSyntax.self))?.attributeName.as(SimpleTypeIdentifierSyntax.self)?.name.text == "IBOutlet" {
+        if (attribute.as(AttributeSyntax.self))?.attributeName.as(IdentifierTypeSyntax.self)?.name.text == "IBOutlet" {
           return .skipChildren
         }
       }

--- a/Sources/SwiftFormatRules/NoAccessLevelOnExtensionDeclaration.swift
+++ b/Sources/SwiftFormatRules/NoAccessLevelOnExtensionDeclaration.swift
@@ -44,7 +44,7 @@ public final class NoAccessLevelOnExtensionDeclaration: SyntaxFormatRule {
         accessKeywordToAdd = accessKeyword
       }
 
-      let newMembers = MemberDeclBlockSyntax(
+      let newMembers = MemberBlockSyntax(
         leftBrace: node.memberBlock.leftBrace,
         members: addMemberAccessKeywords(memDeclBlock: node.memberBlock, keyword: accessKeywordToAdd),
         rightBrace: node.memberBlock.rightBrace)
@@ -78,10 +78,10 @@ public final class NoAccessLevelOnExtensionDeclaration: SyntaxFormatRule {
 
   // Adds given keyword to all members in declaration block
   private func addMemberAccessKeywords(
-    memDeclBlock: MemberDeclBlockSyntax,
+    memDeclBlock: MemberBlockSyntax,
     keyword: DeclModifierSyntax
-  ) -> MemberDeclListSyntax {
-    var newMembers: [MemberDeclListItemSyntax] = []
+  ) -> MemberBlockItemListSyntax {
+    var newMembers: [MemberBlockItemSyntax] = []
     let formattedKeyword = replaceTrivia(
       on: keyword,
       token: keyword.name,
@@ -96,7 +96,7 @@ public final class NoAccessLevelOnExtensionDeclaration: SyntaxFormatRule {
       else { continue }
       newMembers.append(memberItem.with(\.decl, newDecl))
     }
-    return MemberDeclListSyntax(newMembers)
+    return MemberBlockItemListSyntax(newMembers)
   }
 }
 

--- a/Sources/SwiftFormatRules/NoAssignmentInExpressions.swift
+++ b/Sources/SwiftFormatRules/NoAssignmentInExpressions.swift
@@ -102,10 +102,10 @@ public final class NoAssignmentInExpressions: SyntaxFormatRule {
   /// expression (either simple assignment with `=` or compound assignment with an operator like
   /// `+=`).
   private func isAssignmentExpression(_ expr: InfixOperatorExprSyntax) -> Bool {
-    if expr.operatorOperand.is(AssignmentExprSyntax.self) {
+    if expr.operator.is(AssignmentExprSyntax.self) {
       return true
     }
-    guard let binaryOp = expr.operatorOperand.as(BinaryOperatorExprSyntax.self) else {
+    guard let binaryOp = expr.operator.as(BinaryOperatorExprSyntax.self) else {
       return false
     }
     return context.operatorTable.infixOperator(named: binaryOp.operator.text)?.precedenceGroup

--- a/Sources/SwiftFormatRules/NoCasesWithOnlyFallthrough.swift
+++ b/Sources/SwiftFormatRules/NoCasesWithOnlyFallthrough.swift
@@ -126,7 +126,7 @@ public final class NoCasesWithOnlyFallthrough: SyntaxFormatRule {
 
     // When there are any additional or non-fallthrough statements, it isn't only a fallthrough.
     guard let onlyStatement = switchCase.statements.firstAndOnly,
-      onlyStatement.item.is(FallthroughStmtSyntax.self)
+      onlyStatement.item.is(FallThroughStmtSyntax.self)
     else {
       return false
     }
@@ -168,7 +168,7 @@ public final class NoCasesWithOnlyFallthrough: SyntaxFormatRule {
       return cases.first!
     }
 
-    var newCaseItems: [CaseItemSyntax] = []
+    var newCaseItems: [SwitchCaseItemSyntax] = []
     let labels = cases.lazy.compactMap({ $0.label.as(SwitchCaseLabelSyntax.self) })
     for label in labels.dropLast() {
       // We can blindly append all but the last case item because they must already have a trailing
@@ -188,7 +188,7 @@ public final class NoCasesWithOnlyFallthrough: SyntaxFormatRule {
     newCaseItems.append(contentsOf: labels.last!.caseItems)
 
     let newCase = cases.last!.with(\.label, .case(
-      labels.last!.with(\.caseItems, CaseItemListSyntax(newCaseItems))))
+      labels.last!.with(\.caseItems, SwitchCaseItemListSyntax(newCaseItems))))
 
     // Only the first violation case can have displaced trivia, because any non-whitespace
     // trivia in the other violation cases would've prevented collapsing.

--- a/Sources/SwiftFormatRules/NoLeadingUnderscores.swift
+++ b/Sources/SwiftFormatRules/NoLeadingUnderscores.swift
@@ -31,7 +31,7 @@ public final class NoLeadingUnderscores: SyntaxLintRule {
   /// doesn't intend for arbitrary usage.
   public override class var isOptIn: Bool { return true }
 
-  public override func visit(_ node: AssociatedtypeDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: AssociatedTypeDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseIfNameStartsWithUnderscore(node.name)
     return .visitChildren
   }
@@ -107,7 +107,7 @@ public final class NoLeadingUnderscores: SyntaxLintRule {
     return .visitChildren
   }
 
-  public override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {
     diagnoseIfNameStartsWithUnderscore(node.name)
     return .visitChildren
   }

--- a/Sources/SwiftFormatRules/NoParensAroundConditions.swift
+++ b/Sources/SwiftFormatRules/NoParensAroundConditions.swift
@@ -80,16 +80,16 @@ public final class NoParensAroundConditions: SyntaxFormatRule {
 
   /// FIXME(hbh): Parsing for SwitchExprSyntax is not implemented.
   public override func visit(_ node: SwitchExprSyntax) -> ExprSyntax {
-    guard let tup = node.expression.as(TupleExprSyntax.self),
+    guard let tup = node.subject.as(TupleExprSyntax.self),
       tup.elements.firstAndOnly != nil
     else {
       return super.visit(node)
     }
     return ExprSyntax(
-      node.with(\.expression, extractExpr(tup)).with(\.cases, visit(node.cases)))
+      node.with(\.subject, extractExpr(tup)).with(\.cases, visit(node.cases)))
   }
 
-  public override func visit(_ node: RepeatWhileStmtSyntax) -> StmtSyntax {
+  public override func visit(_ node: RepeatStmtSyntax) -> StmtSyntax {
     guard let tup = node.condition.as(TupleExprSyntax.self),
       tup.elements.firstAndOnly != nil
     else {

--- a/Sources/SwiftFormatRules/NoVoidReturnOnFunctionSignature.swift
+++ b/Sources/SwiftFormatRules/NoVoidReturnOnFunctionSignature.swift
@@ -24,7 +24,7 @@ public final class NoVoidReturnOnFunctionSignature: SyntaxFormatRule {
   /// it for closure signatures, because that may introduce an ambiguity when closure signatures
   /// are inferred.
   public override func visit(_ node: FunctionSignatureSyntax) -> FunctionSignatureSyntax {
-    if let returnType = node.returnClause?.type.as(SimpleTypeIdentifierSyntax.self), returnType.name.text == "Void" {
+    if let returnType = node.returnClause?.type.as(IdentifierTypeSyntax.self), returnType.name.text == "Void" {
       diagnose(.removeRedundantReturn("Void"), on: returnType)
       return node.with(\.returnClause, nil)
     }

--- a/Sources/SwiftFormatRules/OneCasePerLine.swift
+++ b/Sources/SwiftFormatRules/OneCasePerLine.swift
@@ -85,7 +85,7 @@ public final class OneCasePerLine: SyntaxFormatRule {
   }
 
   public override func visit(_ node: EnumDeclSyntax) -> DeclSyntax {
-    var newMembers: [MemberDeclListItemSyntax] = []
+    var newMembers: [MemberBlockItemSyntax] = []
 
     for member in node.memberBlock.members {
       // If it's not a case declaration, or it's a case declaration with only one element, leave it
@@ -100,7 +100,7 @@ public final class OneCasePerLine: SyntaxFormatRule {
       // Collect the elements of the case declaration until we see one that has either an associated
       // value or a raw value.
       for element in caseDecl.elements {
-        if element.associatedValue != nil || element.rawValue != nil {
+        if element.parameterClause != nil || element.rawValue != nil {
           // Once we reach one of these, we need to write out the ones we've collected so far, then
           // emit a separate case declaration with the associated/raw value element.
           diagnose(.moveAssociatedOrRawValueCase(name: element.name.text), on: element)
@@ -123,7 +123,7 @@ public final class OneCasePerLine: SyntaxFormatRule {
       }
     }
 
-    let newMemberBlock = node.memberBlock.with(\.members, MemberDeclListSyntax(newMembers))
+    let newMemberBlock = node.memberBlock.with(\.members, MemberBlockItemListSyntax(newMembers))
     return DeclSyntax(node.with(\.memberBlock, newMemberBlock))
   }
 }

--- a/Sources/SwiftFormatRules/ReturnVoidInsteadOfEmptyTuple.swift
+++ b/Sources/SwiftFormatRules/ReturnVoidInsteadOfEmptyTuple.swift
@@ -100,9 +100,9 @@ public final class ReturnVoidInsteadOfEmptyTuple: SyntaxFormatRule {
 
   /// Returns a type syntax node with the identifier `Void` whose leading and trailing trivia have
   /// been copied from the tuple type syntax node it is replacing.
-  private func makeVoidIdentifierType(toReplace node: TupleTypeSyntax) -> SimpleTypeIdentifierSyntax
+  private func makeVoidIdentifierType(toReplace node: TupleTypeSyntax) -> IdentifierTypeSyntax
   {
-    return SimpleTypeIdentifierSyntax(
+    return IdentifierTypeSyntax(
       name: TokenSyntax.identifier(
         "Void",
         leadingTrivia: node.firstToken(viewMode: .sourceAccurate)?.leadingTrivia ?? [],

--- a/Sources/SwiftFormatRules/SemicolonSyntaxProtocol.swift
+++ b/Sources/SwiftFormatRules/SemicolonSyntaxProtocol.swift
@@ -17,7 +17,7 @@ protocol SemicolonSyntaxProtocol: SyntaxProtocol {
   var semicolon: TokenSyntax? { get set }
 }
 
-extension MemberDeclListItemSyntax: SemicolonSyntaxProtocol {}
+extension MemberBlockItemSyntax: SemicolonSyntaxProtocol {}
 extension CodeBlockItemSyntax: SemicolonSyntaxProtocol {}
 
 extension Syntax {

--- a/Sources/SwiftFormatRules/UseLetInEveryBoundCaseVariable.swift
+++ b/Sources/SwiftFormatRules/UseLetInEveryBoundCaseVariable.swift
@@ -40,7 +40,7 @@ public final class UseLetInEveryBoundCaseVariable: SyntaxLintRule {
     while true {
       if let optionalExpr = expression.as(OptionalChainingExprSyntax.self) {
         expression = optionalExpr.expression
-      } else if let forcedExpr = expression.as(ForcedValueExprSyntax.self) {
+      } else if let forcedExpr = expression.as(ForceUnwrapExprSyntax.self) {
         expression = forcedExpr.expression
       } else {
         break

--- a/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
+++ b/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
@@ -22,7 +22,7 @@ import SwiftSyntax
 ///         converted to `[Element]`.
 public final class UseShorthandTypeNames: SyntaxFormatRule {
 
-  public override func visit(_ node: SimpleTypeIdentifierSyntax) -> TypeSyntax {
+  public override func visit(_ node: IdentifierTypeSyntax) -> TypeSyntax {
     // Ignore types that don't have generic arguments.
     guard let genericArgumentClause = node.genericArgumentClause else {
       return super.visit(node)
@@ -34,7 +34,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
     // `Foo<Array<Int>>.Bar` can still be transformed to `Foo<[Int]>.Bar` because the member
     // reference is not directly attached to the type that will be transformed, but we need to visit
     // the children so that we don't skip this).
-    guard let parent = node.parent, !parent.is(MemberTypeIdentifierSyntax.self) else {
+    guard let parent = node.parent, !parent.is(MemberTypeSyntax.self) else {
       return super.visit(node)
     }
 
@@ -98,7 +98,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
     return TypeSyntax(result)
   }
 
-  public override func visit(_ node: SpecializeExprSyntax) -> ExprSyntax {
+  public override func visit(_ node: GenericSpecializationExprSyntax) -> ExprSyntax {
     // `SpecializeExpr`s are found in the syntax tree when a generic type is encountered in an
     // expression context, such as `Array<Int>()`. In these situations, the corresponding array and
     // dictionary shorthand nodes will be expression nodes, not type nodes, so we may need to
@@ -106,7 +106,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
     // appropriate equivalent.
 
     // Ignore nodes where the expression being specialized isn't a simple identifier.
-    guard let expression = node.expression.as(IdentifierExprSyntax.self) else {
+    guard let expression = node.expression.as(DeclReferenceExprSyntax.self) else {
       return super.visit(node)
     }
 
@@ -130,7 +130,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
     let (leadingTrivia, trailingTrivia) = boundaryTrivia(around: Syntax(node))
     let newNode: ExprSyntax?
 
-    switch expression.identifier.text {
+    switch expression.baseName.text {
     case "Array":
       guard let typeArgument = genericArgumentList.firstAndOnly else {
         newNode = nil
@@ -171,7 +171,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
     }
 
     if let newNode = newNode {
-      diagnose(.useTypeShorthand(type: expression.identifier.text), on: expression)
+      diagnose(.useTypeShorthand(type: expression.baseName.text), on: expression)
       return newNode
     }
 
@@ -328,9 +328,9 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
       // otherwise the "?" applies to the return type instead of the function type. Attach the
       // leading trivia to the left-paren that we're adding in this case.
       let tupleExprElement =
-        TupleExprElementSyntax(
+        LabeledExprSyntax(
           label: nil, colon: nil, expression: wrappedTypeExpr, trailingComma: nil)
-      let tupleExprElementList = TupleExprElementListSyntax([tupleExprElement])
+      let tupleExprElementList = LabeledExprListSyntax([tupleExprElement])
       let tupleExpr = TupleExprSyntax(
         leftParen: TokenSyntax.leftParenToken(leadingTrivia: leadingTrivia ?? []),
         elements: tupleExprElementList,
@@ -361,16 +361,16 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
   private func expressionRepresentation(of type: TypeSyntax) -> ExprSyntax? {
     switch Syntax(type).as(SyntaxEnum.self) {
     case .identifierType(let simpleTypeIdentifier):
-      let identifierExpr = IdentifierExprSyntax(
-        identifier: simpleTypeIdentifier.name,
-        declNameArguments: nil)
+      let identifierExpr = DeclReferenceExprSyntax(
+        baseName: simpleTypeIdentifier.name,
+        argumentNames: nil)
 
       // If the type has a generic argument clause, we need to construct a `SpecializeExpr` to wrap
       // the identifier and the generic arguments. Otherwise, we can return just the
       // `IdentifierExpr` itself.
       if let genericArgumentClause = simpleTypeIdentifier.genericArgumentClause {
         let newGenericArgumentClause = visit(genericArgumentClause)
-        let result = SpecializeExprSyntax(
+        let result = GenericSpecializationExprSyntax(
           expression: ExprSyntax(identifierExpr),
           genericArgumentClause: newGenericArgumentClause)
         return ExprSyntax(result)
@@ -437,21 +437,21 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
   }
 
   private func expressionRepresentation(of tupleTypeElements: TupleTypeElementListSyntax)
-    -> TupleExprElementListSyntax?
+    -> LabeledExprListSyntax?
   {
     guard !tupleTypeElements.isEmpty else { return nil }
 
-    var exprElements = [TupleExprElementSyntax]()
+    var exprElements = [LabeledExprSyntax]()
     for typeElement in tupleTypeElements {
       guard let elementExpr = expressionRepresentation(of: typeElement.type) else { return nil }
       exprElements.append(
-        TupleExprElementSyntax(
-          label: typeElement.name,
+        LabeledExprSyntax(
+          label: typeElement.firstName,
           colon: typeElement.colon,
           expression: elementExpr,
           trailingComma: typeElement.trailingComma))
     }
-    return TupleExprElementListSyntax(exprElements)
+    return LabeledExprListSyntax(exprElements)
   }
 
   private func makeFunctionTypeExpression(
@@ -533,7 +533,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
 
   /// Returns true if the given type identifier node represents the type of a mutable variable or
   /// stored property that does not have an initializer clause.
-  private func isTypeOfUninitializedStoredVar(_ node: SimpleTypeIdentifierSyntax) -> Bool {
+  private func isTypeOfUninitializedStoredVar(_ node: IdentifierTypeSyntax) -> Bool {
     if let typeAnnotation = node.parent?.as(TypeAnnotationSyntax.self),
       let patternBinding = nearestAncestor(of: typeAnnotation, type: PatternBindingSyntax.self),
       isStoredProperty(patternBinding),

--- a/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
+++ b/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
@@ -83,7 +83,7 @@ public final class UseSynthesizedInitializer: SyntaxLintRule {
   ///   - properties: The properties from the enclosing type.
   /// - Returns: Whether the initializer has the same access level as the synthesized initializer.
   private func matchesAccessLevel(
-    modifiers: ModifierListSyntax?, properties: [VariableDeclSyntax]
+    modifiers: DeclModifierListSyntax?, properties: [VariableDeclSyntax]
   ) -> Bool {
     let synthesizedAccessLevel = synthesizedInitAccessLevel(using: properties)
     let accessLevel = modifiers?.accessLevelModifier
@@ -117,9 +117,9 @@ public final class UseSynthesizedInitializer: SyntaxLintRule {
       // doesn't match the memberwise initializer.
       let isVarDecl = property.bindingSpecifier.tokenKind == .keyword(.var)
       if isVarDecl, let initializer = property.firstInitializer {
-        guard let defaultArg = parameter.defaultArgument else { return false }
+        guard let defaultArg = parameter.defaultValue else { return false }
         guard initializer.value.description == defaultArg.value.description else { return false }
-      } else if parameter.defaultArgument != nil {
+      } else if parameter.defaultValue != nil {
         return false
       }
 
@@ -143,7 +143,7 @@ public final class UseSynthesizedInitializer: SyntaxLintRule {
     for statement in initBody.statements {
       guard
         let expr = statement.item.as(InfixOperatorExprSyntax.self),
-        expr.operatorOperand.is(AssignmentExprSyntax.self)
+        expr.operator.is(AssignmentExprSyntax.self)
       else {
         return false
       }
@@ -159,13 +159,13 @@ public final class UseSynthesizedInitializer: SyntaxLintRule {
           return false
         }
 
-        leftName = memberAccessExpr.name.text
+        leftName = memberAccessExpr.declName.baseName.text
       } else {
         return false
       }
 
-      if let identifierExpr = expr.rightOperand.as(IdentifierExprSyntax.self) {
-        rightName = identifierExpr.identifier.text
+      if let identifierExpr = expr.rightOperand.as(DeclReferenceExprSyntax.self) {
+        rightName = identifierExpr.baseName.text
       } else {
         return false
       }

--- a/Sources/SwiftFormatRules/UseTripleSlashForDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/UseTripleSlashForDocumentationComments.swift
@@ -60,7 +60,7 @@ public final class UseTripleSlashForDocumentationComments: SyntaxFormatRule {
     return convertDocBlockCommentToDocLineComment(DeclSyntax(node))
   }
 
-  public override func visit(_ node: TypealiasDeclSyntax) -> DeclSyntax {
+  public override func visit(_ node: TypeAliasDeclSyntax) -> DeclSyntax {
     return convertDocBlockCommentToDocLineComment(DeclSyntax(node))
   }
 

--- a/Sources/SwiftFormatRules/UseWhereClausesInForLoops.swift
+++ b/Sources/SwiftFormatRules/UseWhereClausesInForLoops.swift
@@ -25,7 +25,7 @@ public final class UseWhereClausesInForLoops: SyntaxFormatRule {
   /// be enabled by default.
   public override class var isOptIn: Bool { return true }
 
-  public override func visit(_ node: ForInStmtSyntax) -> StmtSyntax {
+  public override func visit(_ node: ForStmtSyntax) -> StmtSyntax {
     // Extract IfStmt node if it's the only node in the function's body.
     guard !node.body.statements.isEmpty else { return StmtSyntax(node) }
     let firstStatement = node.body.statements.first!
@@ -49,8 +49,8 @@ public final class UseWhereClausesInForLoops: SyntaxFormatRule {
 
   private func diagnoseAndUpdateForInStatement(
     firstStmt: StmtSyntax,
-    forInStmt: ForInStmtSyntax
-  ) -> ForInStmtSyntax {
+    forInStmt: ForStmtSyntax
+  ) -> ForStmtSyntax {
     switch Syntax(firstStmt).as(SyntaxEnum.self) {
     case .expressionStmt(let exprStmt):
       switch Syntax(exprStmt.expression).as(SyntaxEnum.self) {
@@ -95,10 +95,10 @@ public final class UseWhereClausesInForLoops: SyntaxFormatRule {
 }
 
 fileprivate func updateWithWhereCondition(
-  node: ForInStmtSyntax,
+  node: ForStmtSyntax,
   condition: ExprSyntax,
   statements: CodeBlockItemListSyntax
-) -> ForInStmtSyntax {
+) -> ForStmtSyntax {
   // Construct a new `where` clause with the condition.
   let lastToken = node.sequence.lastToken(viewMode: .sourceAccurate)
   var whereLeadingTrivia = Trivia()
@@ -111,7 +111,7 @@ fileprivate func updateWithWhereCondition(
   )
   let whereClause = WhereClauseSyntax(
     whereKeyword: whereKeyword,
-    guardResult: condition
+    condition: condition
   )
 
   // Replace the where clause and extract the body from the IfStmt.

--- a/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
@@ -106,7 +106,7 @@ public final class ValidateDocumentationComments: SyntaxLintRule {
     if returnClause == nil && returnsDescription != nil {
       diagnose(.removeReturnComment(funcName: name), on: node)
     } else if let returnClause = returnClause, returnsDescription == nil {
-      if let returnTypeIdentifier = returnClause.type.as(SimpleTypeIdentifierSyntax.self),
+      if let returnTypeIdentifier = returnClause.type.as(IdentifierTypeSyntax.self),
          returnTypeIdentifier.name.text == "Never"
       {
         return


### PR DESCRIPTION
Fix all deprecation warnings in swift-format that arose because of node renames in swift-syntax.