### PR TITLE
Improve a bunch of diagnostic messages.

### DIFF
--- a/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
+++ b/Sources/SwiftFormatRules/AlwaysUseLowerCamelCase.swift
@@ -217,6 +217,6 @@ extension Finding.Message {
   public static func nameMustBeLowerCamelCase(
     _ name: String, description: String
   ) -> Finding.Message {
-    "rename \(description) '\(name)' using lower-camel-case"
+    "rename the \(description) '\(name)' using lowerCamelCase"
   }
 }

--- a/Sources/SwiftFormatRules/AmbiguousTrailingClosureOverload.swift
+++ b/Sources/SwiftFormatRules/AmbiguousTrailingClosureOverload.swift
@@ -74,7 +74,7 @@ public final class AmbiguousTrailingClosureOverload: SyntaxLintRule {
 
 extension Finding.Message {
   public static func ambiguousTrailingClosureOverload(_ decl: String) -> Finding.Message {
-    "rename '\(decl)' so it is no longer ambiguous with a trailing closure"
+    "rename '\(decl)' so it is no longer ambiguous when called with a trailing closure"
   }
 
   public static func otherAmbiguousOverloadHere(_ decl: String) -> Finding.Message {

--- a/Sources/SwiftFormatRules/DontRepeatTypeInStaticProperties.swift
+++ b/Sources/SwiftFormatRules/DontRepeatTypeInStaticProperties.swift
@@ -104,6 +104,6 @@ public final class DontRepeatTypeInStaticProperties: SyntaxLintRule {
 
 extension Finding.Message {
   public static func removeTypeFromName(name: String, type: Substring) -> Finding.Message {
-    "remove '\(type)' from '\(name)'"
+    "remove the suffix '\(type)' from the name of the variable '\(name)'"
   }
 }

--- a/Sources/SwiftFormatRules/FullyIndirectEnum.swift
+++ b/Sources/SwiftFormatRules/FullyIndirectEnum.swift
@@ -109,6 +109,6 @@ public final class FullyIndirectEnum: SyntaxFormatRule {
 
 extension Finding.Message {
   public static func moveIndirectKeywordToEnumDecl(name: String) -> Finding.Message {
-    "move 'indirect' to \(name) enum declaration when all cases are indirect"
+    "move 'indirect' before the enum declaration '\(name)' when all cases are indirect"
   }
 }

--- a/Sources/SwiftFormatRules/NeverUseImplicitlyUnwrappedOptionals.swift
+++ b/Sources/SwiftFormatRules/NeverUseImplicitlyUnwrappedOptionals.swift
@@ -65,6 +65,6 @@ public final class NeverUseImplicitlyUnwrappedOptionals: SyntaxLintRule {
 
 extension Finding.Message {
   public static func doNotUseImplicitUnwrapping(identifier: String) -> Finding.Message {
-    "use \(identifier) or \(identifier)? instead of \(identifier)!"
+    "use '\(identifier)' or '\(identifier)?' instead of '\(identifier)!'"
   }
 }

--- a/Sources/SwiftFormatRules/NoAccessLevelOnExtensionDeclaration.swift
+++ b/Sources/SwiftFormatRules/NoAccessLevelOnExtensionDeclaration.swift
@@ -102,10 +102,10 @@ public final class NoAccessLevelOnExtensionDeclaration: SyntaxFormatRule {
 
 extension Finding.Message {
   public static func removeRedundantAccessKeyword(name: String) -> Finding.Message {
-    "remove redundant 'internal' access keyword from \(name)"
+    "remove redundant 'internal' access keyword from '\(name)'"
   }
 
   public static func moveAccessKeyword(keyword: String) -> Finding.Message {
-    "specify \(keyword) access level for each member inside the extension"
+    "move the '\(keyword)' access keyword to precede each member inside the extension"
   }
 }

--- a/Sources/SwiftFormatRules/NoAssignmentInExpressions.swift
+++ b/Sources/SwiftFormatRules/NoAssignmentInExpressions.swift
@@ -163,5 +163,5 @@ public final class NoAssignmentInExpressions: SyntaxFormatRule {
 
 extension Finding.Message {
   public static let moveAssignmentToOwnStatement: Finding.Message =
-    "move assignment expression into its own statement"
+    "move this assignment expression into its own statement"
 }

--- a/Sources/SwiftFormatRules/NoBlockComments.swift
+++ b/Sources/SwiftFormatRules/NoBlockComments.swift
@@ -30,5 +30,5 @@ public final class NoBlockComments: SyntaxLintRule {
 
 extension Finding.Message {
   public static let avoidBlockComment: Finding.Message =
-    "replace block comment with line comments"
+    "replace this block comment with line comments"
 }

--- a/Sources/SwiftFormatRules/NoCasesWithOnlyFallthrough.swift
+++ b/Sources/SwiftFormatRules/NoCasesWithOnlyFallthrough.swift
@@ -183,7 +183,7 @@ public final class NoCasesWithOnlyFallthrough: SyntaxFormatRule {
       // Diagnose the cases being collapsed. We do this for all but the last one in the array; the
       // last one isn't diagnosed because it will contain the body that applies to all the previous
       // cases.
-      diagnose(.collapseCase(name: label.caseItems.with(\.leadingTrivia, []).with(\.trailingTrivia, []).description), on: label)
+      diagnose(.collapseCase, on: label)
     }
     newCaseItems.append(contentsOf: labels.last!.caseItems)
 
@@ -219,7 +219,7 @@ extension TriviaPiece {
 }
 
 extension Finding.Message {
-  public static func collapseCase(name: String) -> Finding.Message {
-    "combine fallthrough-only case \(name) with a following case"
+  public static var collapseCase: Finding.Message {
+    "combine this fallthrough-only 'case' and the following 'case' into a single 'case'"
   }
 }

--- a/Sources/SwiftFormatRules/NoEmptyTrailingClosureParentheses.swift
+++ b/Sources/SwiftFormatRules/NoEmptyTrailingClosureParentheses.swift
@@ -53,6 +53,6 @@ public final class NoEmptyTrailingClosureParentheses: SyntaxFormatRule {
 
 extension Finding.Message {
   public static func removeEmptyTrailingParentheses(name: String) -> Finding.Message {
-    "remove '()' after \(name)"
+    "remove the empty parentheses following '\(name)'"
   }
 }

--- a/Sources/SwiftFormatRules/NoLabelsInCasePatterns.swift
+++ b/Sources/SwiftFormatRules/NoLabelsInCasePatterns.swift
@@ -72,6 +72,6 @@ public final class NoLabelsInCasePatterns: SyntaxFormatRule {
 
 extension Finding.Message {
   public static func removeRedundantLabel(name: String) -> Finding.Message {
-    "remove \(name) label from case argument"
+    "remove the label '\(name)' from this 'case' pattern"
   }
 }

--- a/Sources/SwiftFormatRules/NoLeadingUnderscores.swift
+++ b/Sources/SwiftFormatRules/NoLeadingUnderscores.swift
@@ -126,6 +126,6 @@ public final class NoLeadingUnderscores: SyntaxLintRule {
 
 extension Finding.Message {
   public static func doNotStartWithUnderscore(identifier: String) -> Finding.Message {
-    "remove leading '_' from identifier '\(identifier)'"
+    "remove the leading '_' from the name '\(identifier)'"
   }
 }

--- a/Sources/SwiftFormatRules/NoParensAroundConditions.swift
+++ b/Sources/SwiftFormatRules/NoParensAroundConditions.swift
@@ -104,5 +104,5 @@ public final class NoParensAroundConditions: SyntaxFormatRule {
 
 extension Finding.Message {
   public static let removeParensAroundExpression: Finding.Message =
-    "remove parentheses around this expression"
+    "remove the parentheses around this expression"
 }

--- a/Sources/SwiftFormatRules/NoVoidReturnOnFunctionSignature.swift
+++ b/Sources/SwiftFormatRules/NoVoidReturnOnFunctionSignature.swift
@@ -38,6 +38,6 @@ public final class NoVoidReturnOnFunctionSignature: SyntaxFormatRule {
 
 extension Finding.Message {
   public static func removeRedundantReturn(_ type: String) -> Finding.Message {
-    "remove explicit '\(type)' return type"
+    "remove the explicit return type '\(type)' from this function"
   }
 }

--- a/Sources/SwiftFormatRules/OneCasePerLine.swift
+++ b/Sources/SwiftFormatRules/OneCasePerLine.swift
@@ -130,6 +130,6 @@ public final class OneCasePerLine: SyntaxFormatRule {
 
 extension Finding.Message {
   public static func moveAssociatedOrRawValueCase(name: String) -> Finding.Message {
-    "move '\(name)' to its own case declaration"
+    "move '\(name)' to its own 'case' declaration"
   }
 }

--- a/Sources/SwiftFormatRules/OneVariableDeclarationPerLine.swift
+++ b/Sources/SwiftFormatRules/OneVariableDeclarationPerLine.swift
@@ -41,7 +41,7 @@ public final class OneVariableDeclarationPerLine: SyntaxFormatRule {
         continue
       }
 
-      diagnose(.onlyOneVariableDeclaration, on: varDecl)
+      diagnose(.onlyOneVariableDeclaration(specifier: varDecl.bindingSpecifier.text), on: varDecl)
 
       // Visit the decl recursively to make sure nested code block items in the
       // bindings (for example, an initializer expression that contains a
@@ -74,8 +74,9 @@ public final class OneVariableDeclarationPerLine: SyntaxFormatRule {
 }
 
 extension Finding.Message {
-  public static let onlyOneVariableDeclaration: Finding.Message =
-    "split this variable declaration to have one variable per declaration"
+  public static func onlyOneVariableDeclaration(specifier: String) -> Finding.Message {
+    "split this variable declaration to introduce only one variable per '\(specifier)'"
+  }
 }
 
 /// Splits a variable declaration with multiple bindings into individual

--- a/Sources/SwiftFormatRules/OnlyOneTrailingClosureArgument.swift
+++ b/Sources/SwiftFormatRules/OnlyOneTrailingClosureArgument.swift
@@ -31,5 +31,5 @@ public final class OnlyOneTrailingClosureArgument: SyntaxLintRule {
 
 extension Finding.Message {
   public static let removeTrailingClosure: Finding.Message =
-    "revise function call to avoid using both closure arguments and a trailing closure"
+    "revise this function call to avoid using both closure arguments and a trailing closure"
 }

--- a/Sources/SwiftFormatRules/OrderedImports.swift
+++ b/Sources/SwiftFormatRules/OrderedImports.swift
@@ -579,7 +579,7 @@ extension Finding.Message {
     "place \(before) imports before \(after) imports"
   }
 
-  public static let removeDuplicateImport: Finding.Message = "remove duplicate import"
+  public static let removeDuplicateImport: Finding.Message = "remove this duplicate import"
 
   public static let sortImports: Finding.Message = "sort import statements lexicographically"
 }

--- a/Sources/SwiftFormatRules/UseEarlyExits.swift
+++ b/Sources/SwiftFormatRules/UseEarlyExits.swift
@@ -108,5 +108,5 @@ public final class UseEarlyExits: SyntaxFormatRule {
 
 extension Finding.Message {
   public static let useGuardStatement: Finding.Message =
-    "replace the `if/else` block with a `guard` statement containing the early exit"
+    "replace the 'if/else' block with a 'guard' statement containing the early exit"
 }

--- a/Sources/SwiftFormatRules/UseLetInEveryBoundCaseVariable.swift
+++ b/Sources/SwiftFormatRules/UseLetInEveryBoundCaseVariable.swift
@@ -67,5 +67,5 @@ public final class UseLetInEveryBoundCaseVariable: SyntaxLintRule {
 
 extension Finding.Message {
   public static let useLetInBoundCaseVariables: Finding.Message =
-    "move 'let' keyword to precede each variable bound in the `case` pattern"
+    "move this 'let' keyword inside the 'case' pattern, before each of the bound variables"
 }

--- a/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
+++ b/Sources/SwiftFormatRules/UseShorthandTypeNames.swift
@@ -564,6 +564,6 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
 
 extension Finding.Message {
   public static func useTypeShorthand(type: String) -> Finding.Message {
-    "use \(type) type shorthand form"
+    "use shorthand syntax for this '\(type)' type"
   }
 }

--- a/Sources/SwiftFormatRules/UseSingleLinePropertyGetter.swift
+++ b/Sources/SwiftFormatRules/UseSingleLinePropertyGetter.swift
@@ -43,5 +43,5 @@ public final class UseSingleLinePropertyGetter: SyntaxFormatRule {
 
 extension Finding.Message {
   public static let removeExtraneousGetBlock: Finding.Message =
-    "remove extraneous 'get {}' block"
+    "remove 'get {...}' around the accessor and move its body directly into the computed property"
 }

--- a/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
+++ b/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
@@ -186,7 +186,7 @@ public final class UseSynthesizedInitializer: SyntaxLintRule {
 
 extension Finding.Message {
   public static let removeRedundantInitializer: Finding.Message =
-    "remove initializer and use the synthesized initializer"
+    "remove this explicit initializer, which is identical to the compiler-synthesized initializer"
 }
 
 /// Defines the access levels which may be assigned to a synthesized memberwise initializer.

--- a/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
+++ b/Sources/SwiftFormatRules/ValidateDocumentationComments.swift
@@ -168,31 +168,31 @@ fileprivate func parametersAreEqual(
 
 extension Finding.Message {
   public static func documentReturnValue(funcName: String) -> Finding.Message {
-    "document the return value of \(funcName)"
+    "add a 'Returns:' section to document the return value of '\(funcName)'"
   }
 
   public static func removeReturnComment(funcName: String) -> Finding.Message {
-    "remove the return comment of \(funcName), it doesn't return a value"
+    "remove the 'Returns:' section of '\(funcName)'; it does not return a value"
   }
 
   public static func parametersDontMatch(funcName: String) -> Finding.Message {
-    "change the parameters of \(funcName)'s documentation to match its parameters"
+    "change the parameters of the documentation of '\(funcName)' to match its parameters"
   }
 
   public static let useSingularParameter: Finding.Message =
-    "replace the plural form of 'Parameters' with a singular inline form of the 'Parameter' tag"
+    "replace the plural 'Parameters:' section with a singular inline 'Parameter' section"
 
   public static let usePluralParameters: Finding.Message =
     """
-    replace the singular inline form of 'Parameter' tag with a plural 'Parameters' tag \
-    and group each parameter as a nested list
+    replace the singular inline 'Parameter' section with a plural 'Parameters:' section \
+    that has the parameters nested inside it
     """
 
   public static func removeThrowsComment(funcName: String) -> Finding.Message {
-    "remove the 'Throws' tag for non-throwing function \(funcName)"
+    "remove the 'Throws:' sections of '\(funcName)'; it does not throw any errors"
   }
 
   public static func documentErrorsThrown(funcName: String) -> Finding.Message {
-    "add a 'Throws' tag describing the errors thrown by \(funcName)"
+    "add a 'Throws:' section to document the errors thrown by '\(funcName)'"
   }
 }

--- a/Tests/SwiftFormatRulesTests/NoCasesWithOnlyFallthroughTests.swift
+++ b/Tests/SwiftFormatRulesTests/NoCasesWithOnlyFallthroughTests.swift
@@ -56,14 +56,14 @@ final class NoCasesWithOnlyFallthroughTests: LintOrFormatRuleTestCase {
         """,
       checkForUnassertedDiagnostics: true)
 
-    XCTAssertDiagnosed(.collapseCase(name: "2"), line: 3, column: 1)
-    XCTAssertDiagnosed(.collapseCase(name: "3"), line: 4, column: 1)
-    XCTAssertDiagnosed(.collapseCase(name: "5"), line: 6, column: 1)
-    XCTAssertDiagnosed(.collapseCase(name: "\"a\""), line: 11, column: 1)
-    XCTAssertDiagnosed(.collapseCase(name: "\"b\", \"c\""), line: 12, column: 1)
-    XCTAssertDiagnosed(.collapseCase(name: "\"f\""), line: 15, column: 1)
-    XCTAssertDiagnosed(.collapseCase(name: ".rightBrace"), line: 21, column: 1)
-    XCTAssertDiagnosed(.collapseCase(name: ".leftBrace"), line: 22, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 3, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 4, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 6, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 11, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 12, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 15, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 21, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 22, column: 1)
   }
 
   func testFallthroughCasesWithCommentsAreNotCombined() {
@@ -104,8 +104,8 @@ final class NoCasesWithOnlyFallthroughTests: LintOrFormatRuleTestCase {
         """,
       checkForUnassertedDiagnostics: true)
 
-    XCTAssertDiagnosed(.collapseCase(name: "2"), line: 4, column: 1)
-    XCTAssertDiagnosed(.collapseCase(name: "6"), line: 12, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 4, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 12, column: 1)
   }
 
   func testCommentsAroundCombinedCasesStayInPlace() {
@@ -137,8 +137,8 @@ final class NoCasesWithOnlyFallthroughTests: LintOrFormatRuleTestCase {
         """,
       checkForUnassertedDiagnostics: true)
 
-    XCTAssertDiagnosed(.collapseCase(name: "6"), line: 4, column: 1)
-    XCTAssertDiagnosed(.collapseCase(name: "8"), line: 7, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 4, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 7, column: 1)
   }
 
   func testNestedSwitches() {
@@ -174,11 +174,11 @@ final class NoCasesWithOnlyFallthroughTests: LintOrFormatRuleTestCase {
         """,
       checkForUnassertedDiagnostics: true)
 
-    XCTAssertDiagnosed(.collapseCase(name: "1"), line: 2, column: 1)
-    XCTAssertDiagnosed(.collapseCase(name: "2"), line: 3, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 2, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 3, column: 1)
     // TODO: Column 9 seems wrong here; it should be 3. Look into this.
-    XCTAssertDiagnosed(.collapseCase(name: "1"), line: 6, column: 9)
-    XCTAssertDiagnosed(.collapseCase(name: "1"), line: 11, column: 3)
+    XCTAssertDiagnosed(.collapseCase, line: 6, column: 9)
+    XCTAssertDiagnosed(.collapseCase, line: 11, column: 3)
   }
 
   func testCasesInsideConditionalCompilationBlock() {
@@ -224,8 +224,8 @@ final class NoCasesWithOnlyFallthroughTests: LintOrFormatRuleTestCase {
         """,
       checkForUnassertedDiagnostics: true)
 
-    XCTAssertDiagnosed(.collapseCase(name: "2"), line: 4, column: 1)
-    XCTAssertDiagnosed(.collapseCase(name: "5"), line: 8, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 4, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 8, column: 1)
   }
 
   func testCasesWithWhereClauses() {
@@ -258,14 +258,14 @@ final class NoCasesWithOnlyFallthroughTests: LintOrFormatRuleTestCase {
         """,
       checkForUnassertedDiagnostics: true)
 
-    XCTAssertDiagnosed(.collapseCase(name: "1 where y < 0"), line: 2, column: 1)
-    XCTAssertDiagnosed(.collapseCase(name: "2 where y == 0"), line: 3, column: 1)
-    XCTAssertDiagnosed(.collapseCase(name: "3 where y < 0"), line: 4, column: 1)
-    XCTAssertDiagnosed(.collapseCase(name: "5"), line: 6, column: 1)
-    XCTAssertDiagnosed(.collapseCase(name: "6"), line: 7, column: 1)
-    XCTAssertDiagnosed(.collapseCase(name: "7"), line: 8, column: 1)
-    XCTAssertDiagnosed(.collapseCase(name: "8"), line: 9, column: 1)
-    XCTAssertDiagnosed(.collapseCase(name: "9"), line: 10, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 2, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 3, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 4, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 6, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 7, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 8, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 9, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 10, column: 1)
   }
 
   func testCasesWithValueBindingsAreNotMerged() {
@@ -300,9 +300,9 @@ final class NoCasesWithOnlyFallthroughTests: LintOrFormatRuleTestCase {
         """,
       checkForUnassertedDiagnostics: true)
 
-    XCTAssertDiagnosed(.collapseCase(name: ".a"), line: 2, column: 1)
-    XCTAssertDiagnosed(.collapseCase(name: ".e"), line: 6, column: 1)
-    XCTAssertDiagnosed(.collapseCase(name: ".i"), line: 9, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 2, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 6, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 9, column: 1)
   }
 
   func testFallthroughOnlyCasesAreNotMergedWithDefault() {
@@ -323,7 +323,7 @@ final class NoCasesWithOnlyFallthroughTests: LintOrFormatRuleTestCase {
         """,
       checkForUnassertedDiagnostics: true)
 
-    XCTAssertDiagnosed(.collapseCase(name: ".a"), line: 2, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 2, column: 1)
   }
 
   func testFallthroughOnlyCasesAreNotMergedWithUnknownDefault() {
@@ -344,6 +344,6 @@ final class NoCasesWithOnlyFallthroughTests: LintOrFormatRuleTestCase {
         """,
       checkForUnassertedDiagnostics: true)
 
-    XCTAssertDiagnosed(.collapseCase(name: ".a"), line: 2, column: 1)
+    XCTAssertDiagnosed(.collapseCase, line: 2, column: 1)
   }
 }

--- a/Tests/SwiftFormatRulesTests/OneVariableDeclarationPerLineTests.swift
+++ b/Tests/SwiftFormatRulesTests/OneVariableDeclarationPerLineTests.swift
@@ -30,10 +30,10 @@ final class OneVariableDeclarationPerLineTests: LintOrFormatRuleTestCase {
         """,
       checkForUnassertedDiagnostics: true
     )
-    XCTAssertDiagnosed(.onlyOneVariableDeclaration, line: 1, column: 1)
-    XCTAssertDiagnosed(.onlyOneVariableDeclaration, line: 2, column: 1)
-    XCTAssertDiagnosed(.onlyOneVariableDeclaration, line: 4, column: 1)
-    XCTAssertDiagnosed(.onlyOneVariableDeclaration, line: 5, column: 1)
+    XCTAssertDiagnosed(.onlyOneVariableDeclaration(specifier: "var"), line: 1, column: 1)
+    XCTAssertDiagnosed(.onlyOneVariableDeclaration(specifier: "let"), line: 2, column: 1)
+    XCTAssertDiagnosed(.onlyOneVariableDeclaration(specifier: "let"), line: 4, column: 1)
+    XCTAssertDiagnosed(.onlyOneVariableDeclaration(specifier: "var"), line: 5, column: 1)
   }
 
   func testNestedVariableBindings() {
@@ -112,13 +112,13 @@ final class OneVariableDeclarationPerLineTests: LintOrFormatRuleTestCase {
         """,
       checkForUnassertedDiagnostics: true
     )
-    XCTAssertDiagnosed(.onlyOneVariableDeclaration, line: 2, column: 3)
-    XCTAssertDiagnosed(.onlyOneVariableDeclaration, line: 7, column: 3)
-    XCTAssertDiagnosed(.onlyOneVariableDeclaration, line: 11, column: 3)
-    XCTAssertDiagnosed(.onlyOneVariableDeclaration, line: 17, column: 5)
-    XCTAssertDiagnosed(.onlyOneVariableDeclaration, line: 21, column: 1)
-    XCTAssertDiagnosed(.onlyOneVariableDeclaration, line: 23, column: 5)
-    XCTAssertDiagnosed(.onlyOneVariableDeclaration, line: 27, column: 5)
+    XCTAssertDiagnosed(.onlyOneVariableDeclaration(specifier: "let"), line: 2, column: 3)
+    XCTAssertDiagnosed(.onlyOneVariableDeclaration(specifier: "let"), line: 7, column: 3)
+    XCTAssertDiagnosed(.onlyOneVariableDeclaration(specifier: "let"), line: 11, column: 3)
+    XCTAssertDiagnosed(.onlyOneVariableDeclaration(specifier: "let"), line: 17, column: 5)
+    XCTAssertDiagnosed(.onlyOneVariableDeclaration(specifier: "let"), line: 21, column: 1)
+    XCTAssertDiagnosed(.onlyOneVariableDeclaration(specifier: "let"), line: 23, column: 5)
+    XCTAssertDiagnosed(.onlyOneVariableDeclaration(specifier: "var"), line: 27, column: 5)
   }
 
   func testMixedInitializedAndTypedBindings() {
@@ -140,8 +140,8 @@ final class OneVariableDeclarationPerLineTests: LintOrFormatRuleTestCase {
         """,
       checkForUnassertedDiagnostics: true
     )
-    XCTAssertDiagnosed(.onlyOneVariableDeclaration, line: 1, column: 1)
-    XCTAssertDiagnosed(.onlyOneVariableDeclaration, line: 2, column: 1)
+    XCTAssertDiagnosed(.onlyOneVariableDeclaration(specifier: "var"), line: 1, column: 1)
+    XCTAssertDiagnosed(.onlyOneVariableDeclaration(specifier: "let"), line: 2, column: 1)
   }
 
   func testCommentPrecedingDeclIsNotRepeated() {
@@ -161,7 +161,7 @@ final class OneVariableDeclarationPerLineTests: LintOrFormatRuleTestCase {
         """,
       checkForUnassertedDiagnostics: true
     )
-    XCTAssertDiagnosed(.onlyOneVariableDeclaration, line: 2, column: 1)
+    XCTAssertDiagnosed(.onlyOneVariableDeclaration(specifier: "let"), line: 2, column: 1)
   }
 
   func testCommentsPrecedingBindingsAreKept() {
@@ -179,7 +179,7 @@ final class OneVariableDeclarationPerLineTests: LintOrFormatRuleTestCase {
         """,
       checkForUnassertedDiagnostics: true
     )
-    XCTAssertDiagnosed(.onlyOneVariableDeclaration, line: 1, column: 1)
+    XCTAssertDiagnosed(.onlyOneVariableDeclaration(specifier: "let"), line: 1, column: 1)
   }
 
   func testInvalidBindingsAreNotDestroyed() {
@@ -204,10 +204,10 @@ final class OneVariableDeclarationPerLineTests: LintOrFormatRuleTestCase {
         """,
       checkForUnassertedDiagnostics: true
     )
-    XCTAssertDiagnosed(.onlyOneVariableDeclaration, line: 1, column: 1)
-    XCTAssertDiagnosed(.onlyOneVariableDeclaration, line: 2, column: 1)
-    XCTAssertDiagnosed(.onlyOneVariableDeclaration, line: 3, column: 1)
-    XCTAssertDiagnosed(.onlyOneVariableDeclaration, line: 4, column: 1)
+    XCTAssertDiagnosed(.onlyOneVariableDeclaration(specifier: "let"), line: 1, column: 1)
+    XCTAssertDiagnosed(.onlyOneVariableDeclaration(specifier: "let"), line: 2, column: 1)
+    XCTAssertDiagnosed(.onlyOneVariableDeclaration(specifier: "let"), line: 3, column: 1)
+    XCTAssertDiagnosed(.onlyOneVariableDeclaration(specifier: "let"), line: 4, column: 1)
   }
 
   func testMultipleBindingsWithAccessorsAreCorrected() {
@@ -227,6 +227,6 @@ final class OneVariableDeclarationPerLineTests: LintOrFormatRuleTestCase {
         """,
       checkForUnassertedDiagnostics: true
     )
-    XCTAssertDiagnosed(.onlyOneVariableDeclaration, line: 1, column: 1)
+    XCTAssertDiagnosed(.onlyOneVariableDeclaration(specifier: "var"), line: 1, column: 1)
   }
 }


### PR DESCRIPTION
In general, this PR attempts to make messages clearer, easier to read, and less terse. I've also tried to unify punctuation surrounding identifiers and other syntactic constructs mentioned in messages to use single quotes (instead of backticks or nothing).