### PR TITLE
Fix a bunch of FIXMEs around linter findings.

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/WhitespaceLinter.swift
+++ b/Sources/SwiftFormat/PrettyPrint/WhitespaceLinter.swift
@@ -481,7 +481,10 @@ extension Finding.Message {
 
   public static let removeLineError: Finding.Message = "remove line break"
 
-  public static func addLinesError(_ lines: Int) -> Finding.Message { "add \(lines) line breaks" }
+  public static func addLinesError(_ lines: Int) -> Finding.Message {
+    let noun = lines == 1 ? "break" : "breaks"
+    return "add \(lines) line \(noun)"
+  }
 
   public static let lineLengthError: Finding.Message = "line is too long"
 }

--- a/Sources/SwiftFormat/Rules/DoNotUseSemicolons.swift
+++ b/Sources/SwiftFormat/Rules/DoNotUseSemicolons.swift
@@ -80,10 +80,18 @@ public final class DoNotUseSemicolons: SyntaxFormatRule {
           }
         }
 
-        // This discards any trailingTrivia from the semicolon. That trivia is at most some spaces,
-        // and the pretty printer adds any necessary spaces so it's safe to discard.
+        // This discards any trailing trivia from the semicolon. That trivia will only be horizontal
+        // whitespace, and the pretty printer adds any necessary spaces so it's safe to discard.
+        // TODO: When we stop using the legacy trivia transform, we need to fix this to preserve
+        // trailing comments.
         newItem = newItem.with(\.semicolon, nil)
