### PR TITLE
Fix broken links in docs

### DIFF
--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -110,7 +110,7 @@ An example `.swift-format` configuration file is shown below.
 
 In the `rules` block of `.swift-format`, you can specify which rules to apply
 when linting and formatting your project. Read the
-[rules documentation](Documentation/RuleDocumentation.md) to see the list of all
+[rules documentation](RuleDocumentation.md) to see the list of all
 supported linter and formatter rules, and their overview.
 
 You can also run this command to see the list of rules in the default

--- a/Documentation/RuleDocumentation.md
+++ b/Documentation/RuleDocumentation.md
@@ -5,7 +5,7 @@
 
 Use the rules below in the `rules` block of your `.swift-format`
 configuration file, as described in
-[Configuration](Documentation/Configuration.md). All of these rules can be
+[Configuration](Configuration.md). All of these rules can be
 applied in the linter, but only some of them can format your source code
 automatically.
 


### PR DESCRIPTION
Fixes this

<img width="943" alt="image" src="https://github.com/apple/swift-format/assets/33631005/1e0a1e37-f998-4db5-a240-d0231dd842af">
