### PR TITLE
Add option to disable trailing commas on multi-line collections

### DIFF
--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -82,7 +82,7 @@ top-level keys and values:
 *  `spacesAroundRangeFormationOperators` _(boolean)_: Determines whether whitespace should be forced
    before and after the range formation operators `...` and `..<`.
 
-*  `multilineCollectionTrailingCommas` _(boolean)_: Determines whether multi-line collections should have trailing commas.
+*  `multiElementCollectionTrailingCommas` _(boolean)_: Determines whether multi-element collection literals should have trailing commas.
     Defaults to `true`.
 
 > TODO: Add support for enabling/disabling specific syntax transformations in

--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -82,6 +82,9 @@ top-level keys and values:
 *  `spacesAroundRangeFormationOperators` _(boolean)_: Determines whether whitespace should be forced
    before and after the range formation operators `...` and `..<`.
 
+*  `multilineCollectionTrailingCommas` _(boolean)_: Determines whether multi-line collections should have trailing commas.
+    Defaults to `true`.
+
 > TODO: Add support for enabling/disabling specific syntax transformations in
 > the pipeline.
 

--- a/Sources/SwiftFormat/API/Configuration+Default.swift
+++ b/Sources/SwiftFormat/API/Configuration+Default.swift
@@ -37,5 +37,6 @@ extension Configuration {
     self.indentSwitchCaseLabels = false
     self.spacesAroundRangeFormationOperators = false
     self.noAssignmentInExpressions = NoAssignmentInExpressionsConfiguration()
+    self.multilineCollectionTrailingCommas = true
   }
 }

--- a/Sources/SwiftFormat/API/Configuration+Default.swift
+++ b/Sources/SwiftFormat/API/Configuration+Default.swift
@@ -37,6 +37,6 @@ extension Configuration {
     self.indentSwitchCaseLabels = false
     self.spacesAroundRangeFormationOperators = false
     self.noAssignmentInExpressions = NoAssignmentInExpressionsConfiguration()
-    self.multilineCollectionTrailingCommas = true
+    self.multiElementCollectionTrailingCommas = true
   }
 }

--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -42,7 +42,7 @@ public struct Configuration: Codable, Equatable {
     case rules
     case spacesAroundRangeFormationOperators
     case noAssignmentInExpressions
-    case multilineCollectionTrailingCommas
+    case multiElementCollectionTrailingCommas
   }
 
   /// A dictionary containing the default enabled/disabled states of rules, keyed by the rules'
