### PR TITLE
[Lint/Format] Add a rule to omit `return` from functions, closures, subscripts, and variables

### DIFF
--- a/Sources/SwiftFormat/Core/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Core/Pipelines+Generated.swift
@@ -232,6 +232,7 @@ class LintPipeline: SyntaxVisitor {
   }
 
   override func visit(_ node: PatternBindingSyntax) -> SyntaxVisitorContinueKind {
+    visitIfEnabled(OmitReturns.visit, for: node)
     visitIfEnabled(UseSingleLinePropertyGetter.visit, for: node)
     return .visitChildren
   }

--- a/Sources/SwiftFormat/Core/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Core/Pipelines+Generated.swift
@@ -281,6 +281,7 @@ class LintPipeline: SyntaxVisitor {
   override func visit(_ node: SubscriptDeclSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, for: node)
     visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
+    visitIfEnabled(OmitReturns.visit, for: node)
     visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }

--- a/Sources/SwiftFormat/Core/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Core/Pipelines+Generated.swift
@@ -60,6 +60,11 @@ class LintPipeline: SyntaxVisitor {
     return .visitChildren
   }
 
+  override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
+    visitIfEnabled(OmitReturns.visit, for: node)
+    return .visitChildren
+  }
+
   override func visit(_ node: ClosureParameterSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
     return .visitChildren

--- a/Sources/SwiftFormat/Core/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Core/Pipelines+Generated.swift
@@ -61,7 +61,7 @@ class LintPipeline: SyntaxVisitor {
   }
 
   override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(OmitReturns.visit, for: node)
+    visitIfEnabled(OmitExplicitReturns.visit, for: node)
     return .visitChildren
   }
 
@@ -151,7 +151,7 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(AlwaysUseLowerCamelCase.visit, for: node)
     visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
-    visitIfEnabled(OmitReturns.visit, for: node)
+    visitIfEnabled(OmitExplicitReturns.visit, for: node)
     visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     visitIfEnabled(ValidateDocumentationComments.visit, for: node)
     return .visitChildren
@@ -232,7 +232,7 @@ class LintPipeline: SyntaxVisitor {
   }
 
   override func visit(_ node: PatternBindingSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(OmitReturns.visit, for: node)
+    visitIfEnabled(OmitExplicitReturns.visit, for: node)
     visitIfEnabled(UseSingleLinePropertyGetter.visit, for: node)
     return .visitChildren
   }
@@ -282,7 +282,7 @@ class LintPipeline: SyntaxVisitor {
   override func visit(_ node: SubscriptDeclSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, for: node)
     visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
-    visitIfEnabled(OmitReturns.visit, for: node)
+    visitIfEnabled(OmitExplicitReturns.visit, for: node)
     visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }
