### PR TITLE
Add GitHub Actions workflows to attach release assets. Fix #427

### DIFF
--- a/.github/workflows/add-release-asset-macos.yml
+++ b/.github/workflows/add-release-asset-macos.yml
@@ -8,6 +8,9 @@ jobs:
   release:
     runs-on: macos-12
 
+    permissions:
+      contents: write
+
     steps:
 
       - name: Checkout

--- a/.github/workflows/add-release-asset-macos.yml
+++ b/.github/workflows/add-release-asset-macos.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           CURRENT_RELEASE: ${{ github.event.release.tag_name }}
         run: |
-          find . -name 'VersionOptions.swift' -exec sed -i '' 's/print("[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}")/print("'$CURRENT_RELEASE'")/g' {} +
+          find . -name 'VersionOptions.swift' -exec sed -i '' 's/print(".*")/print("'$CURRENT_RELEASE'")/g' {} +
           cat Sources/swift-format/VersionOptions.swift
 
       # Should output executable to `.build/release/swift-format`

--- a/.github/workflows/add-release-asset-macos.yml
+++ b/.github/workflows/add-release-asset-macos.yml
@@ -27,9 +27,7 @@ jobs:
           zip $FILENAME .build/release/swift-format
           echo "ARCHIVE_ABSOLUTE_FILEPATH=$(pwd)/$FILENAME" >> $GITHUB_OUTPUT;
 
-      - uses: meeDamian/github-release@2.0
+      - name: Attach asset
+        uses: softprops/action-gh-release@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           files: ${{ steps.create-plugin-archive.outputs.ARCHIVE_ABSOLUTE_FILEPATH }}
-          gzip: false
-          allow_override: true

--- a/.github/workflows/add-release-asset-macos.yml
+++ b/.github/workflows/add-release-asset-macos.yml
@@ -38,7 +38,7 @@ jobs:
           FILENAME=swift-format.${{ github.event.release.name }}.macos.zip
           cd .build/release/
           echo "xattr -c swift-format" > disable-codesigning.sh
-          zip $FILENAME *.*
+          zip $FILENAME swift-format disable-codesigning.sh
           echo "ARCHIVE_ABSOLUTE_FILEPATH=$(pwd)/$FILENAME" >> $GITHUB_OUTPUT;
 
       - name: Attach asset

--- a/.github/workflows/add-release-asset-macos.yml
+++ b/.github/workflows/add-release-asset-macos.yml
@@ -36,7 +36,8 @@ jobs:
         id: create-plugin-archive
         run: |
           FILENAME=swift-format.${{ github.event.release.name }}.macos.zip
-          zip $FILENAME .build/release/swift-format
+          cd .build/release/
+          zip $FILENAME *.*
           echo "ARCHIVE_ABSOLUTE_FILEPATH=$(pwd)/$FILENAME" >> $GITHUB_OUTPUT;
 
       - name: Attach asset

--- a/.github/workflows/add-release-asset-macos.yml
+++ b/.github/workflows/add-release-asset-macos.yml
@@ -31,6 +31,10 @@ jobs:
       - name: Build
         run: swift build --disable-sandbox -c release
 
+      # Smoke test
+      - name: Test the executable works
+        run: .build/release/swift-format --version
+
       # Zip the executable so it can be given a descriptive name to distinguish the MacOS and Ubuntu builds
       - name: Create archive
         id: create-plugin-archive

--- a/.github/workflows/add-release-asset-macos.yml
+++ b/.github/workflows/add-release-asset-macos.yml
@@ -1,4 +1,4 @@
-name: Build and attach on releases
+name: Build and attach on releases – MacOS
 
 on:
   release:

--- a/.github/workflows/add-release-asset-macos.yml
+++ b/.github/workflows/add-release-asset-macos.yml
@@ -1,0 +1,35 @@
+name: Build and attach on releases
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: macos-12
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      # Should output executable to `.build/release/swift-format`
+      - name: Build
+        run: swift build --disable-sandbox -c release
+
+      # Zip the executable so it can be given a descriptive name to distinguish the MacOS and Ubuntu builds
+      - name: Create archive
+        id: create-plugin-archive
+        run: |
+          FILENAME=swift-format.${{ github.event.release.name }}.macos.zip
+          zip $FILENAME .build/release/swift-format
+          echo "ARCHIVE_ABSOLUTE_FILEPATH=$(pwd)/$FILENAME" >> $GITHUB_OUTPUT;
+
+      - uses: meeDamian/github-release@2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: ${{ steps.create-plugin-archive.outputs.ARCHIVE_ABSOLUTE_FILEPATH }}
+          gzip: false
+          allow_override: true

