### PR TITLE
Allow JSON configuration text to be passed directly on the command line.

### DIFF
--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -186,9 +186,14 @@ public struct Configuration: Codable, Equatable {
   /// ```
   public var multiElementCollectionTrailingCommas: Bool
 
-  /// Constructs a Configuration by loading it from a configuration file.
+  /// Creates a new `Configuration` by loading it from a configuration file.
   public init(contentsOf url: URL) throws {
     let data = try Data(contentsOf: url)
+    try self.init(data: data)
+  }
+
+  /// Creates a new `Configuration` by decoding it from the UTF-8 representation in the given data.
+  public init(data: Data) throws {
     self = try JSONDecoder().decode(Configuration.self, from: data)
   }
 

--- a/Sources/swift-format/Subcommands/LintFormatOptions.swift
+++ b/Sources/swift-format/Subcommands/LintFormatOptions.swift
@@ -20,8 +20,11 @@ struct LintFormatOptions: ParsableArguments {
   /// If not specified, the default configuration will be used.
   @Option(
     name: .customLong("configuration"),
-    help: "The path to a JSON file containing the configuration of the linter/formatter.")
-  var configurationPath: String?
+    help: """
+      The path to a JSON file containing the configuration of the linter/formatter or a JSON \
+      string containing the configuration directly.
+      """)
+  var configuration: String?
 
   /// The filename for the source code when reading from standard input, to include in diagnostic
   /// messages.


### PR DESCRIPTION
If the `--configuration` flag is provided and it's not a valid file path, then swift-format will now attempt to parse the value directly as the JSON configuration. For example, `--configuration '{"lineLength": 20}'`. This is primarily useful for quick testing.