@@ -163,8 +163,8 @@ public struct Configuration: Codable, Equatable {
   /// Contains exceptions for the `NoAssignmentInExpressions` rule.
   public var noAssignmentInExpressions: NoAssignmentInExpressionsConfiguration
 
-  /// Determines whether multi-line list initializers should have trailing commas.
-  public var multilineCollectionTrailingCommas: Bool
+  /// Determines whether multi-element collection literals should have trailing commas.
+  public var multiElementCollectionTrailingCommas: Bool
 
   /// Constructs a Configuration by loading it from a configuration file.
   public init(contentsOf url: URL) throws {
@@ -243,10 +243,10 @@ public struct Configuration: Codable, Equatable {
       try container.decodeIfPresent(
         NoAssignmentInExpressionsConfiguration.self, forKey: .noAssignmentInExpressions)
       ?? defaults.noAssignmentInExpressions
-    self.multilineCollectionTrailingCommas =
+    self.multiElementCollectionTrailingCommas =
       try container.decodeIfPresent(
-        Bool.self, forKey: .multilineCollectionTrailingCommas)
-    ?? defaults.multilineCollectionTrailingCommas
+        Bool.self, forKey: .multiElementCollectionTrailingCommas)
+    ?? defaults.multiElementCollectionTrailingCommas
 
     // If the `rules` key is not present at all, default it to the built-in set
     // so that the behavior is the same as if the configuration had been
@@ -279,7 +279,7 @@ public struct Configuration: Codable, Equatable {
     try container.encode(fileScopedDeclarationPrivacy, forKey: .fileScopedDeclarationPrivacy)
     try container.encode(indentSwitchCaseLabels, forKey: .indentSwitchCaseLabels)
     try container.encode(noAssignmentInExpressions, forKey: .noAssignmentInExpressions)
-    try container.encode(multilineCollectionTrailingCommas, forKey: .multilineCollectionTrailingCommas)
+    try container.encode(multiElementCollectionTrailingCommas, forKey: .multiElementCollectionTrailingCommas)
     try container.encode(rules, forKey: .rules)
   }
 

--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -42,6 +42,7 @@ public struct Configuration: Codable, Equatable {
     case rules
     case spacesAroundRangeFormationOperators
     case noAssignmentInExpressions
+    case multilineCollectionTrailingCommas
   }
 
   /// A dictionary containing the default enabled/disabled states of rules, keyed by the rules'
@@ -162,6 +163,9 @@ public struct Configuration: Codable, Equatable {
   /// Contains exceptions for the `NoAssignmentInExpressions` rule.
   public var noAssignmentInExpressions: NoAssignmentInExpressionsConfiguration
 
+  /// Determines whether multi-line list initializers should have trailing commas
+  public var multilineCollectionTrailingCommas: Bool
+
   /// Constructs a Configuration by loading it from a configuration file.
   public init(contentsOf url: URL) throws {
     let data = try Data(contentsOf: url)
@@ -239,6 +243,10 @@ public struct Configuration: Codable, Equatable {
       try container.decodeIfPresent(
         NoAssignmentInExpressionsConfiguration.self, forKey: .noAssignmentInExpressions)
       ?? defaults.noAssignmentInExpressions
+    self.multilineCollectionTrailingCommas =
+      try container.decodeIfPresent(
+        Bool.self, forKey: .multilineCollectionTrailingCommas)
+    ?? defaults.multilineCollectionTrailingCommas
 
     // If the `rules` key is not present at all, default it to the built-in set
     // so that the behavior is the same as if the configuration had been
@@ -271,6 +279,7 @@ public struct Configuration: Codable, Equatable {
     try container.encode(fileScopedDeclarationPrivacy, forKey: .fileScopedDeclarationPrivacy)
     try container.encode(indentSwitchCaseLabels, forKey: .indentSwitchCaseLabels)
     try container.encode(noAssignmentInExpressions, forKey: .noAssignmentInExpressions)
+    try container.encode(multilineCollectionTrailingCommas, forKey: .multilineCollectionTrailingCommas)
     try container.encode(rules, forKey: .rules)
   }
 

--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -163,7 +163,7 @@ public struct Configuration: Codable, Equatable {
   /// Contains exceptions for the `NoAssignmentInExpressions` rule.
   public var noAssignmentInExpressions: NoAssignmentInExpressionsConfiguration
 
-  /// Determines whether multi-line list initializers should have trailing commas
+  /// Determines whether multi-line list initializers should have trailing commas.
   public var multilineCollectionTrailingCommas: Bool
 
   /// Constructs a Configuration by loading it from a configuration file.

--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -163,7 +163,27 @@ public struct Configuration: Codable, Equatable {
   /// Contains exceptions for the `NoAssignmentInExpressions` rule.
   public var noAssignmentInExpressions: NoAssignmentInExpressionsConfiguration
 
-  /// Determines whether multi-element collection literals should have trailing commas.
+  /// Determines if multi-element collection literals should have trailing commas.
+  ///
+  /// When `true` (default), the correct form is:
+  /// ```swift
+  /// let MyCollection = [1, 2,]
+  /// ...
+  /// let MyCollection = [
+  ///   "a": 1,
+  ///   "b": 2,
+  /// ]
+  /// ```
+  ///
+  /// When `false`, the correct form is:
+  /// ```swift
+  /// let MyCollection = [1, 2]
+  /// ...
+  /// let MyCollection = [
+  ///   "a": 1,
+  ///   "b": 2
+  /// ]
+  /// ```
   public var multiElementCollectionTrailingCommas: Bool
 
   /// Constructs a Configuration by loading it from a configuration file.

--- a/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
@@ -557,7 +557,7 @@ public class PrettyPrinter {
       // We never want to add a trailing comma in an initializer so we disable trailing commas on
       // single element collections.
       let shouldHaveTrailingComma =
-        startLineNumber != openCloseBreakCompensatingLineNumber && !isSingleElement && configuration.multilineCollectionTrailingCommas
+        startLineNumber != openCloseBreakCompensatingLineNumber && !isSingleElement && configuration.multiElementCollectionTrailingCommas
       if shouldHaveTrailingComma && !hasTrailingComma {
         diagnose(.addTrailingComma, category: .trailingComma)
       } else if !shouldHaveTrailingComma && hasTrailingComma {

--- a/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
@@ -557,7 +557,7 @@ public class PrettyPrinter {
       // We never want to add a trailing comma in an initializer so we disable trailing commas on
       // single element collections.
       let shouldHaveTrailingComma =
-        startLineNumber != openCloseBreakCompensatingLineNumber && !isSingleElement
+        startLineNumber != openCloseBreakCompensatingLineNumber && !isSingleElement && configuration.multilineCollectionTrailingCommas
       if shouldHaveTrailingComma && !hasTrailingComma {
         diagnose(.addTrailingComma, category: .trailingComma)
       } else if !shouldHaveTrailingComma && hasTrailingComma {

--- a/Sources/_SwiftFormatTestSupport/Configuration+Testing.swift
+++ b/Sources/_SwiftFormatTestSupport/Configuration+Testing.swift
@@ -40,7 +40,7 @@ extension Configuration {
     config.indentSwitchCaseLabels = false
     config.spacesAroundRangeFormationOperators = false
     config.noAssignmentInExpressions = NoAssignmentInExpressionsConfiguration()
-    config.multilineCollectionTrailingCommas = true
+    config.multiElementCollectionTrailingCommas = true
     return config
   }
 }

--- a/Sources/_SwiftFormatTestSupport/Configuration+Testing.swift
+++ b/Sources/_SwiftFormatTestSupport/Configuration+Testing.swift
@@ -40,6 +40,7 @@ extension Configuration {
     config.indentSwitchCaseLabels = false
     config.spacesAroundRangeFormationOperators = false
     config.noAssignmentInExpressions = NoAssignmentInExpressionsConfiguration()
+    config.multilineCollectionTrailingCommas = true
     return config
   }
 }

--- a/Tests/SwiftFormatTests/PrettyPrint/CommaTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/CommaTests.swift
@@ -1,10 +1,10 @@
 import SwiftFormat
 
 final class CommaTests: PrettyPrintTestCase {
-  func testCommasAbsentEnabled() {
+  func testArrayCommasAbsentEnabled() {
     let input =
       """
-      let MyList = [
+      let MyCollection = [
         1,
         2,
         3
@@ -14,7 +14,7 @@ final class CommaTests: PrettyPrintTestCase {
     
     let expected =
       """
-      let MyList = [
+      let MyCollection = [
         1,
         2,
         3,
@@ -27,10 +27,10 @@ final class CommaTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
   }
   
-  func testCommasAbsentDisabled() {
+  func testArrayCommasAbsentDisabled() {
     let input =
       """
-      let MyList = [
+      let MyCollection = [
         1,
         2,
         3
@@ -40,7 +40,7 @@ final class CommaTests: PrettyPrintTestCase {
     
     let expected =
       """
-      let MyList = [
+      let MyCollection = [
         1,
         2,
         3
@@ -53,10 +53,10 @@ final class CommaTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
   }
   
-  func testCommasPresentEnabled() {
+  func testArrayCommasPresentEnabled() {
     let input =
       """
-      let MyList = [
+      let MyCollection = [
         1,
         2,
         3,
@@ -66,7 +66,7 @@ final class CommaTests: PrettyPrintTestCase {
     
     let expected =
       """
-      let MyList = [
+      let MyCollection = [
         1,
         2,
         3,
@@ -79,10 +79,10 @@ final class CommaTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
   }
   
-  func testCommasPresentDisabled() {
+  func testArrayCommasPresentDisabled() {
     let input =
       """
-      let MyList = [
+      let MyCollection = [
         1,
         2,
         3,
@@ -92,7 +92,7 @@ final class CommaTests: PrettyPrintTestCase {
     
     let expected =
       """
-      let MyList = [
+      let MyCollection = [
         1,
         2,
         3
@@ -105,17 +105,17 @@ final class CommaTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
   }
   
-  func testCommasPresentSingleLineDisabled() {
+  func testArraySingleLineCommasPresentDisabled() {
     let input =
       """
-      let MyList = [1, 2, 3,]
+      let MyCollection = [1, 2, 3,]
       
       """
     
     // no effect expected
     let expected =
       """
-      let MyList = [1, 2, 3]
+      let MyCollection = [1, 2, 3]
       
       """
     
@@ -124,17 +124,161 @@ final class CommaTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: configuration)
   }
   
-  func testCommasPresentSingleLineEnabled() {
+  func testArraySingleLineCommasPresentEnabled() {
     let input =
       """
-      let MyList = [1, 2, 3,]
+      let MyCollection = [1, 2, 3,]
       
       """
     
     // no effect expected
     let expected =
       """
-      let MyList = [1, 2, 3]
+      let MyCollection = [1, 2, 3]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multilineCollectionTrailingCommas = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: configuration)
+  }
+  
+  func testDictionaryCommasAbsentEnabled() {
+    let input =
+      """
+      let MyCollection = [
+        "a": 1,
+        "b": 2,
+        "c": 3
+      ]
+      
+      """
+    
+    let expected =
+      """
+      let MyCollection = [
+        "a": 1,
+        "b": 2,
+        "c": 3,
+      ]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multilineCollectionTrailingCommas = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
+  }
+  
+  func testDictionaryCommasAbsentDisabled() {
+    let input =
+      """
+      let MyCollection = [
+        "a": 1,
+        "b": 2,
+        "c": 3
+      ]
+      
+      """
+    
+    let expected =
+      """
+      let MyCollection = [
+        "a": 1,
+        "b": 2,
+        "c": 3
+      ]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multilineCollectionTrailingCommas = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
+  }
+  
+  func testDictionaryCommasPresentEnabled() {
+    let input =
+      """
+      let MyCollection = [
+        "a": 1,
+        "b": 2,
+        "c": 3,
+      ]
+      
+      """
+    
+    let expected =
+      """
+      let MyCollection = [
+        "a": 1,
+        "b": 2,
+        "c": 3,
+      ]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multilineCollectionTrailingCommas = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
+  }
+  
+  func testDictionaryCommasPresentDisabled() {
+    let input =
+      """
+      let MyCollection = [
+        "a": 1,
+        "b": 2,
+        "c": 3,
+      ]
+      
+      """
+    
+    let expected =
+      """
+      let MyCollection = [
+        "a": 1,
+        "b": 2,
+        "c": 3
+      ]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multilineCollectionTrailingCommas = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
+  }
+  
+  func testDictionarySingleLineCommasPresentDisabled() {
+    let input =
+      """
+      let MyCollection = ["a": 1, "b": 2, "c": 3,]
+      
+      """
+    
+    let expected =
+      """
+      let MyCollection = [
+        "a": 1, "b": 2, "c": 3,
+      ]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multilineCollectionTrailingCommas = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: configuration)
+  }
+  
+  func testDictionarySingleLineCommasPresentEnabled() {
+    let input =
+      """
+      let MyCollection = ["a": 1, "b": 2, "c": 3,]
+      
+      """
+    
+    let expected =
+      """
+      let MyCollection = [
+        "a": 1, "b": 2, "c": 3
+      ]
       
       """
     

--- a/Tests/SwiftFormatTests/PrettyPrint/CommaTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/CommaTests.swift
@@ -1,0 +1,145 @@
+import SwiftFormat
+
+final class CommaTests: PrettyPrintTestCase {
+  func testCommasAbsentEnabled() {
+    let input =
+      """
+      let MyList = [
+        1,
+        2,
+        3
+      ]
+      
+      """
+    
+    let expected =
+      """
+      let MyList = [
+        1,
+        2,
+        3,
+      ]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multilineCollectionTrailingCommas = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
+  }
+  
+  func testCommasAbsentDisabled() {
+    let input =
+      """
+      let MyList = [
+        1,
+        2,
+        3
+      ]
+      
+      """
+    
+    let expected =
+      """
+      let MyList = [
+        1,
+        2,
+        3
+      ]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multilineCollectionTrailingCommas = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
+  }
+  
+  func testCommasPresentEnabled() {
+    let input =
+      """
+      let MyList = [
+        1,
+        2,
+        3,
+      ]
+      
+      """
+    
+    let expected =
+      """
+      let MyList = [
+        1,
+        2,
+        3,
+      ]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multilineCollectionTrailingCommas = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
+  }
+  
+  func testCommasPresentDisabled() {
+    let input =
+      """
+      let MyList = [
+        1,
+        2,
+        3,
+      ]
+      
+      """
+    
+    let expected =
+      """
+      let MyList = [
+        1,
+        2,
+        3
+      ]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multilineCollectionTrailingCommas = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
+  }
+  
+  func testCommasPresentSingleLineDisabled() {
+    let input =
+      """
+      let MyList = [1, 2, 3,]
+      
+      """
+    
+    // no effect expected
+    let expected =
+      """
+      let MyList = [1, 2, 3]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multilineCollectionTrailingCommas = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: configuration)
+  }
+  
+  func testCommasPresentSingleLineEnabled() {
+    let input =
+      """
+      let MyList = [1, 2, 3,]
+      
+      """
+    
+    // no effect expected
+    let expected =
+      """
+      let MyList = [1, 2, 3]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multilineCollectionTrailingCommas = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: configuration)
+  }
+}

--- a/Tests/SwiftFormatTests/PrettyPrint/CommaTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/CommaTests.swift
@@ -23,7 +23,7 @@ final class CommaTests: PrettyPrintTestCase {
       """
     
     var configuration = Configuration.forTesting
-    configuration.multilineCollectionTrailingCommas = true
+    configuration.multiElementCollectionTrailingCommas = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
   }
   
@@ -49,7 +49,7 @@ final class CommaTests: PrettyPrintTestCase {
       """
     
     var configuration = Configuration.forTesting
-    configuration.multilineCollectionTrailingCommas = false
+    configuration.multiElementCollectionTrailingCommas = false
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
   }
   
@@ -75,7 +75,7 @@ final class CommaTests: PrettyPrintTestCase {
       """
     
     var configuration = Configuration.forTesting
-    configuration.multilineCollectionTrailingCommas = true
+    configuration.multiElementCollectionTrailingCommas = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
   }
   
@@ -101,7 +101,7 @@ final class CommaTests: PrettyPrintTestCase {
       """
     
     var configuration = Configuration.forTesting
-    configuration.multilineCollectionTrailingCommas = false
+    configuration.multiElementCollectionTrailingCommas = false
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
   }
   
@@ -120,7 +120,7 @@ final class CommaTests: PrettyPrintTestCase {
       """
     
     var configuration = Configuration.forTesting
-    configuration.multilineCollectionTrailingCommas = true
+    configuration.multiElementCollectionTrailingCommas = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: configuration)
   }
   
@@ -139,7 +139,7 @@ final class CommaTests: PrettyPrintTestCase {
       """
     
     var configuration = Configuration.forTesting
-    configuration.multilineCollectionTrailingCommas = false
+    configuration.multiElementCollectionTrailingCommas = false
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: configuration)
   }
   
@@ -165,7 +165,7 @@ final class CommaTests: PrettyPrintTestCase {
       """
     
     var configuration = Configuration.forTesting
-    configuration.multilineCollectionTrailingCommas = true
+    configuration.multiElementCollectionTrailingCommas = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
   }
   
@@ -191,7 +191,7 @@ final class CommaTests: PrettyPrintTestCase {
       """
     
     var configuration = Configuration.forTesting
-    configuration.multilineCollectionTrailingCommas = false
+    configuration.multiElementCollectionTrailingCommas = false
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
   }
   
@@ -217,7 +217,7 @@ final class CommaTests: PrettyPrintTestCase {
       """
     
     var configuration = Configuration.forTesting
-    configuration.multilineCollectionTrailingCommas = true
+    configuration.multiElementCollectionTrailingCommas = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
   }
   
@@ -243,7 +243,7 @@ final class CommaTests: PrettyPrintTestCase {
       """
     
     var configuration = Configuration.forTesting
-    configuration.multilineCollectionTrailingCommas = false
+    configuration.multiElementCollectionTrailingCommas = false
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
   }
   
@@ -263,7 +263,7 @@ final class CommaTests: PrettyPrintTestCase {
       """
     
     var configuration = Configuration.forTesting
-    configuration.multilineCollectionTrailingCommas = true
+    configuration.multiElementCollectionTrailingCommas = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: configuration)
   }
   
@@ -283,7 +283,7 @@ final class CommaTests: PrettyPrintTestCase {
       """
     
     var configuration = Configuration.forTesting
-    configuration.multilineCollectionTrailingCommas = false
+    configuration.multiElementCollectionTrailingCommas = false
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: configuration)
   }
 }


### PR DESCRIPTION
Extends the configuration options to allow disabling the addtion of trailing commas on multi-line collections.