### PR TITLE
[Lint] Add a rule to detect that type declarations are not capitalized

### DIFF
--- a/Sources/SwiftFormat/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Pipelines+Generated.swift
@@ -51,6 +51,7 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
     visitIfEnabled(DontRepeatTypeInStaticProperties.visit, for: node)
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
+    visitIfEnabled(TypeNamesShouldBeCapitalized.visit, for: node)
     visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }
@@ -108,6 +109,7 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(FullyIndirectEnum.visit, for: node)
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
     visitIfEnabled(OneCasePerLine.visit, for: node)
+    visitIfEnabled(TypeNamesShouldBeCapitalized.visit, for: node)
     visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }
@@ -165,9 +167,19 @@ class LintPipeline: SyntaxVisitor {
     return .visitChildren
   }
 
+  override func visit(_ node: GenericSpecializationExprSyntax) -> SyntaxVisitorContinueKind {
+    visitIfEnabled(UseShorthandTypeNames.visit, for: node)
+    return .visitChildren
+  }
+
   override func visit(_ node: IdentifierPatternSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(IdentifiersMustBeASCII.visit, for: node)
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
+    return .visitChildren
+  }
+
+  override func visit(_ node: IdentifierTypeSyntax) -> SyntaxVisitorContinueKind {
+    visitIfEnabled(UseShorthandTypeNames.visit, for: node)
     return .visitChildren
   }
 
@@ -194,13 +206,13 @@ class LintPipeline: SyntaxVisitor {
     return .visitChildren
   }
 
-  override func visit(_ node: MemberBlockSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(AmbiguousTrailingClosureOverload.visit, for: node)
+  override func visit(_ node: MemberBlockItemListSyntax) -> SyntaxVisitorContinueKind {
+    visitIfEnabled(DoNotUseSemicolons.visit, for: node)
     return .visitChildren
   }
 
-  override func visit(_ node: MemberBlockItemListSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(DoNotUseSemicolons.visit, for: node)
+  override func visit(_ node: MemberBlockSyntax) -> SyntaxVisitorContinueKind {
+    visitIfEnabled(AmbiguousTrailingClosureOverload.visit, for: node)
     return .visitChildren
   }
 
@@ -224,17 +236,13 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
     visitIfEnabled(DontRepeatTypeInStaticProperties.visit, for: node)
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
+    visitIfEnabled(TypeNamesShouldBeCapitalized.visit, for: node)
     visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: RepeatStmtSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NoParensAroundConditions.visit, for: node)
-    return .visitChildren
-  }
-
-  override func visit(_ node: IdentifierTypeSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(UseShorthandTypeNames.visit, for: node)
     return .visitChildren
   }
 
@@ -249,16 +257,12 @@ class LintPipeline: SyntaxVisitor {
     return .visitChildren
   }
 
-  override func visit(_ node: GenericSpecializationExprSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(UseShorthandTypeNames.visit, for: node)
-    return .visitChildren
-  }
-
   override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, for: node)
     visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
     visitIfEnabled(DontRepeatTypeInStaticProperties.visit, for: node)
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
+    visitIfEnabled(TypeNamesShouldBeCapitalized.visit, for: node)
     visitIfEnabled(UseSynthesizedInitializer.visit, for: node)
     visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren

--- a/Sources/SwiftFormat/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Pipelines+Generated.swift
@@ -34,6 +34,11 @@ class LintPipeline: SyntaxVisitor {
     super.init(viewMode: .sourceAccurate)
   }
 
+  override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
+    visitIfEnabled(TypeNamesShouldBeCapitalized.visit, for: node)
+    return .visitChildren
+  }
+
   override func visit(_ node: AsExprSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NeverForceUnwrap.visit, for: node)
     return .visitChildren
@@ -42,6 +47,7 @@ class LintPipeline: SyntaxVisitor {
   override func visit(_ node: AssociatedTypeDeclSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
+    visitIfEnabled(TypeNamesShouldBeCapitalized.visit, for: node)
     return .visitChildren
   }
 
@@ -304,6 +310,7 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, for: node)
     visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
