### PR TITLE
Remove unnecessary casting

### DIFF
--- a/Sources/SwiftFormat/Rules/OmitExplicitReturns.swift
+++ b/Sources/SwiftFormat/Rules/OmitExplicitReturns.swift
@@ -123,7 +123,7 @@ public final class OmitExplicitReturns: SyntaxFormatRule {
   }
 
   private func containsSingleReturn(_ body: CodeBlockItemListSyntax) -> ReturnStmtSyntax? {
-    guard let element = body.firstAndOnly?.as(CodeBlockItemSyntax.self),
+    guard let element = body.firstAndOnly,
        let returnStmt = element.item.as(ReturnStmtSyntax.self) else
         {
       return nil

--- a/Sources/SwiftFormat/Rules/ReplaceForEachWithForLoop.swift
+++ b/Sources/SwiftFormat/Rules/ReplaceForEachWithForLoop.swift
@@ -29,8 +29,8 @@ public final class ReplaceForEachWithForLoop : SyntaxLintRule {
       return .visitChildren
     }
 
-    guard let memberName = member.declName.baseName.as(TokenSyntax.self),
-          memberName.text == "forEach" else {
+    let memberName = member.declName.baseName
+    guard memberName.text == "forEach" else {
       return .visitChildren
     }
 


### PR DESCRIPTION
Solves warnings produced by: https://github.com/apple/swift-syntax/pull/2108