### PR TITLE
[Lint] Add a rule to replace `.forEach` with a for-in loop

### DIFF
--- a/Sources/SwiftFormat/Core/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Core/Pipelines+Generated.swift
@@ -143,6 +143,7 @@ class LintPipeline: SyntaxVisitor {
   override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NoEmptyTrailingClosureParentheses.visit, for: node)
     visitIfEnabled(OnlyOneTrailingClosureArgument.visit, for: node)
+    visitIfEnabled(ReplaceForEachWithForLoop.visit, for: node)
     return .visitChildren
   }
 

--- a/Sources/SwiftFormat/Core/RuleNameCache+Generated.swift
+++ b/Sources/SwiftFormat/Core/RuleNameCache+Generated.swift
@@ -42,6 +42,7 @@ public let ruleNameCache: [ObjectIdentifier: String] = [
   ObjectIdentifier(OneVariableDeclarationPerLine.self): "OneVariableDeclarationPerLine",
   ObjectIdentifier(OnlyOneTrailingClosureArgument.self): "OnlyOneTrailingClosureArgument",
   ObjectIdentifier(OrderedImports.self): "OrderedImports",
+  ObjectIdentifier(ReplaceForEachWithForLoop.self): "ReplaceForEachWithForLoop",
   ObjectIdentifier(ReturnVoidInsteadOfEmptyTuple.self): "ReturnVoidInsteadOfEmptyTuple",
   ObjectIdentifier(TypeNamesShouldBeCapitalized.self): "TypeNamesShouldBeCapitalized",
   ObjectIdentifier(UseEarlyExits.self): "UseEarlyExits",

--- a/Sources/SwiftFormat/Rules/ReplaceForEachWithForLoop.swift
+++ b/Sources/SwiftFormat/Rules/ReplaceForEachWithForLoop.swift
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+/// Replace `forEach` with `for-in` loop unless its argument is a function reference.
+///
+/// Lint:  invalid use of `forEach` yield will yield a lint error.
+@_spi(Rules)
+public final class ReplaceForEachWithForLoop : SyntaxLintRule {
+  public override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+    // We are only interested in calls with a single trailing closure
+    // argument.
+    if !node.arguments.isEmpty || node.trailingClosure == nil ||
+       !node.additionalTrailingClosures.isEmpty {
+      return .visitChildren
+    }
+
+    guard let member = node.calledExpression.as(MemberAccessExprSyntax.self) else {
+      return .visitChildren
+    }
+
+    guard let memberName = member.declName.baseName.as(TokenSyntax.self),
+          memberName.text == "forEach" else {
+      return .visitChildren
+    }
+
+    // If there is another chained member after `.forEach`,
+    // let's skip the diagnostic because resulting code might
+    // be less understandable.
+    if node.parent?.is(MemberAccessExprSyntax.self) == true {
+      return .visitChildren
+    }
+
+    diagnose(.replaceForEachWithLoop(), on: memberName)
+    return .visitChildren
+  }
+}
+
+extension Finding.Message {
+  public static func replaceForEachWithLoop() -> Finding.Message {
+    "replace use of '.forEach { ... }' with for-in loop"
+  }
+}

--- a/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
+++ b/Sources/SwiftFormatConfiguration/RuleRegistry+Generated.swift
@@ -41,6 +41,7 @@ enum RuleRegistry {
     "OneVariableDeclarationPerLine": true,
     "OnlyOneTrailingClosureArgument": true,
     "OrderedImports": true,
+    "ReplaceForEachWithForLoop": true,
     "ReturnVoidInsteadOfEmptyTuple": true,
     "TypeNamesShouldBeCapitalized": true,
     "UseEarlyExits": false,

--- a/Tests/SwiftFormatTests/Rules/ReplaceForEachWithForLoopTests.swift
+++ b/Tests/SwiftFormatTests/Rules/ReplaceForEachWithForLoopTests.swift
@@ -1,0 +1,34 @@
+import _SwiftFormatTestSupport
+
+@_spi(Rules) import SwiftFormat
+
+
+final class ReplaceForEachWithForLoopTests: LintOrFormatRuleTestCase {
+  func test() {
+    assertLint(
+      ReplaceForEachWithForLoop.self,
+      """
+      values.1️⃣forEach { $0 * 2 }
+      values.map { $0 }.2️⃣forEach { print($0) }
+      values.forEach(callback)
+      values.forEach { $0 }.chained()
+      values.forEach({ $0 }).chained()
+      values.3️⃣forEach {
+        let arg = $0
+        return arg + 1
+      }
+      values.forEach {
+        let arg = $0
+        return arg + 1
+      } other: {
+        42
+      }
+      """,
+      findings: [
+        FindingSpec("1️⃣", message: "replace use of '.forEach { ... }' with for-in loop"),
+        FindingSpec("2️⃣", message: "replace use of '.forEach { ... }' with for-in loop"),
+        FindingSpec("3️⃣", message: "replace use of '.forEach { ... }' with for-in loop")
+      ]
+    )
+  }
+}


### PR DESCRIPTION
If there is no chaining using for-in loop more understandable and requires less chaining/nesting.