+    visitIfEnabled(TypeNamesShouldBeCapitalized.visit, for: node)
     visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }

--- a/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
+++ b/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
@@ -41,6 +41,7 @@ enum RuleRegistry {
     "OnlyOneTrailingClosureArgument": true,
     "OrderedImports": true,
     "ReturnVoidInsteadOfEmptyTuple": true,
+    "TypeNamesShouldBeCapitalized": true,
     "UseEarlyExits": false,
     "UseLetInEveryBoundCaseVariable": true,
     "UseShorthandTypeNames": true,

--- a/Sources/SwiftFormatRules/RuleNameCache+Generated.swift
+++ b/Sources/SwiftFormatRules/RuleNameCache+Generated.swift
@@ -41,6 +41,7 @@ public let ruleNameCache: [ObjectIdentifier: String] = [
   ObjectIdentifier(OnlyOneTrailingClosureArgument.self): "OnlyOneTrailingClosureArgument",
   ObjectIdentifier(OrderedImports.self): "OrderedImports",
   ObjectIdentifier(ReturnVoidInsteadOfEmptyTuple.self): "ReturnVoidInsteadOfEmptyTuple",
+  ObjectIdentifier(TypeNamesShouldBeCapitalized.self): "TypeNamesShouldBeCapitalized",
   ObjectIdentifier(UseEarlyExits.self): "UseEarlyExits",
   ObjectIdentifier(UseLetInEveryBoundCaseVariable.self): "UseLetInEveryBoundCaseVariable",
   ObjectIdentifier(UseShorthandTypeNames.self): "UseShorthandTypeNames",

--- a/Sources/SwiftFormatRules/TypeNamesShouldBeCapitalized.swift
+++ b/Sources/SwiftFormatRules/TypeNamesShouldBeCapitalized.swift
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftFormatCore
+import SwiftSyntax
+
+/// `struct`, `class`, `enum` and `protocol` declarations should have a capitalized name.
+///
+/// Lint:  Types with un-capitalized names will yield a lint error.
+public final class TypeNamesShouldBeCapitalized : SyntaxLintRule {
+  public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+    diagnoseNameConventionMismatch(node, name: node.name)
+    return .visitChildren
+  }
+
+  public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+    diagnoseNameConventionMismatch(node, name: node.name)
+    return .visitChildren
+  }
+
+  public override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+    diagnoseNameConventionMismatch(node, name: node.name)
+    return .visitChildren
+  }
+
+  public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+    diagnoseNameConventionMismatch(node, name: node.name)
+    return .visitChildren
+  }
+
+  private func diagnoseNameConventionMismatch<T: DeclSyntaxProtocol>(_ type: T, name: TokenSyntax) {
+    if let firstChar = name.text.first, !firstChar.isUppercase {
+      diagnose(.capitalizeTypeName(name: name.text), on: type, severity: .convention)
+    }
+  }
+}
+
+extension Finding.Message {
+  public static func capitalizeTypeName(name: String) -> Finding.Message {
+    let capitalized = name.prefix(1).uppercased() + name.dropFirst()
+    return "type names should be capitalized: \(name) -> \(capitalized)"
+  }
+}