@@ -351,7 +351,7 @@ extension FormatPipeline {
     node = NoLabelsInCasePatterns(context: context).rewrite(node)
     node = NoParensAroundConditions(context: context).rewrite(node)
     node = NoVoidReturnOnFunctionSignature(context: context).rewrite(node)
-    node = OmitReturns(context: context).rewrite(node)
+    node = OmitExplicitReturns(context: context).rewrite(node)
     node = OneCasePerLine(context: context).rewrite(node)
     node = OneVariableDeclarationPerLine(context: context).rewrite(node)
     node = OrderedImports(context: context).rewrite(node)

--- a/Sources/SwiftFormat/Core/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Core/Pipelines+Generated.swift
@@ -146,6 +146,7 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(AlwaysUseLowerCamelCase.visit, for: node)
     visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
+    visitIfEnabled(OmitReturns.visit, for: node)
     visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     visitIfEnabled(ValidateDocumentationComments.visit, for: node)
     return .visitChildren
@@ -343,6 +344,7 @@ extension FormatPipeline {
     node = NoLabelsInCasePatterns(context: context).rewrite(node)
     node = NoParensAroundConditions(context: context).rewrite(node)
     node = NoVoidReturnOnFunctionSignature(context: context).rewrite(node)
+    node = OmitReturns(context: context).rewrite(node)
     node = OneCasePerLine(context: context).rewrite(node)
     node = OneVariableDeclarationPerLine(context: context).rewrite(node)
     node = OrderedImports(context: context).rewrite(node)

--- a/Sources/SwiftFormat/Core/RuleNameCache+Generated.swift
+++ b/Sources/SwiftFormat/Core/RuleNameCache+Generated.swift
@@ -37,7 +37,7 @@ public let ruleNameCache: [ObjectIdentifier: String] = [
   ObjectIdentifier(NoLeadingUnderscores.self): "NoLeadingUnderscores",
   ObjectIdentifier(NoParensAroundConditions.self): "NoParensAroundConditions",
   ObjectIdentifier(NoVoidReturnOnFunctionSignature.self): "NoVoidReturnOnFunctionSignature",
-  ObjectIdentifier(OmitReturns.self): "OmitReturns",
+  ObjectIdentifier(OmitExplicitReturns.self): "OmitExplicitReturns",
   ObjectIdentifier(OneCasePerLine.self): "OneCasePerLine",
   ObjectIdentifier(OneVariableDeclarationPerLine.self): "OneVariableDeclarationPerLine",
   ObjectIdentifier(OnlyOneTrailingClosureArgument.self): "OnlyOneTrailingClosureArgument",

--- a/Sources/SwiftFormat/Core/RuleNameCache+Generated.swift
+++ b/Sources/SwiftFormat/Core/RuleNameCache+Generated.swift
@@ -37,6 +37,7 @@ public let ruleNameCache: [ObjectIdentifier: String] = [
   ObjectIdentifier(NoLeadingUnderscores.self): "NoLeadingUnderscores",
   ObjectIdentifier(NoParensAroundConditions.self): "NoParensAroundConditions",
   ObjectIdentifier(NoVoidReturnOnFunctionSignature.self): "NoVoidReturnOnFunctionSignature",
+  ObjectIdentifier(OmitReturns.self): "OmitReturns",
   ObjectIdentifier(OneCasePerLine.self): "OneCasePerLine",
   ObjectIdentifier(OneVariableDeclarationPerLine.self): "OneVariableDeclarationPerLine",
   ObjectIdentifier(OnlyOneTrailingClosureArgument.self): "OnlyOneTrailingClosureArgument",

--- a/Sources/SwiftFormat/Rules/OmitExplicitReturns.swift
+++ b/Sources/SwiftFormat/Rules/OmitExplicitReturns.swift
@@ -32,7 +32,7 @@ public final class OmitExplicitReturns: SyntaxFormatRule {
       return decl
     }
 
-    funcDecl.body?.statements = unwrapReturnStmt(returnStmt)
+    funcDecl.body?.statements = rewrapReturnedExpression(returnStmt)
     diagnose(.omitReturnStatement, on: returnStmt, severity: .refactoring)
     return DeclSyntax(funcDecl)
   }
@@ -73,7 +73,7 @@ public final class OmitExplicitReturns: SyntaxFormatRule {
        return expr
     }
 
-    closureExpr.statements = unwrapReturnStmt(returnStmt)
+    closureExpr.statements = rewrapReturnedExpression(returnStmt)
     diagnose(.omitReturnStatement, on: returnStmt, severity: .refactoring)
     return ExprSyntax(closureExpr)
   }
@@ -100,7 +100,7 @@ public final class OmitExplicitReturns: SyntaxFormatRule {
         return nil
       }
 
-      getter.body?.statements = unwrapReturnStmt(returnStmt)
+      getter.body?.statements = rewrapReturnedExpression(returnStmt)
 
       diagnose(.omitReturnStatement, on: returnStmt, severity: .refactoring)
 
@@ -116,7 +116,7 @@ public final class OmitExplicitReturns: SyntaxFormatRule {
       diagnose(.omitReturnStatement, on: returnStmt, severity: .refactoring)
 
       var newBlock = accessorBlock
-      newBlock.accessors = .getter(unwrapReturnStmt(returnStmt))
+      newBlock.accessors = .getter(rewrapReturnedExpression(returnStmt))
       return newBlock
     }
   }
@@ -131,7 +131,7 @@ public final class OmitExplicitReturns: SyntaxFormatRule {
     return !returnStmt.children(viewMode: .all).isEmpty && returnStmt.expression != nil ? returnStmt : nil
   }
 
-  private func unwrapReturnStmt(_ returnStmt: ReturnStmtSyntax) -> CodeBlockItemListSyntax {
+  private func rewrapReturnedExpression(_ returnStmt: ReturnStmtSyntax) -> CodeBlockItemListSyntax {
     CodeBlockItemListSyntax([
       CodeBlockItemSyntax(
         leadingTrivia: returnStmt.leadingTrivia,

--- a/Sources/SwiftFormat/Rules/OmitExplicitReturns.swift
+++ b/Sources/SwiftFormat/Rules/OmitExplicitReturns.swift
@@ -19,7 +19,7 @@ import SwiftSyntax
 /// Format: `func <name>() { return ... }` constructs will be replaced with
 ///         equivalent `func <name>() { ... }` constructs.
 @_spi(Rules)
-public final class OmitReturns: SyntaxFormatRule {
+public final class OmitExplicitReturns: SyntaxFormatRule {
   public override class var isOptIn: Bool { return true }
 
   public override func visit(_ node: FunctionDeclSyntax) -> DeclSyntax {

--- a/Sources/SwiftFormat/Rules/OmitExplicitReturns.swift
+++ b/Sources/SwiftFormat/Rules/OmitExplicitReturns.swift
@@ -144,5 +144,5 @@ public final class OmitExplicitReturns: SyntaxFormatRule {
 
 extension Finding.Message {
   public static let omitReturnStatement: Finding.Message =
-    "`return` can be omitted because body consists of a single expression"
+    "'return' can be omitted because body consists of a single expression"
 }

--- a/Sources/SwiftFormat/Rules/OmitReturns.swift
+++ b/Sources/SwiftFormat/Rules/OmitReturns.swift
@@ -37,6 +37,69 @@ public final class OmitReturns: SyntaxFormatRule {
     return decl
   }
 
+  public override func visit(_ node: SubscriptDeclSyntax) -> DeclSyntax {
+    let decl = super.visit(node)
+
+    guard var `subscript` = decl.as(SubscriptDeclSyntax.self) else {
+      return decl
+    }
+
+    if let accessorBlock = `subscript`.accessorBlock {
+      // We are assuming valid Swift code here where only
+      // one `get { ... }` is allowed.
+      switch accessorBlock.accessors {
+      case .accessors(let accessors):
+        guard var getter = accessors.filter({
+          $0.accessorSpecifier.tokenKind == .keyword(.get)
+        }).first else {
+          return decl
+        }
+
+        guard let body = getter.body,
+              let `return` = containsSingleReturn(body.statements) else {
+          return decl
+        }
+
+        guard let getterAt = accessors.firstIndex(where: {
+          $0.accessorSpecifier.tokenKind == .keyword(.get)
+        }) else {
+          return decl
+        }
+
+        getter.body?.statements = unwrapReturnStmt(`return`)
+
+        `subscript`.accessorBlock = .init(
+            leadingTrivia: accessorBlock.leadingTrivia,
+            leftBrace: accessorBlock.leftBrace,
+            accessors: .accessors(accessors.with(\.[getterAt], getter)),
+            rightBrace: accessorBlock.rightBrace,
+            trailingTrivia: accessorBlock.trailingTrivia)
+
+        diagnose(.omitReturnStatement, on: `return`, severity: .refactoring)
+
+        return DeclSyntax(`subscript`)
+
+      case .getter(let getter):
+        guard let `return` = containsSingleReturn(getter) else {
+          return decl
+        }
+        
+        `subscript`.accessorBlock = .init(
+            leadingTrivia: accessorBlock.leadingTrivia,
+            leftBrace: accessorBlock.leftBrace,
+            accessors: .getter(unwrapReturnStmt(`return`)),
+            rightBrace: accessorBlock.rightBrace,
+            trailingTrivia: accessorBlock.trailingTrivia)
+
+        diagnose(.omitReturnStatement, on: `return`, severity: .refactoring)
+
+        return DeclSyntax(`subscript`)
+      }
+    }
+
+    return decl
+  }
+
   public override func visit(_ node: ClosureExprSyntax) -> ExprSyntax {
     let expr = super.visit(node)
 

--- a/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
+++ b/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
@@ -36,7 +36,7 @@ enum RuleRegistry {
     "NoLeadingUnderscores": false,
     "NoParensAroundConditions": true,
     "NoVoidReturnOnFunctionSignature": true,
-    "OmitReturns": false,
+    "OmitExplicitReturns": false,
     "OneCasePerLine": true,
     "OneVariableDeclarationPerLine": true,
     "OnlyOneTrailingClosureArgument": true,

--- a/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
+++ b/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
@@ -36,6 +36,7 @@ enum RuleRegistry {
     "NoLeadingUnderscores": false,
     "NoParensAroundConditions": true,
     "NoVoidReturnOnFunctionSignature": true,
+    "OmitReturns": false,
     "OneCasePerLine": true,
     "OneVariableDeclarationPerLine": true,
     "OnlyOneTrailingClosureArgument": true,

--- a/Tests/SwiftFormatTests/Rules/OmitReturnsTests.swift
+++ b/Tests/SwiftFormatTests/Rules/OmitReturnsTests.swift
@@ -30,4 +30,46 @@ final class OmitReturnsTests: LintOrFormatRuleTestCase {
         }
         """)
   }
+
+  func testOmitReturnInSubscript() {
+      XCTAssertFormatting(
+        OmitReturns.self,
+        input: """
+          struct Test {
+            subscript(x: Int) -> Bool {
+              return false
+            }
+          }
+          """,
+        expected: """
+          struct Test {
+            subscript(x: Int) -> Bool {
+              false
+            }
+          }
+          """)
+
+      XCTAssertFormatting(
+        OmitReturns.self,
+        input: """
+          struct Test {
+            subscript(x: Int) -> Bool {
+              get {
+                return false
+              }
+              set { }
+            }
+          }
+          """,
+        expected: """
+          struct Test {
+            subscript(x: Int) -> Bool {
+              get {
+                false
+              }
+              set { }
+            }
+          }
+          """)
+  }
 }

--- a/Tests/SwiftFormatTests/Rules/OmitReturnsTests.swift
+++ b/Tests/SwiftFormatTests/Rules/OmitReturnsTests.swift
@@ -72,4 +72,42 @@ final class OmitReturnsTests: LintOrFormatRuleTestCase {
           }
           """)
   }
+
+  func testOmitReturnInComputedVars() {
+    XCTAssertFormatting(
+      OmitReturns.self,
+      input: """
+        var x: Int {
+          return 42
+        }
+        """,
+      expected: """
+        var x: Int {
+          42
+        }
+        """)
+
+    XCTAssertFormatting(
+      OmitReturns.self,
+      input: """
+        struct Test {
+          var x: Int {
+            get {
+              return 42
+            }
+            set { }
+          }
+        }
+        """,
+      expected: """
+        struct Test {
+          var x: Int {
+            get {
+              42
+            }
+            set { }
+          }
+        }
+        """)
+  }
 }

--- a/Tests/SwiftFormatTests/Rules/OmitReturnsTests.swift
+++ b/Tests/SwiftFormatTests/Rules/OmitReturnsTests.swift
@@ -1,105 +1,107 @@
+import _SwiftFormatTestSupport
+
 @_spi(Rules) import SwiftFormat
 
 final class OmitReturnsTests: LintOrFormatRuleTestCase {
   func testOmitReturnInFunction() {
-    XCTAssertFormatting(
+    assertFormatting(
       OmitReturns.self,
       input: """
         func test() -> Bool {
-          return false
+          1️⃣return false
         }
-        """,
+      """,
       expected: """
         func test() -> Bool {
           false
         }
-        """)
+      """,
+      findings: [
+        FindingSpec("1️⃣", message: "`return` can be omitted because body consists of a single expression")
+      ])
   }
 
   func testOmitReturnInClosure() {
-    XCTAssertFormatting(
+    assertFormatting(
       OmitReturns.self,
       input: """
         vals.filter {
-          return $0.count == 1
+          1️⃣return $0.count == 1
         }
-        """,
+      """,
       expected: """
         vals.filter {
           $0.count == 1
         }
-        """)
+      """,
+      findings: [
+        FindingSpec("1️⃣", message: "`return` can be omitted because body consists of a single expression")
+      ])
   }
 
   func testOmitReturnInSubscript() {
-      XCTAssertFormatting(
-        OmitReturns.self,
-        input: """
-          struct Test {
-            subscript(x: Int) -> Bool {
-              return false
-            }
-          }
-          """,
-        expected: """
-          struct Test {
-            subscript(x: Int) -> Bool {
-              false
-            }
-          }
-          """)
-
-      XCTAssertFormatting(
-        OmitReturns.self,
-        input: """
-          struct Test {
-            subscript(x: Int) -> Bool {
-              get {
-                return false
-              }
-              set { }
-            }
-          }
-          """,
-        expected: """
-          struct Test {
-            subscript(x: Int) -> Bool {
-              get {
-                false
-              }
-              set { }
-            }
-          }
-          """)
-  }
-
-  func testOmitReturnInComputedVars() {
-    XCTAssertFormatting(
-      OmitReturns.self,
-      input: """
-        var x: Int {
-          return 42
-        }
-        """,
-      expected: """
-        var x: Int {
-          42
-        }
-        """)
-
-    XCTAssertFormatting(
+    assertFormatting(
       OmitReturns.self,
       input: """
         struct Test {
-          var x: Int {
+          subscript(x: Int) -> Bool {
+            1️⃣return false
+          }
+        }
+
+        struct Test {
+          subscript(x: Int) -> Bool {
             get {
-              return 42
+              2️⃣return false
             }
             set { }
           }
         }
-        """,
+      """,
       expected: """
+        struct Test {
+          subscript(x: Int) -> Bool {
+            false
+          }
+        }
+
+        struct Test {
+          subscript(x: Int) -> Bool {
+            get {
+              false
+            }
+            set { }
+          }
+        }
+      """,
+      findings: [
+        FindingSpec("1️⃣", message: "`return` can be omitted because body consists of a single expression"),
+        FindingSpec("2️⃣", message: "`return` can be omitted because body consists of a single expression")
+      ])
+  }
+
+  func testOmitReturnInComputedVars() {
+    assertFormatting(
+      OmitReturns.self,
+      input: """
+        var x: Int {
+          1️⃣return 42
+        }
+
+        struct Test {
+          var x: Int {
+            get {
+              2️⃣return 42
+            }
+            set { }
+          }
+        }
+      """,
+      expected: """
+        var x: Int {
+          42
+        }
+
         struct Test {
           var x: Int {
             get {
@@ -108,6 +110,10 @@ final class OmitReturnsTests: LintOrFormatRuleTestCase {
             set { }
           }
         }
-        """)
+      """,
+      findings: [
+        FindingSpec("1️⃣", message: "`return` can be omitted because body consists of a single expression"),
+        FindingSpec("2️⃣", message: "`return` can be omitted because body consists of a single expression")
+      ])
   }
 }

--- a/Tests/SwiftFormatTests/Rules/OmitReturnsTests.swift
+++ b/Tests/SwiftFormatTests/Rules/OmitReturnsTests.swift
@@ -17,7 +17,7 @@ final class OmitReturnsTests: LintOrFormatRuleTestCase {
         }
       """,
       findings: [
-        FindingSpec("1️⃣", message: "`return` can be omitted because body consists of a single expression")
+        FindingSpec("1️⃣", message: "'return' can be omitted because body consists of a single expression")
       ])
   }
 
@@ -35,7 +35,7 @@ final class OmitReturnsTests: LintOrFormatRuleTestCase {
         }
       """,
       findings: [
-        FindingSpec("1️⃣", message: "`return` can be omitted because body consists of a single expression")
+        FindingSpec("1️⃣", message: "'return' can be omitted because body consists of a single expression")
       ])
   }
 
@@ -75,8 +75,8 @@ final class OmitReturnsTests: LintOrFormatRuleTestCase {
         }
       """,
       findings: [
-        FindingSpec("1️⃣", message: "`return` can be omitted because body consists of a single expression"),
-        FindingSpec("2️⃣", message: "`return` can be omitted because body consists of a single expression")
+        FindingSpec("1️⃣", message: "'return' can be omitted because body consists of a single expression"),
+        FindingSpec("2️⃣", message: "'return' can be omitted because body consists of a single expression")
       ])
   }
 
@@ -112,8 +112,8 @@ final class OmitReturnsTests: LintOrFormatRuleTestCase {
         }
       """,
       findings: [
-        FindingSpec("1️⃣", message: "`return` can be omitted because body consists of a single expression"),
-        FindingSpec("2️⃣", message: "`return` can be omitted because body consists of a single expression")
+        FindingSpec("1️⃣", message: "'return' can be omitted because body consists of a single expression"),
+        FindingSpec("2️⃣", message: "'return' can be omitted because body consists of a single expression")
       ])
   }
 }

--- a/Tests/SwiftFormatTests/Rules/OmitReturnsTests.swift
+++ b/Tests/SwiftFormatTests/Rules/OmitReturnsTests.swift
@@ -15,4 +15,19 @@ final class OmitReturnsTests: LintOrFormatRuleTestCase {
         }
         """)
   }
+
+  func testOmitReturnInClosure() {
+    XCTAssertFormatting(
+      OmitReturns.self,
+      input: """
+        vals.filter {
+          return $0.count == 1
+        }
+        """,
+      expected: """
+        vals.filter {
+          $0.count == 1
+        }
+        """)
+  }
 }

--- a/Tests/SwiftFormatTests/Rules/OmitReturnsTests.swift
+++ b/Tests/SwiftFormatTests/Rules/OmitReturnsTests.swift
@@ -5,7 +5,7 @@ import _SwiftFormatTestSupport
 final class OmitReturnsTests: LintOrFormatRuleTestCase {
   func testOmitReturnInFunction() {
     assertFormatting(
-      OmitReturns.self,
+      OmitExplicitReturns.self,
       input: """
         func test() -> Bool {
           1️⃣return false
@@ -23,7 +23,7 @@ final class OmitReturnsTests: LintOrFormatRuleTestCase {
 
   func testOmitReturnInClosure() {
     assertFormatting(
-      OmitReturns.self,
+      OmitExplicitReturns.self,
       input: """
         vals.filter {
           1️⃣return $0.count == 1
@@ -41,7 +41,7 @@ final class OmitReturnsTests: LintOrFormatRuleTestCase {
 
   func testOmitReturnInSubscript() {
     assertFormatting(
-      OmitReturns.self,
+      OmitExplicitReturns.self,
       input: """
         struct Test {
           subscript(x: Int) -> Bool {
@@ -82,7 +82,7 @@ final class OmitReturnsTests: LintOrFormatRuleTestCase {
 
   func testOmitReturnInComputedVars() {
     assertFormatting(
-      OmitReturns.self,
+      OmitExplicitReturns.self,
       input: """
         var x: Int {
           1️⃣return 42

--- a/Tests/SwiftFormatTests/Rules/OmitReturnsTests.swift
+++ b/Tests/SwiftFormatTests/Rules/OmitReturnsTests.swift
@@ -1,0 +1,18 @@
+@_spi(Rules) import SwiftFormat
+
+final class OmitReturnsTests: LintOrFormatRuleTestCase {
+  func testOmitReturnInFunction() {
+    XCTAssertFormatting(
+      OmitReturns.self,
+      input: """
+        func test() -> Bool {
+          return false
+        }
+        """,
+      expected: """
+        func test() -> Bool {
+          false
+        }
+        """)
+  }
+}


### PR DESCRIPTION
This is an opt-in rule that would warn about a possible refactoring in lint mode and drop returns from single-expression bodies of functions, closures, subscripts and computed variables/properties.