### PR TITLE
Make `shebang` a child of `SourceFileSyntax`

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1519,6 +1519,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       appendFormatterIgnored(node: Syntax(node))
       return .skipChildren
     }
+    after(node.shebang, tokens: .break(.same, newlines: .soft))
     after(node.endOfFileToken, tokens: .break(.same, newlines: .soft))
     return .visitChildren
   }
@@ -2673,7 +2674,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     var verbatimText = ""
     for piece in trailingTrivia[...lastIndex] {
       switch piece {
-      case .shebang, .unexpectedText, .spaces, .tabs, .formfeeds, .verticalTabs:
+      case .unexpectedText, .spaces, .tabs, .formfeeds, .verticalTabs:
         piece.write(to: &verbatimText)
       default:
         // The implementation of the lexer today ensures that newlines, carriage returns, and
@@ -3160,7 +3161,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
           }
         }
 
-      case .shebang(let text), .unexpectedText(let text):
+      case .unexpectedText(let text):
         // Garbage text in leading trivia might be something meaningful that would be disruptive to
         // throw away when formatting the file, like a hashbang line or Unicode byte-order marker at
         // the beginning of a file, or source control conflict markers. Keep it as verbatim text so

--- a/Sources/SwiftFormatRules/ReturnVoidInsteadOfEmptyTuple.swift
+++ b/Sources/SwiftFormatRules/ReturnVoidInsteadOfEmptyTuple.swift
@@ -88,8 +88,7 @@ public final class ReturnVoidInsteadOfEmptyTuple: SyntaxFormatRule {
   private func hasNonWhitespaceTrivia(_ token: TokenSyntax, at position: TriviaPosition) -> Bool {
     for piece in position == .leading ? token.leadingTrivia : token.trailingTrivia {
       switch piece {
-      case .blockComment, .docBlockComment, .docLineComment, .unexpectedText, .lineComment,
-        .shebang:
+      case .blockComment, .docBlockComment, .docLineComment, .unexpectedText, .lineComment:
         return true
       default:
         break


### PR DESCRIPTION
To sync changes in https://github.com/apple/swift-syntax/pull/1979