--- a/Sources/SwiftFormatRules/TypeNamesShouldBeCapitalized.swift
+++ b/Sources/SwiftFormatRules/TypeNamesShouldBeCapitalized.swift
@@ -53,7 +53,9 @@ public final class TypeNamesShouldBeCapitalized : SyntaxLintRule {
   }
 
   private func diagnoseNameConventionMismatch<T: DeclSyntaxProtocol>(_ type: T, name: TokenSyntax) {
-    if let firstChar = name.text.first, !firstChar.isUppercase {
+    let leadingUnderscores = name.text.prefix { $0 == "_" }
+    if let firstChar = name.text[leadingUnderscores.endIndex...].first,
+       firstChar.uppercased() != String(firstChar) {
       diagnose(.capitalizeTypeName(name: name.text), on: type, severity: .convention)
     }
   }
@@ -61,7 +63,10 @@ public final class TypeNamesShouldBeCapitalized : SyntaxLintRule {
 
 extension Finding.Message {
   public static func capitalizeTypeName(name: String) -> Finding.Message {
-    let capitalized = name.prefix(1).uppercased() + name.dropFirst()
+    var capitalized = name
+    let leadingUnderscores = capitalized.prefix { $0 == "_" }
+    let charAt = leadingUnderscores.endIndex
+    capitalized.replaceSubrange(charAt...charAt, with: capitalized[charAt].uppercased())
     return "type names should be capitalized: \(name) -> \(capitalized)"
   }
 }

--- a/Sources/SwiftFormatRules/TypeNamesShouldBeCapitalized.swift
+++ b/Sources/SwiftFormatRules/TypeNamesShouldBeCapitalized.swift
@@ -37,6 +37,21 @@ public final class TypeNamesShouldBeCapitalized : SyntaxLintRule {
     return .visitChildren
   }
 
+  public override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
+    diagnoseNameConventionMismatch(node, name: node.name)
+    return .visitChildren
+  }
+
+  public override func visit(_ node: AssociatedTypeDeclSyntax) -> SyntaxVisitorContinueKind {
+    diagnoseNameConventionMismatch(node, name: node.name)
+    return .visitChildren
+  }
+
+  public override func visit(_ node: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {
+    diagnoseNameConventionMismatch(node, name: node.name)
+    return .visitChildren
+  }
+
   private func diagnoseNameConventionMismatch<T: DeclSyntaxProtocol>(_ type: T, name: TokenSyntax) {
     if let firstChar = name.text.first, !firstChar.isUppercase {
       diagnose(.capitalizeTypeName(name: name.text), on: type, severity: .convention)

--- a/Tests/SwiftFormatRulesTests/TypeNamesShouldBeCapitalizedTests.swift
+++ b/Tests/SwiftFormatRulesTests/TypeNamesShouldBeCapitalizedTests.swift
@@ -24,4 +24,51 @@ final class TypeNamesShouldBeCapitalizedTests: LintOrFormatRuleTestCase {
     XCTAssertNotDiagnosed(.capitalizeTypeName(name: "myType"))
     XCTAssertDiagnosed(.capitalizeTypeName(name: "innerType"))
   }
+
+  func testActors() {
+    let input =
+      """
+      actor myActor {}
+      actor OtherActor {}
+      distributed actor greeter {}
+      distributed actor DistGreeter {}
+      """
+
+    performLint(TypeNamesShouldBeCapitalized.self, input: input)
+
+    XCTAssertDiagnosed(.capitalizeTypeName(name: "myActor"))
+    XCTAssertNotDiagnosed(.capitalizeTypeName(name: "OtherActor"))
+    XCTAssertDiagnosed(.capitalizeTypeName(name: "greeter"))
+    XCTAssertNotDiagnosed(.capitalizeTypeName(name: "DistGreeter"))
+  }
+
+  func testAssociatedTypeandTypeAlias() {
+    let input =
+      """
+      protocol P {
+        associatedtype kind
+        associatedtype OtherKind
+      }
+
+      typealias x = Int
+      typealias Y = String
+
+      struct MyType {
+        typealias data<T> = Y
+
+        func test() {
+          typealias Value<T> = Y
+        }
+      }
+      """
+
+    performLint(TypeNamesShouldBeCapitalized.self, input: input)
+
+    XCTAssertDiagnosed(.capitalizeTypeName(name: "kind"))
+    XCTAssertNotDiagnosed(.capitalizeTypeName(name: "OtherKind"))
+    XCTAssertDiagnosed(.capitalizeTypeName(name: "x"))
+    XCTAssertNotDiagnosed(.capitalizeTypeName(name: "Y"))
+    XCTAssertDiagnosed(.capitalizeTypeName(name: "data"))
+    XCTAssertNotDiagnosed(.capitalizeTypeName(name: "Value"))
+  }
 }

--- a/Tests/SwiftFormatRulesTests/TypeNamesShouldBeCapitalizedTests.swift
+++ b/Tests/SwiftFormatRulesTests/TypeNamesShouldBeCapitalizedTests.swift
@@ -1,0 +1,27 @@
+import SwiftFormatRules
+
+final class TypeNamesShouldBeCapitalizedTests: LintOrFormatRuleTestCase {
+  func testConstruction() {
+    let input =
+      """
+      struct a {}
+      class klassName {
+        struct subType {}
+      }
+      protocol myProtocol {}
+
+      extension myType {
+        struct innerType {}
+      }
+      """
+
+    performLint(TypeNamesShouldBeCapitalized.self, input: input)
+
+    XCTAssertDiagnosed(.capitalizeTypeName(name: "a"))
+    XCTAssertDiagnosed(.capitalizeTypeName(name: "klassName"))
+    XCTAssertDiagnosed(.capitalizeTypeName(name: "subType"))
+    XCTAssertDiagnosed(.capitalizeTypeName(name: "myProtocol"))
+    XCTAssertNotDiagnosed(.capitalizeTypeName(name: "myType"))
+    XCTAssertDiagnosed(.capitalizeTypeName(name: "innerType"))
+  }
+}

--- a/Tests/SwiftFormatRulesTests/TypeNamesShouldBeCapitalizedTests.swift
+++ b/Tests/SwiftFormatRulesTests/TypeNamesShouldBeCapitalizedTests.swift
@@ -71,4 +71,58 @@ final class TypeNamesShouldBeCapitalizedTests: LintOrFormatRuleTestCase {
     XCTAssertDiagnosed(.capitalizeTypeName(name: "data"))
     XCTAssertNotDiagnosed(.capitalizeTypeName(name: "Value"))
   }
+
+  func testThatUnderscoredNamesAreDiagnosed() {
+    let input =
+      """
+      protocol _p {
+        associatedtype _value
+        associatedtype __Value
+      }
+
+      protocol ___Q {
+      }
+
+      struct _data {
+        typealias _x = Int
+      }
+
+      struct _Data {}
+
+      actor _internalActor {}
+
+      enum __e {
+      }
+
+      enum _OtherE {
+      }
+
+      func test() {
+        class _myClass {}
+        do {
+          class _MyClass {}
+        }
+      }
+
+      distributed actor __greeter {}
+      distributed actor __InternalGreeter {}
+      """
+
+    performLint(TypeNamesShouldBeCapitalized.self, input: input)
+
+    XCTAssertDiagnosed(.capitalizeTypeName(name: "_p"))
+    XCTAssertNotDiagnosed(.capitalizeTypeName(name: "___Q"))
+    XCTAssertDiagnosed(.capitalizeTypeName(name: "_value"))
+    XCTAssertNotDiagnosed(.capitalizeTypeName(name: "__Value"))
+    XCTAssertDiagnosed(.capitalizeTypeName(name: "_data"))
+    XCTAssertNotDiagnosed(.capitalizeTypeName(name: "_Data"))
+    XCTAssertDiagnosed(.capitalizeTypeName(name: "_x"))
+    XCTAssertDiagnosed(.capitalizeTypeName(name: "_internalActor"))
+    XCTAssertDiagnosed(.capitalizeTypeName(name: "__e"))
+    XCTAssertNotDiagnosed(.capitalizeTypeName(name: "__OtherE"))
+    XCTAssertDiagnosed(.capitalizeTypeName(name: "_myClass"))
+    XCTAssertNotDiagnosed(.capitalizeTypeName(name: "_MyClass"))
+    XCTAssertDiagnosed(.capitalizeTypeName(name: "__greeter"))
+    XCTAssertNotDiagnosed(.capitalizeTypeName(name: "__InternalGreeter"))
+  }
 }


### PR DESCRIPTION
This is a first "convention" rule that checks that type names are capitalized.