-        if idx < node.count - 1 {
+
+        // When emitting the finding, tell the user to move the next statement down if there is
+        // another statement following this one. Otherwise, just tell them to remove the semicolon.
+        if let nextToken = semicolon.nextToken(viewMode: .sourceAccurate),
+          nextToken.tokenKind != .rightBrace && nextToken.tokenKind != .endOfFile
+            && !nextToken.leadingTrivia.containsNewlines
+        {
           diagnose(.removeSemicolonAndMove, on: semicolon)
         } else {
           diagnose(.removeSemicolon, on: semicolon)

--- a/Sources/SwiftFormat/Rules/DontRepeatTypeInStaticProperties.swift
+++ b/Sources/SwiftFormat/Rules/DontRepeatTypeInStaticProperties.swift
@@ -77,7 +77,7 @@ public final class DontRepeatTypeInStaticProperties: SyntaxLintRule {
       for pattern in varDecl.identifiers {
         let varName = pattern.identifier.text
         if varName.contains(bareTypeName) {
-          diagnose(.removeTypeFromName(name: varName, type: bareTypeName), on: varDecl)
+          diagnose(.removeTypeFromName(name: varName, type: bareTypeName), on: pattern.identifier)
         }
       }
     }

--- a/Sources/SwiftFormat/Rules/FullyIndirectEnum.swift
+++ b/Sources/SwiftFormat/Rules/FullyIndirectEnum.swift
@@ -25,12 +25,20 @@ public final class FullyIndirectEnum: SyntaxFormatRule {
   public override func visit(_ node: EnumDeclSyntax) -> DeclSyntax {
     let enumMembers = node.memberBlock.members
     guard !node.modifiers.has(modifier: "indirect"),
-      allCasesAreIndirect(in: enumMembers)
+      case let indirectModifiers = indirectModifiersIfAllCasesIndirect(in: enumMembers),
+      !indirectModifiers.isEmpty
     else {
       return DeclSyntax(node)
     }
 
-    diagnose(.moveIndirectKeywordToEnumDecl(name: node.name.text), on: node.name)
+    let notes = indirectModifiers.map { modifier in
+      Finding.Note(
+        message: .removeIndirect,
+        location: Finding.Location(
+          modifier.startLocation(converter: self.context.sourceLocationConverter)))
+    }
+    diagnose(
+      .moveIndirectKeywordToEnumDecl(name: node.name.text), on: node.enumKeyword, notes: notes)
 
     // Removes 'indirect' keyword from cases, reformats
     let newMembers = enumMembers.map {
@@ -75,17 +83,21 @@ public final class FullyIndirectEnum: SyntaxFormatRule {
   /// Returns a value indicating whether all enum cases in the given list are indirect.
   ///
   /// Note that if the enum has no cases, this returns false.
-  private func allCasesAreIndirect(in members: MemberBlockItemListSyntax) -> Bool {
-    var hadCases = false
+  private func indirectModifiersIfAllCasesIndirect(in members: MemberBlockItemListSyntax)
+    -> [DeclModifierSyntax]
+  {
+    var indirectModifiers = [DeclModifierSyntax]()
     for member in members {
       if let caseMember = member.decl.as(EnumCaseDeclSyntax.self) {
-        hadCases = true
-        guard caseMember.modifiers.has(modifier: "indirect") else {
-          return false
+        guard let indirectModifier = caseMember.modifiers.first(
+          where: { $0.name.text == "indirect" }
+        ) else {
+          return []
         }
+        indirectModifiers.append(indirectModifier)
       }
     }
-    return hadCases
+    return indirectModifiers
   }
 
   /// Transfers given leading trivia to the first token in the case declaration.
@@ -112,6 +124,8 @@ public final class FullyIndirectEnum: SyntaxFormatRule {
 extension Finding.Message {
   @_spi(Rules)
   public static func moveIndirectKeywordToEnumDecl(name: String) -> Finding.Message {
-    "move 'indirect' before the enum declaration '\(name)' when all cases are indirect"
+    "declare enum '\(name)' itself as indirect when all cases are indirect"
   }
+
+  public static let removeIndirect: Finding.Message = "remove 'indirect' here"
 }

--- a/Sources/SwiftFormat/Rules/GroupNumericLiterals.swift
+++ b/Sources/SwiftFormat/Rules/GroupNumericLiterals.swift
@@ -40,13 +40,13 @@ public final class GroupNumericLiterals: SyntaxFormatRule {
       // Hexadecimal
       let digitsNoPrefix = String(originalDigits.dropFirst(2))
       guard digitsNoPrefix.count >= 8 else { return ExprSyntax(node) }
-      diagnose(.groupNumericLiteral(every: 4), on: node)
+      diagnose(.groupNumericLiteral(every: 4, base: "hexadecimal"), on: node)
       newDigits = "0x" + digits(digitsNoPrefix, groupedEvery: 4)
     case "0b":
       // Binary
       let digitsNoPrefix = String(originalDigits.dropFirst(2))
       guard digitsNoPrefix.count >= 10 else { return ExprSyntax(node) }
-      diagnose(.groupNumericLiteral(every: 8), on: node)
+      diagnose(.groupNumericLiteral(every: 8, base: "binary"), on: node)
       newDigits = "0b" + digits(digitsNoPrefix, groupedEvery: 8)
     case "0o":
       // Octal
@@ -54,7 +54,7 @@ public final class GroupNumericLiterals: SyntaxFormatRule {
     default:
       // Decimal
       guard originalDigits.count >= 7 else { return ExprSyntax(node) }
-      diagnose(.groupNumericLiteral(every: 3), on: node)
+      diagnose(.groupNumericLiteral(every: 3, base: "decimal"), on: node)
       newDigits = digits(originalDigits, groupedEvery: 3)
     }
 
@@ -84,8 +84,7 @@ public final class GroupNumericLiterals: SyntaxFormatRule {
 
 extension Finding.Message {
   @_spi(Rules)
-  public static func groupNumericLiteral(every stride: Int) -> Finding.Message {
-    let ending = stride == 3 ? "rd" : "th"
-    return "group numeric literal using '_' every \(stride)\(ending) number"
+  public static func groupNumericLiteral(every stride: Int, base: String) -> Finding.Message {
+    return "group every \(stride) digits in this \(base) literal using a '_' separator"
   }
 }

--- a/Sources/SwiftFormat/Rules/NoEmptyTrailingClosureParentheses.swift
+++ b/Sources/SwiftFormat/Rules/NoEmptyTrailingClosureParentheses.swift
@@ -24,16 +24,18 @@ public final class NoEmptyTrailingClosureParentheses: SyntaxFormatRule {
   public override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
     guard node.arguments.count == 0 else { return super.visit(node) }
 
-    guard let trailingClosure = node.trailingClosure,
-      node.arguments.isEmpty && node.leftParen != nil else
-    {
+    guard
+      let trailingClosure = node.trailingClosure,
+      let leftParen = node.leftParen,
+      node.arguments.isEmpty
+    else {
       return super.visit(node)
     }
     guard let name = node.calledExpression.lastToken(viewMode: .sourceAccurate) else {
       return super.visit(node)
     }
 
-    diagnose(.removeEmptyTrailingParentheses(name: "\(name.trimmedDescription)"), on: node)
+    diagnose(.removeEmptyTrailingParentheses(name: "\(name.trimmedDescription)"), on: leftParen)
 
     // Need to visit `calledExpression` before creating a new node so that the location data (column
     // and line numbers) is available.

--- a/Sources/SwiftFormat/Rules/NoParensAroundConditions.swift
+++ b/Sources/SwiftFormat/Rules/NoParensAroundConditions.swift
@@ -42,7 +42,7 @@ public final class NoParensAroundConditions: SyntaxFormatRule {
       }
     }
 
-    diagnose(.removeParensAroundExpression, on: expr)
+    diagnose(.removeParensAroundExpression, on: tuple.leftParen)
 
     guard
       let visitedTuple = visit(tuple).as(TupleExprSyntax.self),
@@ -75,7 +75,6 @@ public final class NoParensAroundConditions: SyntaxFormatRule {
     return node.with(\.condition, .expression(extractExpr(tup)))
   }
 
-  /// FIXME(hbh): Parsing for SwitchExprSyntax is not implemented.
   public override func visit(_ node: SwitchExprSyntax) -> ExprSyntax {
     guard let tup = node.subject.as(TupleExprSyntax.self),
       tup.elements.firstAndOnly != nil

--- a/Sources/SwiftFormat/Rules/TypeNamesShouldBeCapitalized.swift
+++ b/Sources/SwiftFormat/Rules/TypeNamesShouldBeCapitalized.swift
@@ -18,56 +18,60 @@ import SwiftSyntax
 @_spi(Rules)
 public final class TypeNamesShouldBeCapitalized : SyntaxLintRule {
   public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseNameConventionMismatch(node, name: node.name)
+    diagnoseNameConventionMismatch(node, name: node.name, kind: "struct")
     return .visitChildren
   }
 
   public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseNameConventionMismatch(node, name: node.name)
+    diagnoseNameConventionMismatch(node, name: node.name, kind: "class")
     return .visitChildren
   }
 
   public override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseNameConventionMismatch(node, name: node.name)
+    diagnoseNameConventionMismatch(node, name: node.name, kind: "enum")
     return .visitChildren
   }
 
   public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseNameConventionMismatch(node, name: node.name)
+    diagnoseNameConventionMismatch(node, name: node.name, kind: "protocol")
     return .visitChildren
   }
 
   public override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseNameConventionMismatch(node, name: node.name)
+    diagnoseNameConventionMismatch(node, name: node.name, kind: "actor")
     return .visitChildren
   }
 
   public override func visit(_ node: AssociatedTypeDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseNameConventionMismatch(node, name: node.name)
+    diagnoseNameConventionMismatch(node, name: node.name, kind: "associated type")
     return .visitChildren
   }
 
   public override func visit(_ node: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {
-    diagnoseNameConventionMismatch(node, name: node.name)
+    diagnoseNameConventionMismatch(node, name: node.name, kind: "type alias")
     return .visitChildren
   }
 
-  private func diagnoseNameConventionMismatch<T: DeclSyntaxProtocol>(_ type: T, name: TokenSyntax) {
+  private func diagnoseNameConventionMismatch<T: DeclSyntaxProtocol>(
+    _ type: T,
+    name: TokenSyntax,
+    kind: String
+  ) {
     let leadingUnderscores = name.text.prefix { $0 == "_" }
     if let firstChar = name.text[leadingUnderscores.endIndex...].first,
        firstChar.uppercased() != String(firstChar) {
-      diagnose(.capitalizeTypeName(name: name.text), on: type, severity: .convention)
+      diagnose(.capitalizeTypeName(name: name.text, kind: kind), on: name, severity: .convention)
     }
   }
 }
 
 extension Finding.Message {
   @_spi(Rules)
-  public static func capitalizeTypeName(name: String) -> Finding.Message {
+  public static func capitalizeTypeName(name: String, kind: String) -> Finding.Message {
     var capitalized = name
     let leadingUnderscores = capitalized.prefix { $0 == "_" }
     let charAt = leadingUnderscores.endIndex
     capitalized.replaceSubrange(charAt...charAt, with: capitalized[charAt].uppercased())
-    return "type names should be capitalized: \(name) -> \(capitalized)"
+    return "rename the \(kind) '\(name)' using UpperCamelCase; for example, '\(capitalized)'"
   }
 }

--- a/Sources/SwiftFormat/Rules/UseTripleSlashForDocumentationComments.swift
+++ b/Sources/SwiftFormat/Rules/UseTripleSlashForDocumentationComments.swift
@@ -80,6 +80,8 @@ public final class UseTripleSlashForDocumentationComments: SyntaxFormatRule {
       return decl
     }
 
+    diagnose(.avoidDocBlockComment, on: decl, leadingTriviaIndex: commentInfo.startIndex)
+
     // Keep any trivia leading up to the doc comment.
     var pieces = Array(decl.leadingTrivia[..<commentInfo.startIndex])
 

--- a/Sources/SwiftFormat/Rules/UseWhereClausesInForLoops.swift
+++ b/Sources/SwiftFormat/Rules/UseWhereClausesInForLoops.swift
@@ -31,7 +31,7 @@ public final class UseWhereClausesInForLoops: SyntaxFormatRule {
     let firstStatement = node.body.statements.first!
 
     // Ignore for-loops with a `where` clause already.
-    // FIXME: Create an `&&` expression with both conditions?
+    // TODO: Create an `&&` expression with both conditions?
     guard node.whereClause == nil else { return StmtSyntax(node) }
 
     // Match:

--- a/Tests/SwiftFormatTests/PrettyPrint/WhitespaceLintTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/WhitespaceLintTests.swift
@@ -164,10 +164,9 @@ final class WhitespaceLintTests: WhitespaceTestCase {
 
         """,
       findings: [
-        // FIXME: These should be singular.
-        FindingSpec("1️⃣", message: "add 1 line breaks"),
-        FindingSpec("2️⃣", message: "add 1 line breaks"),
-        FindingSpec("3️⃣", message: "add 1 line breaks"),
+        FindingSpec("1️⃣", message: "add 1 line break"),
+        FindingSpec("2️⃣", message: "add 1 line break"),
+        FindingSpec("3️⃣", message: "add 1 line break"),
       ]
     )
   }
@@ -241,7 +240,7 @@ final class WhitespaceLintTests: WhitespaceTestCase {
       findings: [
         FindingSpec("1️⃣", message: "line is too long"),
         FindingSpec("2️⃣", message: "line is too long"),
-        FindingSpec("3️⃣", message: "add 1 line breaks"),
+        FindingSpec("3️⃣", message: "add 1 line break"),
       ]
     )
   }

--- a/Tests/SwiftFormatTests/Rules/DoNotUseSemicolonsTests.swift
+++ b/Tests/SwiftFormatTests/Rules/DoNotUseSemicolonsTests.swift
@@ -2,7 +2,6 @@ import _SwiftFormatTestSupport
 
 @_spi(Rules) import SwiftFormat
 
-// FIXME: Some of the messages suggesting the next statement be moved to a new line are inaccurate.
 final class DoNotUseSemicolonsTests: LintOrFormatRuleTestCase {
   func testSemicolonUse() {
     assertFormatting(
@@ -18,7 +17,7 @@ final class DoNotUseSemicolonsTests: LintOrFormatRuleTestCase {
         """,
       findings: [
         FindingSpec("1️⃣", message: "remove ';' and move the next statement to a new line"),
-        FindingSpec("2️⃣", message: "remove ';' and move the next statement to a new line"),
+        FindingSpec("2️⃣", message: "remove ';'"),
       ]
     )
   }
@@ -73,7 +72,7 @@ final class DoNotUseSemicolonsTests: LintOrFormatRuleTestCase {
         }
         """,
       findings: [
-        FindingSpec("1️⃣", message: "remove ';' and move the next statement to a new line"),
+        FindingSpec("1️⃣", message: "remove ';'"),
         FindingSpec("2️⃣", message: "remove ';' and move the next statement to a new line"),
         FindingSpec("3️⃣", message: "remove ';'"),
       ]
@@ -111,12 +110,12 @@ final class DoNotUseSemicolonsTests: LintOrFormatRuleTestCase {
         print("7")
         """,
       findings: [
-        FindingSpec("1️⃣", message: "remove ';' and move the next statement to a new line"),
-        FindingSpec("2️⃣", message: "remove ';' and move the next statement to a new line"),
-        FindingSpec("3️⃣", message: "remove ';' and move the next statement to a new line"),
+        FindingSpec("1️⃣", message: "remove ';'"),
+        FindingSpec("2️⃣", message: "remove ';'"),
+        FindingSpec("3️⃣", message: "remove ';'"),
         FindingSpec("4️⃣", message: "remove ';' and move the next statement to a new line"),
-        FindingSpec("5️⃣", message: "remove ';' and move the next statement to a new line"),
-        FindingSpec("6️⃣", message: "remove ';' and move the next statement to a new line"),
+        FindingSpec("5️⃣", message: "remove ';'"),
+        FindingSpec("6️⃣", message: "remove ';'"),
         FindingSpec("7️⃣", message: "remove ';'"),
       ]
     )
@@ -158,7 +157,7 @@ final class DoNotUseSemicolonsTests: LintOrFormatRuleTestCase {
         for _ in 0..<10 { g() }
         """,
       findings: [
-        FindingSpec("1️⃣", message: "remove ';' and move the next statement to a new line"),
+        FindingSpec("1️⃣", message: "remove ';'"),
       ]
     )
   }

--- a/Tests/SwiftFormatTests/Rules/DontRepeatTypeInStaticPropertiesTests.swift
+++ b/Tests/SwiftFormatTests/Rules/DontRepeatTypeInStaticPropertiesTests.swift
@@ -2,36 +2,35 @@ import _SwiftFormatTestSupport
 
 @_spi(Rules) import SwiftFormat
 
-// FIXME: These diagnostics should be on the variable name, not at the beginning of the declaration.
 final class DontRepeatTypeInStaticPropertiesTests: LintOrFormatRuleTestCase {
   func testRepetitiveProperties() {
     assertLint(
       DontRepeatTypeInStaticProperties.self,
       """
       public class UIColor {
-        1️⃣static let redColor: UIColor
-        2️⃣public class var blueColor: UIColor
+        static let 1️⃣redColor: UIColor
+        public class var 2️⃣blueColor: UIColor
         var yellowColor: UIColor
         static let green: UIColor
         public class var purple: UIColor
       }
       enum Sandwich {
-        3️⃣static let bolognaSandwich: Sandwich
-        4️⃣static var hamSandwich: Sandwich
+        static let 3️⃣bolognaSandwich: Sandwich
+        static var 4️⃣hamSandwich: Sandwich
         static var turkey: Sandwich
       }
       protocol RANDPerson {
         var oldPerson: Person
-        5️⃣static let youngPerson: Person
+        static let 5️⃣youngPerson: Person
       }
       struct TVGame {
-        6️⃣static var basketballGame: TVGame
-        7️⃣static var baseballGame: TVGame
+        static var 6️⃣basketballGame: TVGame
+        static var 7️⃣baseballGame: TVGame
         static let soccer: TVGame
         let hockey: TVGame
       }
       extension URLSession {
-        8️⃣class var sharedSession: URLSession
+        class var 8️⃣sharedSession: URLSession
       }
       """,
       findings: [
@@ -64,7 +63,7 @@ final class DontRepeatTypeInStaticPropertiesTests: LintOrFormatRuleTestCase {
       DontRepeatTypeInStaticProperties.self,
       """
       extension Dotted.Thing {
-        1️⃣static let defaultThing: Dotted.Thing
+        static let 1️⃣defaultThing: Dotted.Thing
       }
       """,
       findings: [

--- a/Tests/SwiftFormatTests/Rules/FullyIndirectEnumTests.swift
+++ b/Tests/SwiftFormatTests/Rules/FullyIndirectEnumTests.swift
@@ -2,20 +2,17 @@ import _SwiftFormatTestSupport
 
 @_spi(Rules) import SwiftFormat
 
-// FIXME: Since we're putting the finding on the `enum` decl, we should have notes pointing to each
-// `indirect` that should be removed from the cases. The finding should also probably be attached to
-// the `enum` keyword, not the name, since the inserted keyword will be there.
 class FullyIndirectEnumTests: LintOrFormatRuleTestCase {
   func testAllIndirectCases() {
     assertFormatting(
       FullyIndirectEnum.self,
       input: """
         // Comment 1
-        public enum 1️⃣DependencyGraphNode {
-          internal indirect case userDefined(dependencies: [DependencyGraphNode])
+        public 1️⃣enum DependencyGraphNode {
+          internal 2️⃣indirect case userDefined(dependencies: [DependencyGraphNode])
           // Comment 2
-          indirect case synthesized(dependencies: [DependencyGraphNode])
-          indirect case other(dependencies: [DependencyGraphNode])
+          3️⃣indirect case synthesized(dependencies: [DependencyGraphNode])
+          4️⃣indirect case other(dependencies: [DependencyGraphNode])
           var x: Int
         }
         """,
@@ -30,7 +27,15 @@ class FullyIndirectEnumTests: LintOrFormatRuleTestCase {
         }
         """,
       findings: [
-        FindingSpec("1️⃣", message: "move 'indirect' before the enum declaration 'DependencyGraphNode' when all cases are indirect"),
+        FindingSpec(
+          "1️⃣",
+          message: "declare enum 'DependencyGraphNode' itself as indirect when all cases are indirect",
+          notes: [
+            NoteSpec("2️⃣", message: "remove 'indirect' here"),
+            NoteSpec("3️⃣", message: "remove 'indirect' here"),
+            NoteSpec("4️⃣", message: "remove 'indirect' here"),
+          ]
+        ),
       ]
     )
   }
@@ -40,11 +45,11 @@ class FullyIndirectEnumTests: LintOrFormatRuleTestCase {
       FullyIndirectEnum.self,
       input: """
         // Comment 1
-        public enum 1️⃣DependencyGraphNode {
-          @someAttr internal indirect case userDefined(dependencies: [DependencyGraphNode])
+        public 1️⃣enum DependencyGraphNode {
+          @someAttr internal 2️⃣indirect case userDefined(dependencies: [DependencyGraphNode])
           // Comment 2
-          @someAttr indirect case synthesized(dependencies: [DependencyGraphNode])
-          @someAttr indirect case other(dependencies: [DependencyGraphNode])
+          @someAttr 3️⃣indirect case synthesized(dependencies: [DependencyGraphNode])
+          @someAttr 4️⃣indirect case other(dependencies: [DependencyGraphNode])
           var x: Int
         }
         """,
@@ -59,7 +64,15 @@ class FullyIndirectEnumTests: LintOrFormatRuleTestCase {
         }
         """,
       findings: [
-        FindingSpec("1️⃣", message: "move 'indirect' before the enum declaration 'DependencyGraphNode' when all cases are indirect"),
+        FindingSpec(
+          "1️⃣",
+          message: "declare enum 'DependencyGraphNode' itself as indirect when all cases are indirect",
+          notes: [
+            NoteSpec("2️⃣", message: "remove 'indirect' here"),
+            NoteSpec("3️⃣", message: "remove 'indirect' here"),
+            NoteSpec("4️⃣", message: "remove 'indirect' here"),
+          ]
+        ),
       ]
     )
   }

--- a/Tests/SwiftFormatTests/Rules/GroupNumericLiteralsTests.swift
+++ b/Tests/SwiftFormatTests/Rules/GroupNumericLiteralsTests.swift
@@ -2,8 +2,6 @@ import _SwiftFormatTestSupport
 
 @_spi(Rules) import SwiftFormat
 
-// FIXME: The finding message should indicate what kind of literal it is (decimal, binary, etc.) and
-// it should refer to "digits" instead of "numbers".
 final class GroupNumericLiteralsTests: LintOrFormatRuleTestCase {
   func testNumericGrouping() {
     assertFormatting(
@@ -47,15 +45,15 @@ final class GroupNumericLiteralsTests: LintOrFormatRuleTestCase {
         ]
         """,
       findings: [
-        FindingSpec("1️⃣", message: "group numeric literal using '_' every 3rd number"),
-        FindingSpec("2️⃣", message: "group numeric literal using '_' every 4th number"),
-        FindingSpec("3️⃣", message: "group numeric literal using '_' every 8th number"),
-        FindingSpec("4️⃣", message: "group numeric literal using '_' every 3rd number"),
-        FindingSpec("5️⃣", message: "group numeric literal using '_' every 3rd number"),
-        FindingSpec("6️⃣", message: "group numeric literal using '_' every 4th number"),
-        FindingSpec("7️⃣", message: "group numeric literal using '_' every 8th number"),
-        FindingSpec("8️⃣", message: "group numeric literal using '_' every 4th number"),
-        FindingSpec("9️⃣", message: "group numeric literal using '_' every 4th number"),
+        FindingSpec("1️⃣", message: "group every 3 digits in this decimal literal using a '_' separator"),
+        FindingSpec("2️⃣", message: "group every 4 digits in this hexadecimal literal using a '_' separator"),
+        FindingSpec("3️⃣", message: "group every 8 digits in this binary literal using a '_' separator"),
+        FindingSpec("4️⃣", message: "group every 3 digits in this decimal literal using a '_' separator"),
+        FindingSpec("5️⃣", message: "group every 3 digits in this decimal literal using a '_' separator"),
+        FindingSpec("6️⃣", message: "group every 4 digits in this hexadecimal literal using a '_' separator"),
+        FindingSpec("7️⃣", message: "group every 8 digits in this binary literal using a '_' separator"),
+        FindingSpec("8️⃣", message: "group every 4 digits in this hexadecimal literal using a '_' separator"),
+        FindingSpec("9️⃣", message: "group every 4 digits in this hexadecimal literal using a '_' separator"),
       ]
     )
   }

--- a/Tests/SwiftFormatTests/Rules/NoAccessLevelOnExtensionDeclarationTests.swift
+++ b/Tests/SwiftFormatTests/Rules/NoAccessLevelOnExtensionDeclarationTests.swift
@@ -2,33 +2,25 @@ import _SwiftFormatTestSupport
 
 @_spi(Rules) import SwiftFormat
 
-// FIXME: We should have notes on each of the declarations inside the extension that we modify.
-// Also fix the lack of trimming around the extension name, and we should say "extension X" instead
-// of just "X".
 final class NoAccessLevelOnExtensionDeclarationTests: LintOrFormatRuleTestCase {
   func testExtensionDeclarationAccessLevel() {
     assertFormatting(
       NoAccessLevelOnExtensionDeclaration.self,
       input: """
         1️⃣public extension Foo {
-          var x: Bool
+          2️⃣var x: Bool
           // Comment 1
           internal var y: Bool
           // Comment 2
-          static var z: Bool
+          3️⃣static var z: Bool
           // Comment 3
-          static func someFunc() {}
-          init() {}
-          subscript(index: Int) -> Element {}
-          protocol SomeProtocol {}
-          class SomeClass {}
-          struct SomeStruct {}
-          enum SomeEnum {}
-          typealias Foo = Bar
-        }
-        2️⃣internal extension Bar {
-          var a: Int
-          var b: Int
+          4️⃣static func someFunc() {}
+          5️⃣init() {}
+          6️⃣subscript(index: Int) -> Element {}
+          7️⃣class SomeClass {}
+          8️⃣struct SomeStruct {}
+          9️⃣enum SomeEnum {}
+          🔟typealias Foo = Bar
         }
         """,
       expected: """
@@ -42,20 +34,49 @@ final class NoAccessLevelOnExtensionDeclarationTests: LintOrFormatRuleTestCase {
           public static func someFunc() {}
           public init() {}
           public subscript(index: Int) -> Element {}
-          public protocol SomeProtocol {}
           public class SomeClass {}
           public struct SomeStruct {}
           public enum SomeEnum {}
           public typealias Foo = Bar
         }
+        """,
+      findings: [
+        FindingSpec(
+          "1️⃣",
+          message: "move this 'public' access modifier to precede each member inside this extension",
+          notes: [
+            NoteSpec("2️⃣", message: "add 'public' access modifier to this declaration"),
+            NoteSpec("3️⃣", message: "add 'public' access modifier to this declaration"),
+            NoteSpec("4️⃣", message: "add 'public' access modifier to this declaration"),
+            NoteSpec("5️⃣", message: "add 'public' access modifier to this declaration"),
+            NoteSpec("6️⃣", message: "add 'public' access modifier to this declaration"),
+            NoteSpec("7️⃣", message: "add 'public' access modifier to this declaration"),
+            NoteSpec("8️⃣", message: "add 'public' access modifier to this declaration"),
+            NoteSpec("9️⃣", message: "add 'public' access modifier to this declaration"),
+            NoteSpec("🔟", message: "add 'public' access modifier to this declaration"),
+          ]
+        ),
+      ]
+    )
+  }
+
+  func testRemoveRedundantInternal() {
+    assertFormatting(
+      NoAccessLevelOnExtensionDeclaration.self,
+      input: """
+        1️⃣internal extension Bar {
+          var a: Int
+          var b: Int
+        }
+        """,
+      expected: """
         extension Bar {
           var a: Int
           var b: Int
         }
         """,
       findings: [
-        FindingSpec("1️⃣", message: "move the 'public' access keyword to precede each member inside the extension"),
-        FindingSpec("2️⃣", message: "remove redundant 'internal' access keyword from 'Bar '"),
+        FindingSpec("1️⃣", message: "remove this redundant 'internal' access modifier from this extension"),
       ]
     )
   }
@@ -66,9 +87,9 @@ final class NoAccessLevelOnExtensionDeclarationTests: LintOrFormatRuleTestCase {
       input: """
         /// This doc comment should stick around.
         1️⃣public extension Foo {
-          func f() {}
+          3️⃣func f() {}
           // This should not change.
-          func g() {}
+          4️⃣func g() {}
         }
 
         /// So should this one.
@@ -94,8 +115,15 @@ final class NoAccessLevelOnExtensionDeclarationTests: LintOrFormatRuleTestCase {
         }
         """,
       findings: [
-        FindingSpec("1️⃣", message: "move the 'public' access keyword to precede each member inside the extension"),
-        FindingSpec("2️⃣", message: "remove redundant 'internal' access keyword from 'Foo '"),
+        FindingSpec(
+          "1️⃣",
+          message: "move this 'public' access modifier to precede each member inside this extension",
+          notes: [
+            NoteSpec("3️⃣", message: "add 'public' access modifier to this declaration"),
+            NoteSpec("4️⃣", message: "add 'public' access modifier to this declaration"),
+          ]
+        ),
+        FindingSpec("2️⃣", message: "remove this redundant 'internal' access modifier from this extension"),
       ]
     )
   }
@@ -105,7 +133,7 @@ final class NoAccessLevelOnExtensionDeclarationTests: LintOrFormatRuleTestCase {
       NoAccessLevelOnExtensionDeclaration.self,
       input: """
         1️⃣private extension Foo {
-          func f() {}
+          2️⃣func f() {}
         }
         """,
       expected: """
@@ -114,7 +142,13 @@ final class NoAccessLevelOnExtensionDeclarationTests: LintOrFormatRuleTestCase {
         }
         """,
       findings: [
-        FindingSpec("1️⃣", message: "move the 'private' access keyword to precede each member inside the extension"),
+        FindingSpec(
+          "1️⃣",
+          message: "remove this 'private' access modifier and declare each member inside this extension as 'fileprivate'",
+          notes: [
+            NoteSpec("2️⃣", message: "add 'fileprivate' access modifier to this declaration"),
+          ]
+        ),
       ]
     )
   }
@@ -133,7 +167,7 @@ final class NoAccessLevelOnExtensionDeclarationTests: LintOrFormatRuleTestCase {
         }
         """,
       findings: [
-        FindingSpec("1️⃣", message: "move the 'public' access keyword to precede each member inside the extension"),
+        FindingSpec("1️⃣", message: "move this 'public' access modifier to precede each member inside this extension"),
       ]
     )
   }
@@ -145,17 +179,16 @@ final class NoAccessLevelOnExtensionDeclarationTests: LintOrFormatRuleTestCase {
         /// This extension has a comment.
         1️⃣public extension Foo {
           /// This property has a doc comment.
-          @objc var x: Bool { get { return true }}
+          2️⃣@objc var x: Bool { get { return true }}
           // This property has a developer comment.
-          @objc static var z: Bool { get { return false }}
+          3️⃣@objc static var z: Bool { get { return false }}
           /// This static function has a doc comment.
-          @objc static func someStaticFunc() {}
-          @objc init(with foo: Foo) {}
-          @objc func someOtherFunc() {}
-          @objc protocol SomeProtocol {}
-          @objc class SomeClass : NSObject {}
-          @objc associatedtype SomeType
-          @objc enum SomeEnum : Int {
+          4️⃣@objc static func someStaticFunc() {}
+          5️⃣@objc init(with foo: Foo) {}
+          6️⃣@objc func someOtherFunc() {}
+          7️⃣@objc class SomeClass : NSObject {}
+          8️⃣@objc typealias SomeType = SomeOtherType
+          9️⃣@objc enum SomeEnum : Int {
             case SomeInt = 32
           }
         }
@@ -171,16 +204,28 @@ final class NoAccessLevelOnExtensionDeclarationTests: LintOrFormatRuleTestCase {
           @objc public static func someStaticFunc() {}
           @objc public init(with foo: Foo) {}
           @objc public func someOtherFunc() {}
-          @objc public protocol SomeProtocol {}
           @objc public class SomeClass : NSObject {}
-          @objc public associatedtype SomeType
+          @objc public typealias SomeType = SomeOtherType
           @objc public enum SomeEnum : Int {
             case SomeInt = 32
           }
         }
         """,
       findings: [
-        FindingSpec("1️⃣", message: "move the 'public' access keyword to precede each member inside the extension"),
+        FindingSpec(
+          "1️⃣",
+          message: "move this 'public' access modifier to precede each member inside this extension",
+          notes: [
+            NoteSpec("2️⃣", message: "add 'public' access modifier to this declaration"),
+            NoteSpec("3️⃣", message: "add 'public' access modifier to this declaration"),
+            NoteSpec("4️⃣", message: "add 'public' access modifier to this declaration"),
+            NoteSpec("5️⃣", message: "add 'public' access modifier to this declaration"),
+            NoteSpec("6️⃣", message: "add 'public' access modifier to this declaration"),
+            NoteSpec("7️⃣", message: "add 'public' access modifier to this declaration"),
+            NoteSpec("8️⃣", message: "add 'public' access modifier to this declaration"),
+            NoteSpec("9️⃣", message: "add 'public' access modifier to this declaration"),
+          ]
+        ),
       ]
     )
   }
@@ -192,25 +237,23 @@ final class NoAccessLevelOnExtensionDeclarationTests: LintOrFormatRuleTestCase {
         /// This extension has a comment.
         1️⃣public extension Foo {
           /// This property has a doc comment.
-          @available(iOS 13, *)
+          2️⃣@available(iOS 13, *)
           var x: Bool { get { return true }}
           // This property has a developer comment.
-          @available(iOS 13, *)
+          3️⃣@available(iOS 13, *)
           static var z: Bool { get { return false }}
           // This static function has a developer comment.
-          @objc(someStaticFunction)
+          4️⃣@objc(someStaticFunction)
           static func someStaticFunc() {}
-          @objc(initWithFoo:)
+          5️⃣@objc(initWithFoo:)
           init(with foo: Foo) {}
-          @objc
+          6️⃣@objc
           func someOtherFunc() {}
-          @objc
-          protocol SomeProtocol {}
-          @objc
+          7️⃣@objc
           class SomeClass : NSObject {}
-          @available(iOS 13, *)
-          associatedtype SomeType
-          @objc
+          8️⃣@available(iOS 13, *)
+          typealias SomeType = SomeOtherType
+          9️⃣@objc
           enum SomeEnum : Int {
             case SomeInt = 32
           }
@@ -241,11 +284,9 @@ final class NoAccessLevelOnExtensionDeclarationTests: LintOrFormatRuleTestCase {
           @objc
           public func someOtherFunc() {}
           @objc
-          public protocol SomeProtocol {}
-          @objc
           public class SomeClass : NSObject {}
           @available(iOS 13, *)
-          public associatedtype SomeType
+          public typealias SomeType = SomeOtherType
           @objc
           public enum SomeEnum : Int {
             case SomeInt = 32
@@ -261,7 +302,20 @@ final class NoAccessLevelOnExtensionDeclarationTests: LintOrFormatRuleTestCase {
         }
         """,
       findings: [
-        FindingSpec("1️⃣", message: "move the 'public' access keyword to precede each member inside the extension"),
+        FindingSpec(
+          "1️⃣",
+          message: "move this 'public' access modifier to precede each member inside this extension",
+          notes: [
+            NoteSpec("2️⃣", message: "add 'public' access modifier to this declaration"),
+            NoteSpec("3️⃣", message: "add 'public' access modifier to this declaration"),
+            NoteSpec("4️⃣", message: "add 'public' access modifier to this declaration"),
+            NoteSpec("5️⃣", message: "add 'public' access modifier to this declaration"),
+            NoteSpec("6️⃣", message: "add 'public' access modifier to this declaration"),
+            NoteSpec("7️⃣", message: "add 'public' access modifier to this declaration"),
+            NoteSpec("8️⃣", message: "add 'public' access modifier to this declaration"),
+            NoteSpec("9️⃣", message: "add 'public' access modifier to this declaration"),
+          ]
+        ),
       ]
     )
   }

--- a/Tests/SwiftFormatTests/Rules/NoCasesWithOnlyFallthroughTests.swift
+++ b/Tests/SwiftFormatTests/Rules/NoCasesWithOnlyFallthroughTests.swift
@@ -147,7 +147,6 @@ final class NoCasesWithOnlyFallthroughTests: LintOrFormatRuleTestCase {
   }
 
   func testNestedSwitches() {
-    // FIXME: Finding #3 is at an odd column; it should be before the `case`. Look into this.
     assertFormatting(
       NoCasesWithOnlyFallthrough.self,
       input: """
@@ -156,7 +155,7 @@ final class NoCasesWithOnlyFallthroughTests: LintOrFormatRuleTestCase {
         2️⃣case 2: fallthrough
         case 3:
           switch y {
-          case 13️⃣: fallthrough
+          3️⃣case 1: fallthrough
           case 2: print(2)
           }
         case 4:

--- a/Tests/SwiftFormatTests/Rules/NoEmptyTrailingClosureParenthesesTests.swift
+++ b/Tests/SwiftFormatTests/Rules/NoEmptyTrailingClosureParenthesesTests.swift
@@ -2,7 +2,6 @@ import _SwiftFormatTestSupport
 
 @_spi(Rules) import SwiftFormat
 
-// FIXME: Why not emit the finding at the very parentheses we want the user to remove?
 final class NoEmptyTrailingClosureParenthesesTests: LintOrFormatRuleTestCase {
   func testInvalidEmptyParenTrailingClosure() {
     assertFormatting(
@@ -14,29 +13,29 @@ final class NoEmptyTrailingClosureParenthesesTests: LintOrFormatRuleTestCase {
         func greetApathetically(_ nameProvider: () -> String) {
           // ...
         }
-        0️⃣greetEnthusiastically() { "John" }
+        greetEnthusiastically0️⃣() { "John" }
         greetApathetically { "not John" }
         func myfunc(cls: MyClass) {
           cls.myClosure { $0 }
         }
         func myfunc(cls: MyClass) {
-          1️⃣cls.myBadClosure() { $0 }
+          cls.myBadClosure1️⃣() { $0 }
         }
-        2️⃣DispatchQueue.main.async() {
-          3️⃣greetEnthusiastically() { "John" }
-          4️⃣DispatchQueue.main.async() {
-            5️⃣greetEnthusiastically() { "Willis" }
+        DispatchQueue.main.async2️⃣() {
+          greetEnthusiastically3️⃣() { "John" }
+          DispatchQueue.main.async4️⃣() {
+            greetEnthusiastically5️⃣() { "Willis" }
           }
         }
         DispatchQueue.global.async(inGroup: blah) {
-          6️⃣DispatchQueue.main.async() {
-            7️⃣greetEnthusiastically() { "Willis" }
+          DispatchQueue.main.async6️⃣() {
+            greetEnthusiastically7️⃣() { "Willis" }
           }
           DispatchQueue.main.async {
-            8️⃣greetEnthusiastically() { "Willis" }
+            greetEnthusiastically8️⃣() { "Willis" }
           }
         }
-        9️⃣foo(🔟bar() { baz })() { blah }
+        foo(bar🔟() { baz })9️⃣() { blah }
         """,
       expected: """
         func greetEnthusiastically(_ nameProvider: () -> String) {

--- a/Tests/SwiftFormatTests/Rules/NoParensAroundConditionsTests.swift
+++ b/Tests/SwiftFormatTests/Rules/NoParensAroundConditionsTests.swift
@@ -2,18 +2,17 @@ import _SwiftFormatTestSupport
 
 @_spi(Rules) import SwiftFormat
 
-// FIXME: Emit
 final class NoParensAroundConditionsTests: LintOrFormatRuleTestCase {
   func testParensAroundConditions() {
     assertFormatting(
       NoParensAroundConditions.self,
       input: """
-        if (1️⃣x) {}
-        while (2️⃣x) {}
-        guard (3️⃣x), (4️⃣y), (5️⃣x == 3) else {}
+        if 1️⃣(x) {}
+        while 2️⃣(x) {}
+        guard 3️⃣(x), 4️⃣(y), 5️⃣(x == 3) else {}
         if (foo { x }) {}
-        repeat {} while(6️⃣x)
-        switch (7️⃣4) { default: break }
+        repeat {} while6️⃣(x)
+        switch 7️⃣(4) { default: break }
         """,
       expected: """
         if x {}
@@ -39,18 +38,18 @@ final class NoParensAroundConditionsTests: LintOrFormatRuleTestCase {
     assertFormatting(
       NoParensAroundConditions.self,
       input: """
-        switch (1️⃣a) {
+        switch 1️⃣(a) {
           case 1:
-            switch (2️⃣b) {
+            switch 2️⃣(b) {
               default: break
             }
         }
-        if (3️⃣x) {
-          if (4️⃣y) {
-          } else if (5️⃣z) {
+        if 3️⃣(x) {
+          if 4️⃣(y) {
+          } else if 5️⃣(z) {
           } else {
           }
-        } else if (6️⃣w) {
+        } else if 6️⃣(w) {
         }
         """,
       expected: """
@@ -81,20 +80,20 @@ final class NoParensAroundConditionsTests: LintOrFormatRuleTestCase {
     assertFormatting(
       NoParensAroundConditions.self,
       input: """
-        while (1️⃣x) {
-          while (2️⃣y) {}
+        while 1️⃣(x) {
+          while 2️⃣(y) {}
         }
-        guard (3️⃣x), (4️⃣y), (5️⃣x == 3) else {
-          guard (6️⃣a), (7️⃣b), (8️⃣c == x) else {
+        guard 3️⃣(x), 4️⃣(y), 5️⃣(x == 3) else {
+          guard 6️⃣(a), 7️⃣(b), 8️⃣(c == x) else {
             return
           }
           return
         }
         repeat {
           repeat {
-          } while (9️⃣y)
-        } while(🔟x)
-        if (0️⃣foo.someCall({ if (ℹ️x) {} })) {}
+          } while 9️⃣(y)
+        } while🔟(x)
+        if 0️⃣(foo.someCall({ if ℹ️(x) {} })) {}
         """,
       expected: """
         while x {
@@ -135,25 +134,25 @@ final class NoParensAroundConditionsTests: LintOrFormatRuleTestCase {
       input: """
         switch b {
           case 2:
-            switch (1️⃣d) {
+            switch 1️⃣(d) {
               default: break
             }
         }
         if x {
-          if (2️⃣y) {
-          } else if (3️⃣z) {
+          if 2️⃣(y) {
+          } else if 3️⃣(z) {
           } else {
           }
-        } else if (4️⃣w) {
+        } else if 4️⃣(w) {
         }
         while x {
-          while (5️⃣y) {}
+          while 5️⃣(y) {}
         }
         repeat {
           repeat {
-          } while (6️⃣y)
+          } while 6️⃣(y)
         } while x
-        if foo.someCall({ if (7️⃣x) {} }) {}
+        if foo.someCall({ if 7️⃣(x) {} }) {}
         """,
       expected: """
         switch b {
@@ -194,13 +193,13 @@ final class NoParensAroundConditionsTests: LintOrFormatRuleTestCase {
     assertFormatting(
       NoParensAroundConditions.self,
       input: """
-        let x = if (1️⃣x) {}
-        let y = switch (2️⃣4) { default: break }
+        let x = if 1️⃣(x) {}
+        let y = switch 2️⃣(4) { default: break }
         func foo() {
-          return if (3️⃣x) {}
+          return if 3️⃣(x) {}
         }
         func bar() {
-          return switch (4️⃣4) { default: break }
+          return switch 4️⃣(4) { default: break }
         }
         """,
       expected: """

--- a/Tests/SwiftFormatTests/Rules/TypeNamesShouldBeCapitalizedTests.swift
+++ b/Tests/SwiftFormatTests/Rules/TypeNamesShouldBeCapitalizedTests.swift
@@ -2,28 +2,27 @@ import _SwiftFormatTestSupport
 
 @_spi(Rules) import SwiftFormat
 
-// FIXME: Diagnostics should be emitted at the identifier, not at the start of the declaration.
 final class TypeNamesShouldBeCapitalizedTests: LintOrFormatRuleTestCase {
   func testConstruction() {
     assertLint(
       TypeNamesShouldBeCapitalized.self,
       """
-      1️⃣struct a {}
-      2️⃣class klassName {
-        3️⃣struct subType {}
+      struct 1️⃣a {}
+      class 2️⃣klassName {
+        struct 3️⃣subType {}
       }
-      4️⃣protocol myProtocol {}
+      protocol 4️⃣myProtocol {}
 
       extension myType {
-        5️⃣struct innerType {}
+        struct 5️⃣innerType {}
       }
       """,
       findings: [
-        FindingSpec("1️⃣", message: "type names should be capitalized: a -> A"),
-        FindingSpec("2️⃣", message: "type names should be capitalized: klassName -> KlassName"),
-        FindingSpec("3️⃣", message: "type names should be capitalized: subType -> SubType"),
-        FindingSpec("4️⃣", message: "type names should be capitalized: myProtocol -> MyProtocol"),
-        FindingSpec("5️⃣", message: "type names should be capitalized: innerType -> InnerType"),
+        FindingSpec("1️⃣", message: "rename the struct 'a' using UpperCamelCase; for example, 'A'"),
+        FindingSpec("2️⃣", message: "rename the class 'klassName' using UpperCamelCase; for example, 'KlassName'"),
+        FindingSpec("3️⃣", message: "rename the struct 'subType' using UpperCamelCase; for example, 'SubType'"),
+        FindingSpec("4️⃣", message: "rename the protocol 'myProtocol' using UpperCamelCase; for example, 'MyProtocol'"),
+        FindingSpec("5️⃣", message: "rename the struct 'innerType' using UpperCamelCase; for example, 'InnerType'"),
       ]
     )
   }
@@ -32,14 +31,14 @@ final class TypeNamesShouldBeCapitalizedTests: LintOrFormatRuleTestCase {
     assertLint(
       TypeNamesShouldBeCapitalized.self,
       """
-      1️⃣actor myActor {}
+      actor 1️⃣myActor {}
       actor OtherActor {}
-      2️⃣distributed actor greeter {}
+      distributed actor 2️⃣greeter {}
       distributed actor DistGreeter {}
       """,
       findings: [
-        FindingSpec("1️⃣", message: "type names should be capitalized: myActor -> MyActor"),
-        FindingSpec("2️⃣", message: "type names should be capitalized: greeter -> Greeter"),
+        FindingSpec("1️⃣", message: "rename the actor 'myActor' using UpperCamelCase; for example, 'MyActor'"),
+        FindingSpec("2️⃣", message: "rename the actor 'greeter' using UpperCamelCase; for example, 'Greeter'"),
       ]
     )
   }
@@ -49,15 +48,15 @@ final class TypeNamesShouldBeCapitalizedTests: LintOrFormatRuleTestCase {
       TypeNamesShouldBeCapitalized.self,
       """
       protocol P {
-        1️⃣associatedtype kind
+        associatedtype 1️⃣kind
         associatedtype OtherKind
       }
 
-      2️⃣typealias x = Int
+      typealias 2️⃣x = Int
       typealias Y = String
 
       struct MyType {
-        3️⃣typealias data<T> = Y
+        typealias 3️⃣data<T> = Y
 
         func test() {
           typealias Value<T> = Y
@@ -65,9 +64,9 @@ final class TypeNamesShouldBeCapitalizedTests: LintOrFormatRuleTestCase {
       }
       """,
       findings: [
-        FindingSpec("1️⃣", message: "type names should be capitalized: kind -> Kind"),
-        FindingSpec("2️⃣", message: "type names should be capitalized: x -> X"),
-        FindingSpec("3️⃣", message: "type names should be capitalized: data -> Data"),
+        FindingSpec("1️⃣", message: "rename the associated type 'kind' using UpperCamelCase; for example, 'Kind'"),
+        FindingSpec("2️⃣", message: "rename the type alias 'x' using UpperCamelCase; for example, 'X'"),
+        FindingSpec("3️⃣", message: "rename the type alias 'data' using UpperCamelCase; for example, 'Data'"),
       ]
     )
   }
@@ -76,47 +75,47 @@ final class TypeNamesShouldBeCapitalizedTests: LintOrFormatRuleTestCase {
     assertLint(
       TypeNamesShouldBeCapitalized.self,
       """
-      1️⃣protocol _p {
-        2️⃣associatedtype _value
+      protocol 1️⃣_p {
+        associatedtype 2️⃣_value
         associatedtype __Value
       }
 
       protocol ___Q {
       }
 
-      3️⃣struct _data {
-        4️⃣typealias _x = Int
+      struct 3️⃣_data {
+        typealias 4️⃣_x = Int
       }
 
       struct _Data {}
 
-      5️⃣actor _internalActor {}
+      actor 5️⃣_internalActor {}
 
-      6️⃣enum __e {
+      enum 6️⃣__e {
       }
 
       enum _OtherE {
       }
 
       func test() {
-        7️⃣class _myClass {}
+        class 7️⃣_myClass {}
         do {
           class _MyClass {}
         }
       }
 
-      8️⃣distributed actor __greeter {}
+      distributed actor 8️⃣__greeter {}
       distributed actor __InternalGreeter {}
       """,
       findings: [
-        FindingSpec("1️⃣", message: "type names should be capitalized: _p -> _P"),
-        FindingSpec("2️⃣", message: "type names should be capitalized: _value -> _Value"),
-        FindingSpec("3️⃣", message: "type names should be capitalized: _data -> _Data"),
-        FindingSpec("4️⃣", message: "type names should be capitalized: _x -> _X"),
-        FindingSpec("5️⃣", message: "type names should be capitalized: _internalActor -> _InternalActor"),
-        FindingSpec("6️⃣", message: "type names should be capitalized: __e -> __E"),
-        FindingSpec("7️⃣", message: "type names should be capitalized: _myClass -> _MyClass"),
-        FindingSpec("8️⃣", message: "type names should be capitalized: __greeter -> __Greeter"),
+        FindingSpec("1️⃣", message: "rename the protocol '_p' using UpperCamelCase; for example, '_P'"),
+        FindingSpec("2️⃣", message: "rename the associated type '_value' using UpperCamelCase; for example, '_Value'"),
+        FindingSpec("3️⃣", message: "rename the struct '_data' using UpperCamelCase; for example, '_Data'"),
+        FindingSpec("4️⃣", message: "rename the type alias '_x' using UpperCamelCase; for example, '_X'"),
+        FindingSpec("5️⃣", message: "rename the actor '_internalActor' using UpperCamelCase; for example, '_InternalActor'"),
+        FindingSpec("6️⃣", message: "rename the enum '__e' using UpperCamelCase; for example, '__E'"),
+        FindingSpec("7️⃣", message: "rename the class '_myClass' using UpperCamelCase; for example, '_MyClass'"),
+        FindingSpec("8️⃣", message: "rename the actor '__greeter' using UpperCamelCase; for example, '__Greeter'"),
       ]
     )
   }

--- a/Tests/SwiftFormatTests/Rules/UseEarlyExitsTests.swift
+++ b/Tests/SwiftFormatTests/Rules/UseEarlyExitsTests.swift
@@ -2,9 +2,6 @@ import _SwiftFormatTestSupport
 
 @_spi(Rules) import SwiftFormat
 
-// FIXME: The findings are emitted in odd places; the last test is especially wrong. Their locations
-// may be getting computed from the tree post-transformation, so they no longer map to the right
-// locations in the original tree.
 final class UseEarlyExitsTests: LintOrFormatRuleTestCase {
   func testBasicIfElse() {
     // In this and other tests, the indentation of the true block in the expected output is
@@ -13,9 +10,9 @@ final class UseEarlyExitsTests: LintOrFormatRuleTestCase {
     assertFormatting(
       UseEarlyExits.self,
       input: """
-        if condition {
+        1️⃣if condition {
           trueBlock()
-        } 1️⃣else {
+        } else {
           falseBlock()
           return
         }
@@ -28,7 +25,7 @@ final class UseEarlyExitsTests: LintOrFormatRuleTestCase {
           trueBlock()
         """,
       findings: [
-        FindingSpec("1️⃣", message: "replace the 'if/else' block with a 'guard' statement containing the early exit"),
+        FindingSpec("1️⃣", message: "replace this 'if/else' block with a 'guard' statement containing the early exit"),
       ]
     )
   }
@@ -37,10 +34,10 @@ final class UseEarlyExitsTests: LintOrFormatRuleTestCase {
     assertFormatting(
       UseEarlyExits.self,
       input: """
-        if condition {
+        1️⃣if condition {
           trueBlock()
           return
-        } 1️⃣else {
+        } else {
           falseBlock()
           return
         }
@@ -54,7 +51,7 @@ final class UseEarlyExitsTests: LintOrFormatRuleTestCase {
           return
         """,
       findings: [
-        FindingSpec("1️⃣", message: "replace the 'if/else' block with a 'guard' statement containing the early exit"),
+        FindingSpec("1️⃣", message: "replace this 'if/else' block with a 'guard' statement containing the early exit"),
       ]
     )
   }
@@ -94,20 +91,20 @@ final class UseEarlyExitsTests: LintOrFormatRuleTestCase {
 
           // Comment 1
 
-          /*Comment 2*/ if let first = values.first {
+          /*Comment 2*/ 1️⃣if let first = values.first {
             // Comment 3
 
             /// Doc comment
-            if first >= 0 {
+            2️⃣if first >= 0 {
               // Comment 4
               var result = 0
-           2️⃣   for value in values {
+              for value in values {
                 result += invertedCombobulatorFactor(of: value)
               }
               return result
             } else {
               print("Can't have negative energy")
-          1️⃣    throw DiscombobulationError.negativeEnergy
+              throw DiscombobulationError.negativeEnergy
             }
           } else {
             print("The array was empty")
@@ -140,8 +137,8 @@ final class UseEarlyExitsTests: LintOrFormatRuleTestCase {
         }
         """,
       findings: [
-        FindingSpec("1️⃣", message: "replace the 'if/else' block with a 'guard' statement containing the early exit"),
-        FindingSpec("2️⃣", message: "replace the 'if/else' block with a 'guard' statement containing the early exit"),
+        FindingSpec("1️⃣", message: "replace this 'if/else' block with a 'guard' statement containing the early exit"),
+        FindingSpec("2️⃣", message: "replace this 'if/else' block with a 'guard' statement containing the early exit"),
       ]
     )
   }

--- a/Tests/SwiftFormatTests/Rules/UseTripleSlashForDocumentationCommentsTests.swift
+++ b/Tests/SwiftFormatTests/Rules/UseTripleSlashForDocumentationCommentsTests.swift
@@ -2,7 +2,6 @@ import _SwiftFormatTestSupport
 
 @_spi(Rules) import SwiftFormat
 
-// FIXME: Findings aren't actually being emitted by this rule!
 final class UseTripleSlashForDocumentationCommentsTests: LintOrFormatRuleTestCase {
   func testRemoveDocBlockComments() {
     assertFormatting(
@@ -12,7 +11,7 @@ final class UseTripleSlashForDocumentationCommentsTests: LintOrFormatRuleTestCas
          * This comment should not be converted.
          */
 
-        /**
+        1️⃣/**
          * Returns a docLineComment.
          *
          * - Parameters:
@@ -33,7 +32,9 @@ final class UseTripleSlashForDocumentationCommentsTests: LintOrFormatRuleTestCas
         /// - Returns: docLineComment.
         func foo(withOutStar: Bool) {}
         """,
-      findings: []
+      findings: [
+        FindingSpec("1️⃣", message: "replace documentation block comments with documentation line comments")
+      ]
     )
   }
   
@@ -41,7 +42,7 @@ final class UseTripleSlashForDocumentationCommentsTests: LintOrFormatRuleTestCas
     assertFormatting(
       UseTripleSlashForDocumentationComments.self,
       input: """
-        /**
+        1️⃣/**
          Returns a docLineComment.
 
          - Parameters:
@@ -58,7 +59,9 @@ final class UseTripleSlashForDocumentationCommentsTests: LintOrFormatRuleTestCas
         /// - Returns: docLineComment.
         public var test = 1
         """,
-      findings: []
+      findings: [
+        FindingSpec("1️⃣", message: "replace documentation block comments with documentation line comments")
+      ]
     )
   }
 
@@ -137,7 +140,7 @@ final class UseTripleSlashForDocumentationCommentsTests: LintOrFormatRuleTestCas
         /// Why are there so many comments?
         /// Who knows! But there are loads.
 
-        /** AClazz is a class with good name. */
+        1️⃣/** AClazz is a class with good name. */
         public class AClazz {
         }
         """,
@@ -158,7 +161,9 @@ final class UseTripleSlashForDocumentationCommentsTests: LintOrFormatRuleTestCas
         public class AClazz {
         }
         """,
-      findings: []
+      findings: [
+        FindingSpec("1️⃣", message: "replace documentation block comments with documentation line comments")
+      ]
     )
   }
 


### PR DESCRIPTION
- Whitespace linter: Fix improper pluralization of "add 1 line breaks".
- `DoNotUseSemicolons`: Only show the part of the message about moving the next statement to a new line if a statement actually follows the semicolon on the same line.
- `DontRepeatTypeInStaticProperties`: Place the finding on the identifier, not at the start of the decl.
- `FullyIndirectEnum`: Move the finding to the `enum` keyword and add notes to each `indirect` keyword that should be removed.
- `GroupNumericLiterals`: Clean up the finding message and include the numeric base of the literal.
- `NoAccessLevelOnExtensionDeclaration`: Add notes for each extension declaration that needs to have the access modifier added to it.
- `NoCasesWithOnlyFallthrough`: Put findings at the right locations.
- `NoEmptyTrailingClosureParentheses`: Place the finding on the parentheses themselves.
- `NoParensAroundConditions`: Place the finding on the parentheses themselves.
- `TypeNamesShouldBeCapitalized`: Place the finding on the name instead of the declaration and clean up the message to make it more consistent with other rules.
- `UseEarlyExits`: Put findings at the right locations.
- `UseTripleSlashForDocumentationComments`: Place the finding on the comment, not on the declaration.