--- a/.github/workflows/add-release-asset-macos.yml
+++ b/.github/workflows/add-release-asset-macos.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           FILENAME=swift-format.${{ github.event.release.name }}.macos.zip
           cd .build/release/
+          echo "xattr -c swift-format" > disable-codesigning.sh
           zip $FILENAME *.*
           echo "ARCHIVE_ABSOLUTE_FILEPATH=$(pwd)/$FILENAME" >> $GITHUB_OUTPUT;
 

--- a/.github/workflows/add-release-asset-macos.yml
+++ b/.github/workflows/add-release-asset-macos.yml
@@ -18,6 +18,15 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
 
+      # @see https://github.com/apple/swift-format/commit/fbfe1869527923dd9f9b2edac148baccfce0dce7
+      # NB: sed syntax differs between MacOS and Ubuntu
+      - name: Edit `VersionOptions.swift` to update the version number
+        env:
+          CURRENT_RELEASE: ${{ github.event.release.tag_name }}
+        run: |
+          find . -name 'VersionOptions.swift' -exec sed -i '' 's/print("[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}")/print("'$CURRENT_RELEASE'")/g' {} +
+          cat Sources/swift-format/VersionOptions.swift
+
       # Should output executable to `.build/release/swift-format`
       - name: Build
         run: swift build --disable-sandbox -c release

--- a/.github/workflows/add-release-asset-macos.yml
+++ b/.github/workflows/add-release-asset-macos.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
 
-      # @see https://github.com/apple/swift-format/commit/fbfe1869527923dd9f9b2edac148baccfce0dce7
+      # @see https://github.com/apple/swift-format/commit/705038361379825ef201d96f2709587b08212f5a
       # NB: sed syntax differs between MacOS and Ubuntu
       - name: Edit `VersionOptions.swift` to update the version number
         env:

--- a/.github/workflows/add-release-asset-ubuntu.yml
+++ b/.github/workflows/add-release-asset-ubuntu.yml
@@ -36,7 +36,8 @@ jobs:
         id: create-plugin-archive
         run: |
           FILENAME=swift-format.${{ github.event.release.name }}.ubuntu.zip
-          zip $FILENAME .build/release/swift-format
+          cd .build/release/
+          zip $FILENAME swift-format
           echo "ARCHIVE_ABSOLUTE_FILEPATH=$(pwd)/$FILENAME" >> $GITHUB_OUTPUT;
 
       - uses: meeDamian/github-release@2.0

--- a/.github/workflows/add-release-asset-ubuntu.yml
+++ b/.github/workflows/add-release-asset-ubuntu.yml
@@ -18,6 +18,15 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
 
+      # @see https://github.com/apple/swift-format/commit/fbfe1869527923dd9f9b2edac148baccfce0dce7
+      # NB: sed syntax differs between MacOS and Ubuntu
+      - name: Edit `VersionOptions.swift` to update the version number
+        env:
+          CURRENT_RELEASE: ${{ github.event.release.tag_name }}
+        run: |
+          find . -name 'VersionOptions.swift' -exec sed -i 's/print("[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}")/print("'$CURRENT_RELEASE'")/g' {} +
+          cat Sources/swift-format/VersionOptions.swift
+
       # Should output executable to `.build/release/swift-format`
       - name: Build
         run: swift build --disable-sandbox -c release

--- a/.github/workflows/add-release-asset-ubuntu.yml
+++ b/.github/workflows/add-release-asset-ubuntu.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           CURRENT_RELEASE: ${{ github.event.release.tag_name }}
         run: |
-          find . -name 'VersionOptions.swift' -exec sed -i 's/print("[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}")/print("'$CURRENT_RELEASE'")/g' {} +
+          find . -name 'VersionOptions.swift' -exec sed -i 's/print(".*")/print("'$CURRENT_RELEASE'")/g' {} +
           cat Sources/swift-format/VersionOptions.swift
 
       # Should output executable to `.build/release/swift-format`

