### PR TITLE
Don't alter doc line comments unnecessarily.

### DIFF
--- a/Sources/SwiftFormatCore/DocumentationComment.swift
+++ b/Sources/SwiftFormatCore/DocumentationComment.swift
@@ -82,7 +82,7 @@ public struct DocumentationComment {
   ///
   /// - Parameter node: The syntax node from which the documentation comment should be extracted.
   public init?<Node: SyntaxProtocol>(extractedFrom node: Node) {
-    guard let commentInfo = documentationCommentText(extractedFrom: node.leadingTrivia) else {
+    guard let commentInfo = DocumentationCommentText(extractedFrom: node.leadingTrivia) else {
       return nil
     }
 

--- a/Sources/SwiftFormatCore/DocumentationCommentText.swift
+++ b/Sources/SwiftFormatCore/DocumentationCommentText.swift
@@ -12,121 +12,160 @@
 
 import SwiftSyntax
 
-/// Extracts and returns the body text of a documentation comment represented as a trivia
-/// collection.
+/// The text contents of a documentation comment extracted from trivia.
 ///
-/// This function should be used when only the text of the comment is important, not the structural
-/// organization. It automatically handles trimming leading indentation from comments as well as
-/// "ASCII art" in block comments (i.e., leading asterisks on each line).
-///
-/// This implementation is based on
-/// https://github.com/apple/swift/blob/main/lib/Markup/LineList.cpp.
-///
-/// - Parameter trivia: The trivia collection from which to extract the comment text.
-/// - Returns: If a comment was found, a tuple containing the `String` containing the extracted text
-///   and the index into the trivia collection where the comment began is returned. Otherwise, `nil`
-///   is returned.
-public func documentationCommentText(extractedFrom trivia: Trivia)
-  -> (text: String, startIndex: Trivia.Index)?
-{
-  /// Represents a line of text and its leading indentation.
-  struct Line {
-    var text: Substring
-    var firstNonspaceDistance: Int
-    
-    init(_ text: Substring) {
-      self.text = text
-      self.firstNonspaceDistance = indentationDistance(of: text)
-    }
+/// This type should be used when only the text of the comment is important, not the Markdown
+/// structural organization. It automatically handles trimming leading indentation from comments as
+/// well as "ASCII art" in block comments (i.e., leading asterisks on each line).
+public struct DocumentationCommentText {
+  /// Denotes the kind of punctuation used to introduce the comment.
+  public enum Introducer {
+    /// The comment was introduced entirely by line-style comments (`///`).
+    case line
+
+    /// The comment was introduced entirely by block-style comments (`/** ... */`).
+    case block
+
+    /// The comment was introduced by a mixture of line-style and block-style comments.
+    case mixed
   }
 
-  // Look backwards from the end of the trivia collection to find the logical start of the comment.
-  // We have to copy it into an array since `Trivia` doesn't support bidirectional indexing.
-  let triviaArray = Array(trivia)
-  let commentStartIndex: Array<TriviaPiece>.Index
-  if
-    let lastNonDocCommentIndex = triviaArray.lastIndex(where: {
-      switch $0 {
-      case .docBlockComment, .docLineComment,
-          .newlines(1), .carriageReturns(1), .carriageReturnLineFeeds(1),
-          .spaces, .tabs:
-        return false
+  /// The comment text extracted from the trivia.
+  public let text: String
+
+  /// The index in the trivia collection passed to the initializer where the comment started.
+  public let startIndex: Trivia.Index
+
+  /// The kind of punctuation used to introduce the comment.
+  public let introducer: Introducer
+
+  /// Extracts and returns the body text of a documentation comment represented as a trivia
+  /// collection.
+  ///
+  /// This implementation is based on
+  /// https://github.com/apple/swift/blob/main/lib/Markup/LineList.cpp.
+  ///
+  /// - Parameter trivia: The trivia collection from which to extract the comment text.
+  /// - Returns: If a comment was found, a tuple containing the `String` containing the extracted
+  ///   text and the index into the trivia collection where the comment began is returned.
+  ///   Otherwise, `nil` is returned.
+  public init?(extractedFrom trivia: Trivia) {
+    /// Represents a line of text and its leading indentation.
+    struct Line {
+      var text: Substring
+      var firstNonspaceDistance: Int
+
+      init(_ text: Substring) {
+        self.text = text
+        self.firstNonspaceDistance = indentationDistance(of: text)
+      }
+    }
+
+    // Look backwards from the end of the trivia collection to find the logical start of the
+    // comment. We have to copy it into an array since `Trivia` doesn't support bidirectional
+    // indexing.
+    let triviaArray = Array(trivia)
+    let commentStartIndex: Array<TriviaPiece>.Index
+    if
+      let lastNonDocCommentIndex = triviaArray.lastIndex(where: {
+        switch $0 {
+        case .docBlockComment, .docLineComment,
+            .newlines(1), .carriageReturns(1), .carriageReturnLineFeeds(1),
+            .spaces, .tabs:
+          return false
+        default:
+          return true
+        }
+      }),
+      lastNonDocCommentIndex != trivia.endIndex
+    {
+      commentStartIndex = triviaArray.index(after: lastNonDocCommentIndex)
+    } else {
+      commentStartIndex = triviaArray.startIndex
+    }
+
+    // Determine the indentation level of the first line of the comment. This is used to adjust
+    // block comments, whose text spans multiple lines.
+    let leadingWhitespace = contiguousWhitespace(in: triviaArray, before: commentStartIndex)
+    var lines = [Line]()
+
+    var introducer: Introducer?
+    func updateIntroducer(_ newIntroducer: Introducer) {
+      if let knownIntroducer = introducer, knownIntroducer != newIntroducer {
+        introducer = .mixed
+      } else {
+        introducer = newIntroducer
+      }
+    }
+
+    // Extract the raw lines of text (which will include their leading comment punctuation, which is
+    // stripped).
+    for triviaPiece in trivia[commentStartIndex...] {
+      switch triviaPiece {
+      case .docLineComment(let line):
+        updateIntroducer(.line)
+        lines.append(Line(line.dropFirst(3)))
+
+      case .docBlockComment(let line):
+        updateIntroducer(.block)
+
+        var cleaned = line.dropFirst(3)
+        if cleaned.hasSuffix("*/") {
+          cleaned = cleaned.dropLast(2)
+        }
+
+        var hasASCIIArt = false
+        if cleaned.hasPrefix("\n") {
+          cleaned = cleaned.dropFirst()
+          hasASCIIArt = asciiArtLength(of: cleaned, leadingSpaces: leadingWhitespace) != 0
+        }
+
+        while !cleaned.isEmpty {
+          var index = cleaned.firstIndex(where: \.isNewline) ?? cleaned.endIndex
+          if hasASCIIArt {
+            cleaned =
+              cleaned.dropFirst(asciiArtLength(of: cleaned, leadingSpaces: leadingWhitespace))
+            index = cleaned.firstIndex(where: \.isNewline) ?? cleaned.endIndex
+          }
+
+          // Don't add an unnecessary blank line at the end when `*/` is on its own line.
+          guard cleaned.firstIndex(where: { !$0.isWhitespace }) != nil else {
+            break
+          }
+
+          let line = cleaned.prefix(upTo: index)
+          lines.append(Line(line))
+          cleaned = cleaned[index...].dropFirst()
+        }
+
       default:
-        return true
+        break
       }
-    }),
-    lastNonDocCommentIndex != trivia.endIndex
-  {
-    commentStartIndex = triviaArray.index(after: lastNonDocCommentIndex)
-  } else {
-    commentStartIndex = triviaArray.startIndex
-  }
-
-  // Determine the indentation level of the first line of the comment. This is used to adjust
-  // block comments, whose text spans multiple lines.
-  let leadingWhitespace = contiguousWhitespace(in: triviaArray, before: commentStartIndex)
-  var lines = [Line]()
-  
-  // Extract the raw lines of text (which will include their leading comment punctuation, which is
-  // stripped).
-  for triviaPiece in trivia[commentStartIndex...] {
-    switch triviaPiece {
-    case .docLineComment(let line):
-      lines.append(Line(line.dropFirst(3)))
-
-    case .docBlockComment(let line):
-      var cleaned = line.dropFirst(3)
-      if cleaned.hasSuffix("*/") {
-        cleaned = cleaned.dropLast(2)
-      }
-      
-      var hasASCIIArt = false
-      if cleaned.hasPrefix("\n") {
-        cleaned = cleaned.dropFirst()
-        hasASCIIArt = asciiArtLength(of: cleaned, leadingSpaces: leadingWhitespace) != 0
-      }
-      
-      while !cleaned.isEmpty {
-        var index = cleaned.firstIndex(where: \.isNewline) ?? cleaned.endIndex
-        if hasASCIIArt {
-          cleaned = cleaned.dropFirst(asciiArtLength(of: cleaned, leadingSpaces: leadingWhitespace))
-          index = cleaned.firstIndex(where: \.isNewline) ?? cleaned.endIndex
-        }
-
-        // Don't add an unnecessary blank line at the end when `*/` is on its own line.
-        guard cleaned.firstIndex(where: { !$0.isWhitespace }) != nil else {
-          break
-        }
-
-        let line = cleaned.prefix(upTo: index)
-        lines.append(Line(line))
-        cleaned = cleaned[index...].dropFirst()
-      }
-
-    default:
-      break
     }
+
+    // Concatenate the lines into a single string, trimming any leading indentation that might be
+    // present.
+    guard
+      let introducer = introducer,
+      !lines.isEmpty,
+      let firstLineIndex = lines.firstIndex(where: { !$0.text.isEmpty })
+    else { return nil }
+
+    let initialIndentation = indentationDistance(of: lines[firstLineIndex].text)
+    var result = ""
+    for line in lines[firstLineIndex...] {
+      let countToDrop = min(initialIndentation, line.firstNonspaceDistance)
+      result.append(contentsOf: "\(line.text.dropFirst(countToDrop))\n")
+    }
+
+    guard !result.isEmpty else { return nil }
+
+    let commentStartDistance =
+      triviaArray.distance(from: triviaArray.startIndex, to: commentStartIndex)
+    self.text = result
+    self.startIndex = trivia.index(trivia.startIndex, offsetBy: commentStartDistance)
+    self.introducer = introducer
   }
-
-  // Concatenate the lines into a single string, trimming any leading indentation that might be
-  // present.
-  guard
-    !lines.isEmpty,
-    let firstLineIndex = lines.firstIndex(where: { !$0.text.isEmpty })
-  else { return nil }
-
-  let initialIndentation = indentationDistance(of: lines[firstLineIndex].text)
-  var result = ""
-  for line in lines[firstLineIndex...] {
-    let countToDrop = min(initialIndentation, line.firstNonspaceDistance)
-    result.append(contentsOf: "\(line.text.dropFirst(countToDrop))\n")
-  }
-
-  guard !result.isEmpty else { return nil }
-
-  let commentStartDistance =
-    triviaArray.distance(from: triviaArray.startIndex, to: commentStartIndex)
-  return (text: result, startIndex: trivia.index(trivia.startIndex, offsetBy: commentStartDistance))
 }
 
 /// Returns the distance from the start of the string to the first non-whitespace character.

--- a/Sources/SwiftFormatRules/AllPublicDeclarationsHaveDocumentation.swift
+++ b/Sources/SwiftFormatRules/AllPublicDeclarationsHaveDocumentation.swift
@@ -76,7 +76,7 @@ public final class AllPublicDeclarationsHaveDocumentation: SyntaxLintRule {
     modifiers: DeclModifierListSyntax?
   ) {
     guard
-      documentationCommentText(extractedFrom: decl.leadingTrivia) == nil,
+      DocumentationCommentText(extractedFrom: decl.leadingTrivia) == nil,
       let mods = modifiers, mods.has(modifier: "public") && !mods.has(modifier: "override")
     else {
       return

--- a/Sources/SwiftFormatRules/UseTripleSlashForDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/UseTripleSlashForDocumentationComments.swift
@@ -68,11 +68,15 @@ public final class UseTripleSlashForDocumentationComments: SyntaxFormatRule {
     return convertDocBlockCommentToDocLineComment(DeclSyntax(node))
   }
 
-  /// In the case the given declaration has a docBlockComment as it's documentation
-  /// comment. Returns the declaration with the docBlockComment converted to
-  /// a docLineComment.
+  /// If the declaration has a doc block comment, return the declaration with the comment rewritten
+  /// as a line comment.
+  ///
+  /// If the declaration had no comment or had only line comments, it is returned unchanged.
   private func convertDocBlockCommentToDocLineComment(_ decl: DeclSyntax) -> DeclSyntax {
-    guard let commentInfo = documentationCommentText(extractedFrom: decl.leadingTrivia) else {
+    guard
+      let commentInfo = DocumentationCommentText(extractedFrom: decl.leadingTrivia),
+      commentInfo.introducer != .line
+    else {
       return decl
     }
 

--- a/Tests/SwiftFormatCoreTests/DocumentationCommentTextTests.swift
+++ b/Tests/SwiftFormatCoreTests/DocumentationCommentTextTests.swift
@@ -9,8 +9,10 @@ final class DocumentationCommentTextTests: XCTestCase {
       /// A simple doc comment.
       func f() {}
       """
+    let commentText = try XCTUnwrap(DocumentationCommentText(extractedFrom: decl.leadingTrivia))
+    XCTAssertEqual(commentText.introducer, .line)
     XCTAssertEqual(
-      documentationCommentText(extractedFrom: decl.leadingTrivia)?.text,
+      commentText.text,
       """
       A simple doc comment.
       
@@ -23,8 +25,10 @@ final class DocumentationCommentTextTests: XCTestCase {
       /** A simple doc comment. */
       func f() {}
       """
+    let commentText = try XCTUnwrap(DocumentationCommentText(extractedFrom: decl.leadingTrivia))
+    XCTAssertEqual(commentText.introducer, .block)
     XCTAssertEqual(
-      documentationCommentText(extractedFrom: decl.leadingTrivia)?.text,
+      commentText.text,
       """
       A simple doc comment.\u{0020}
       
@@ -39,8 +43,10 @@ final class DocumentationCommentTextTests: XCTestCase {
        */
       func f() {}
       """
+    let commentText = try XCTUnwrap(DocumentationCommentText(extractedFrom: decl.leadingTrivia))
+    XCTAssertEqual(commentText.introducer, .block)
     XCTAssertEqual(
-      documentationCommentText(extractedFrom: decl.leadingTrivia)?.text,
+      commentText.text,
       """
       A simple doc comment.
       
@@ -55,8 +61,10 @@ final class DocumentationCommentTextTests: XCTestCase {
        */
       func f() {}
       """
+    let commentText = try XCTUnwrap(DocumentationCommentText(extractedFrom: decl.leadingTrivia))
+    XCTAssertEqual(commentText.introducer, .block)
     XCTAssertEqual(
-      documentationCommentText(extractedFrom: decl.leadingTrivia)?.text,
+      commentText.text,
       """
       A simple doc comment.
       
@@ -75,8 +83,10 @@ final class DocumentationCommentTextTests: XCTestCase {
       /// - Returns: A value.
       func f(x: Int) -> Int {}
       """
+    let commentText = try XCTUnwrap(DocumentationCommentText(extractedFrom: decl.leadingTrivia))
+    XCTAssertEqual(commentText.introducer, .line)
     XCTAssertEqual(
-      documentationCommentText(extractedFrom: decl.leadingTrivia)?.text,
+      commentText.text,
       """
       A doc comment.
       
@@ -97,8 +107,10 @@ final class DocumentationCommentTextTests: XCTestCase {
       /// A doc comment.
       func f(x: Int) -> Int {}
       """
+    let commentText = try XCTUnwrap(DocumentationCommentText(extractedFrom: decl.leadingTrivia))
+    XCTAssertEqual(commentText.introducer, .line)
     XCTAssertEqual(
-      documentationCommentText(extractedFrom: decl.leadingTrivia)?.text,
+      commentText.text,
       """
       A doc comment.
       
@@ -116,8 +128,10 @@ final class DocumentationCommentTextTests: XCTestCase {
       /** so is this */
       func f(x: Int) -> Int {}
       """
+    let commentText = try XCTUnwrap(DocumentationCommentText(extractedFrom: decl.leadingTrivia))
+    XCTAssertEqual(commentText.introducer, .block)
     XCTAssertEqual(
-      documentationCommentText(extractedFrom: decl.leadingTrivia)?.text,
+      commentText.text,
       """
       This is part of the comment.
        so is this\u{0020}
@@ -126,10 +140,28 @@ final class DocumentationCommentTextTests: XCTestCase {
     )
   }
 
+  func testDocCommentHasMixedIntroducers() throws {
+    let decl: DeclSyntax = """
+      /// This is part of the comment.
+      /** This is too. */
+      func f(x: Int) -> Int {}
+      """
+    let commentText = try XCTUnwrap(DocumentationCommentText(extractedFrom: decl.leadingTrivia))
+    XCTAssertEqual(commentText.introducer, .mixed)
+    XCTAssertEqual(
+      commentText.text,
+      """
+      This is part of the comment.
+      This is too.\u{0020}
+
+      """
+    )
+  }
+
   func testNilIfNoComment() throws {
     let decl: DeclSyntax = """
       func f(x: Int) -> Int {}
       """
-    XCTAssertNil(documentationCommentText(extractedFrom: decl.leadingTrivia))
+    XCTAssertNil(DocumentationCommentText(extractedFrom: decl.leadingTrivia))
   }
 }

--- a/Tests/SwiftFormatRulesTests/UseTripleSlashForDocumentationCommentsTests.swift
+++ b/Tests/SwiftFormatRulesTests/UseTripleSlashForDocumentationCommentsTests.swift
@@ -148,4 +148,27 @@ final class UseTripleSlashForDocumentationCommentsTests: LintOrFormatRuleTestCas
                 }
                 """)
   }
+
+  func testDocLineCommentsAreNotNormalized() {
+    XCTAssertFormatting(
+      UseTripleSlashForDocumentationComments.self,
+      input: """
+        ///
+        ///   Normally that initial blank line and these leading spaces
+        ///   would be removed by DocumentationCommentText. But we don't
+        ///   touch the comment if it's already a doc line comment.
+        ///
+        public class AClazz {
+        }
+        """,
+      expected: """
+        ///
+        ///   Normally that initial blank line and these leading spaces
+        ///   would be removed by DocumentationCommentText. But we don't
+        ///   touch the comment if it's already a doc line comment.
+        ///
+        public class AClazz {
+        }
+        """)
+  }
 }


### PR DESCRIPTION
Since we introduced the new logic to parse doc comments, the `UseTripleSlashForDocumentationComments` rule started inadvertently normalizing comments that were already doc line comments. For example,

```swift
///
///     Foo
///
```

would have its initial blank line(s) and leading spaces removed, leaving this:

```swift
/// Foo
///
```

While we may want to be opinionated at some point about how such comments are formatted, it's not a desired consequence of *this* rule; the name on the tin doesn't say anything about altering comments that already meet the requirement, so now we make sure to leave them alone if they're already doc line comments.