### PR TITLE
Don't warn about a redundant synthesized memberwise init if it has attributes.

### DIFF
--- a/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
+++ b/Sources/SwiftFormatRules/UseSynthesizedInitializer.swift
@@ -46,17 +46,21 @@ public final class UseSynthesizedInitializer: SyntaxLintRule {
     var extraneousInitializers = [InitializerDeclSyntax]()
     for initializer in initializers {
       guard
+        // Attributes signify intent that isn't automatically synthesized by the compiler.
+        initializer.attributes.isEmpty,
         matchesPropertyList(
           parameters: initializer.signature.parameterClause.parameters,
-          properties: storedProperties)
-      else { continue }
-      guard
+          properties: storedProperties),
         matchesAssignmentBody(
           variables: storedProperties,
-          initBody: initializer.body)
-      else { continue }
-      guard matchesAccessLevel(modifiers: initializer.modifiers, properties: storedProperties)
-      else { continue }
+          initBody: initializer.body),
+        matchesAccessLevel(
+          modifiers: initializer.modifiers,
+          properties: storedProperties)
+      else {
+        continue
+      }
+
       extraneousInitializers.append(initializer)
     }
 

--- a/Tests/SwiftFormatRulesTests/UseSynthesizedInitializerTests.swift
+++ b/Tests/SwiftFormatRulesTests/UseSynthesizedInitializerTests.swift
@@ -404,4 +404,22 @@ final class UseSynthesizedInitializerTests: LintOrFormatRuleTestCase {
     XCTAssertDiagnosed(.removeRedundantInitializer, line: 15)
     XCTAssertDiagnosed(.removeRedundantInitializer, line: 25)
   }
+
+  func testMemberwiseInitializerWithAttributeIsNotDiagnosed() {
+    let input =
+      """
+      public struct Person {
+        let phoneNumber: String
+        let address: String
+
+        @inlinable init(phoneNumber: String, address: String) {
+          self.address = address
+          self.phoneNumber = phoneNumber
+        }
+      }
+      """
+
+    performLint(UseSynthesizedInitializer.self, input: input)
+    XCTAssertNotDiagnosed(.removeRedundantInitializer)
+  }
 }


### PR DESCRIPTION
Fixes #591.