--- a/.github/workflows/add-release-asset-ubuntu.yml
+++ b/.github/workflows/add-release-asset-ubuntu.yml
@@ -31,6 +31,10 @@ jobs:
       - name: Build
         run: swift build --disable-sandbox -c release
 
+      # Smoke test
+      - name: Test the executable works
+        run: .build/release/swift-format --version
+
       # Zip the executable so it can be given a descriptive name to distinguish the MacOS and Ubuntu builds
       - name: Create archive
         id: create-plugin-archive

--- a/.github/workflows/add-release-asset-ubuntu.yml
+++ b/.github/workflows/add-release-asset-ubuntu.yml
@@ -40,9 +40,7 @@ jobs:
           zip $FILENAME swift-format
           echo "ARCHIVE_ABSOLUTE_FILEPATH=$(pwd)/$FILENAME" >> $GITHUB_OUTPUT;
 
-      - uses: meeDamian/github-release@2.0
+      - name: Attach asset
+        uses: softprops/action-gh-release@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           files: ${{ steps.create-plugin-archive.outputs.ARCHIVE_ABSOLUTE_FILEPATH }}
-          gzip: false
-          allow_override: true

--- a/.github/workflows/add-release-asset-ubuntu.yml
+++ b/.github/workflows/add-release-asset-ubuntu.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
 
-      # @see https://github.com/apple/swift-format/commit/fbfe1869527923dd9f9b2edac148baccfce0dce7
+      # @see https://github.com/apple/swift-format/commit/705038361379825ef201d96f2709587b08212f5a
       # NB: sed syntax differs between MacOS and Ubuntu
       - name: Edit `VersionOptions.swift` to update the version number
         env:

--- a/.github/workflows/add-release-asset-ubuntu.yml
+++ b/.github/workflows/add-release-asset-ubuntu.yml
@@ -1,0 +1,35 @@
+name: Build and attach on releases
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      # Should output executable to `.build/release/swift-format`
+      - name: Build
+        run: swift build --disable-sandbox -c release
+
+      # Zip the executable so it can be given a descriptive name to distinguish the MacOS and Ubuntu builds
+      - name: Create archive
+        id: create-plugin-archive
+        run: |
+          FILENAME=swift-format.${{ github.event.release.name }}.ubuntu.zip
+          zip $FILENAME .build/release/swift-format
+          echo "ARCHIVE_ABSOLUTE_FILEPATH=$(pwd)/$FILENAME" >> $GITHUB_OUTPUT;
+
+      - uses: meeDamian/github-release@2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: ${{ steps.create-plugin-archive.outputs.ARCHIVE_ABSOLUTE_FILEPATH }}
+          gzip: false
+          allow_override: true

--- a/.github/workflows/add-release-asset-ubuntu.yml
+++ b/.github/workflows/add-release-asset-ubuntu.yml
@@ -1,4 +1,4 @@
-name: Build and attach on releases
+name: Build and attach on releases - Ubuntu
 
 on:
   release:

--- a/.github/workflows/add-release-asset-ubuntu.yml
+++ b/.github/workflows/add-release-asset-ubuntu.yml
@@ -8,6 +8,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
 
       - name: Checkout


### PR DESCRIPTION
Adds two GitHub Actions workflows, one running MacOS and the other Ubuntu, triggered by new releases, each of which updates the version number and runs `swift build --disable-sandbox -c release`, zips the file and attaches it to the release.

I'm not sure why it uses `--disable-sandbox`, I copied that from [Iron-Ham/swift-format-linter-action](https://github.com/Iron-Ham/swift-format-linter-action) but maybe it's unnecessary? 

The MacOS asset also contains `disable-codesigning.sh` which contains the command `xattr -c swift-format` because otherwise :

> "swift-format" cannot be opened because the developer cannot be verified

<img width="282" alt="Screenshot 2023-09-05 at 4 25 30 PM" src="https://github.com/apple/swift-format/assets/4720401/94f022cb-687d-4047-b4e0-7ca1aaafb657">

While I say fixes #427, rather than trigger on tag, this is triggered on release.

Main isn't building for me so I branched at 508.0.1 and tested on that: https://github.com/BrianHenryIE/swift-format/releases