### PR TITLE
Make all `Finding.Message` extensions file-private.

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
@@ -790,12 +790,12 @@ public class PrettyPrinter {
 }
 
 extension Finding.Message {
-  public static let moveEndOfLineComment: Finding.Message =
+  fileprivate static let moveEndOfLineComment: Finding.Message =
     "move end-of-line comment that exceeds the line length"
 
-  public static let addTrailingComma: Finding.Message =
+  fileprivate static let addTrailingComma: Finding.Message =
     "add trailing comma to the last element in multiline collection literal"
 
-  public static let removeTrailingComma: Finding.Message =
+  fileprivate static let removeTrailingComma: Finding.Message =
     "remove trailing comma from the last element in single line collection literal"
 }

--- a/Sources/SwiftFormat/PrettyPrint/WhitespaceLinter.swift
+++ b/Sources/SwiftFormat/PrettyPrint/WhitespaceLinter.swift
@@ -432,9 +432,9 @@ extension WhitespaceIndentation {
 }
 
 extension Finding.Message {
-  public static let trailingWhitespaceError: Finding.Message = "remove trailing whitespace"
+  fileprivate static let trailingWhitespaceError: Finding.Message = "remove trailing whitespace"
 
-  public static func indentationError(
+  fileprivate static func indentationError(
     expected expectedIndentation: WhitespaceIndentation,
     actual actualIndentation: WhitespaceIndentation
   ) -> Finding.Message {
@@ -470,20 +470,20 @@ extension Finding.Message {
     }
   }
 
-  public static func spacingError(_ spaces: Int) -> Finding.Message {
+  fileprivate static func spacingError(_ spaces: Int) -> Finding.Message {
     let verb = spaces > 0 ? "add" : "remove"
     let noun = abs(spaces) == 1 ? "space" : "spaces"
     return "\(verb) \(abs(spaces)) \(noun)"
   }
 
-  public static let spacingCharError: Finding.Message = "use spaces for spacing"
+  fileprivate static let spacingCharError: Finding.Message = "use spaces for spacing"
 
-  public static let removeLineError: Finding.Message = "remove line break"
+  fileprivate static let removeLineError: Finding.Message = "remove line break"
 
-  public static func addLinesError(_ lines: Int) -> Finding.Message {
+  fileprivate static func addLinesError(_ lines: Int) -> Finding.Message {
     let noun = lines == 1 ? "break" : "breaks"
     return "add \(lines) line \(noun)"
   }
 
-  public static let lineLengthError: Finding.Message = "line is too long"
+  fileprivate static let lineLengthError: Finding.Message = "line is too long"
 }

--- a/Sources/SwiftFormat/Rules/AllPublicDeclarationsHaveDocumentation.swift
+++ b/Sources/SwiftFormat/Rules/AllPublicDeclarationsHaveDocumentation.swift
@@ -87,8 +87,7 @@ public final class AllPublicDeclarationsHaveDocumentation: SyntaxLintRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static func declRequiresComment(_ name: String) -> Finding.Message {
+  fileprivate static func declRequiresComment(_ name: String) -> Finding.Message {
     "add a documentation comment for '\(name)'"
   }
 }

--- a/Sources/SwiftFormat/Rules/AlwaysUseLiteralForEmptyCollectionInit.swift
+++ b/Sources/SwiftFormat/Rules/AlwaysUseLiteralForEmptyCollectionInit.swift
@@ -201,7 +201,9 @@ public final class AlwaysUseLiteralForEmptyCollectionInit : SyntaxFormatRule {
 }
 
 extension Finding.Message {
-  public static func refactorIntoEmptyLiteral(replace: String, with: String) -> Finding.Message {
+  fileprivate static func refactorIntoEmptyLiteral(replace: String, with: String)
+    -> Finding.Message
+  {
     "replace '\(replace)' with '\(with)'"
   }
 }

--- a/Sources/SwiftFormat/Rules/AlwaysUseLowerCamelCase.swift
+++ b/Sources/SwiftFormat/Rules/AlwaysUseLowerCamelCase.swift
@@ -214,8 +214,7 @@ extension ReturnClauseSyntax {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static func nameMustBeLowerCamelCase(
+  fileprivate static func nameMustBeLowerCamelCase(
     _ name: String, description: String
   ) -> Finding.Message {
     "rename the \(description) '\(name)' using lowerCamelCase"

--- a/Sources/SwiftFormat/Rules/AmbiguousTrailingClosureOverload.swift
+++ b/Sources/SwiftFormat/Rules/AmbiguousTrailingClosureOverload.swift
@@ -73,13 +73,11 @@ public final class AmbiguousTrailingClosureOverload: SyntaxLintRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static func ambiguousTrailingClosureOverload(_ decl: String) -> Finding.Message {
+  fileprivate static func ambiguousTrailingClosureOverload(_ decl: String) -> Finding.Message {
     "rename '\(decl)' so it is no longer ambiguous when called with a trailing closure"
   }
 
-  @_spi(Rules)
-  public static func otherAmbiguousOverloadHere(_ decl: String) -> Finding.Message {
+  fileprivate static func otherAmbiguousOverloadHere(_ decl: String) -> Finding.Message {
     "ambiguous overload '\(decl)' is here"
   }
 }

--- a/Sources/SwiftFormat/Rules/BeginDocumentationCommentWithOneLineSummary.swift
+++ b/Sources/SwiftFormat/Rules/BeginDocumentationCommentWithOneLineSummary.swift
@@ -195,15 +195,13 @@ public final class BeginDocumentationCommentWithOneLineSummary: SyntaxLintRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static func terminateSentenceWithPeriod<Sentence: StringProtocol>(_ text: Sentence)
+  fileprivate static func terminateSentenceWithPeriod<Sentence: StringProtocol>(_ text: Sentence)
     -> Finding.Message
   {
     "terminate this sentence with a period: \"\(text)\""
   }
 
-  @_spi(Rules)
-  public static func addBlankLineAfterFirstSentence<Sentence: StringProtocol>(_ text: Sentence)
+  fileprivate static func addBlankLineAfterFirstSentence<Sentence: StringProtocol>(_ text: Sentence)
     -> Finding.Message
   {
     "add a blank comment line after this sentence: \"\(text)\""

--- a/Sources/SwiftFormat/Rules/DoNotUseSemicolons.swift
+++ b/Sources/SwiftFormat/Rules/DoNotUseSemicolons.swift
@@ -111,10 +111,8 @@ public final class DoNotUseSemicolons: SyntaxFormatRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static let removeSemicolon: Finding.Message = "remove ';'"
+  fileprivate static let removeSemicolon: Finding.Message = "remove ';'"
 
-  @_spi(Rules)
-  public static let removeSemicolonAndMove: Finding.Message =
+  fileprivate static let removeSemicolonAndMove: Finding.Message =
     "remove ';' and move the next statement to a new line"
 }

--- a/Sources/SwiftFormat/Rules/DontRepeatTypeInStaticProperties.swift
+++ b/Sources/SwiftFormat/Rules/DontRepeatTypeInStaticProperties.swift
@@ -106,8 +106,7 @@ public final class DontRepeatTypeInStaticProperties: SyntaxLintRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static func removeTypeFromName(name: String, type: Substring) -> Finding.Message {
+  fileprivate static func removeTypeFromName(name: String, type: Substring) -> Finding.Message {
     "remove the suffix '\(type)' from the name of the variable '\(name)'"
   }
 }

--- a/Sources/SwiftFormat/Rules/FileScopedDeclarationPrivacy.swift
+++ b/Sources/SwiftFormat/Rules/FileScopedDeclarationPrivacy.swift
@@ -160,11 +160,9 @@ public final class FileScopedDeclarationPrivacy: SyntaxFormatRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static let replacePrivateWithFileprivate: Finding.Message =
+  fileprivate static let replacePrivateWithFileprivate: Finding.Message =
     "replace 'private' with 'fileprivate' on file-scoped declarations"
 
-  @_spi(Rules)
-  public static let replaceFileprivateWithPrivate: Finding.Message =
+  fileprivate static let replaceFileprivateWithPrivate: Finding.Message =
     "replace 'fileprivate' with 'private' on file-scoped declarations"
 }

--- a/Sources/SwiftFormat/Rules/FullyIndirectEnum.swift
+++ b/Sources/SwiftFormat/Rules/FullyIndirectEnum.swift
@@ -123,10 +123,9 @@ public final class FullyIndirectEnum: SyntaxFormatRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static func moveIndirectKeywordToEnumDecl(name: String) -> Finding.Message {
+  fileprivate static func moveIndirectKeywordToEnumDecl(name: String) -> Finding.Message {
     "declare enum '\(name)' itself as indirect when all cases are indirect"
   }
 
-  public static let removeIndirect: Finding.Message = "remove 'indirect' here"
+  fileprivate static let removeIndirect: Finding.Message = "remove 'indirect' here"
 }

--- a/Sources/SwiftFormat/Rules/GroupNumericLiterals.swift
+++ b/Sources/SwiftFormat/Rules/GroupNumericLiterals.swift
@@ -80,8 +80,7 @@ public final class GroupNumericLiterals: SyntaxFormatRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static func groupNumericLiteral(every stride: Int, base: String) -> Finding.Message {
+  fileprivate static func groupNumericLiteral(every stride: Int, base: String) -> Finding.Message {
     return "group every \(stride) digits in this \(base) literal using a '_' separator"
   }
 }

--- a/Sources/SwiftFormat/Rules/IdentifiersMustBeASCII.swift
+++ b/Sources/SwiftFormat/Rules/IdentifiersMustBeASCII.swift
@@ -31,8 +31,7 @@ public final class IdentifiersMustBeASCII: SyntaxLintRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static func nonASCIICharsNotAllowed(
+  fileprivate static func nonASCIICharsNotAllowed(
     _ invalidCharacters: [String], _ identifierName: String
   ) -> Finding.Message {
     """

--- a/Sources/SwiftFormat/Rules/NeverForceUnwrap.swift
+++ b/Sources/SwiftFormat/Rules/NeverForceUnwrap.swift
@@ -50,13 +50,11 @@ public final class NeverForceUnwrap: SyntaxLintRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static func doNotForceUnwrap(name: String) -> Finding.Message {
+  fileprivate static func doNotForceUnwrap(name: String) -> Finding.Message {
     "do not force unwrap '\(name)'"
   }
 
-  @_spi(Rules)
-  public static func doNotForceCast(name: String) -> Finding.Message {
+  fileprivate static func doNotForceCast(name: String) -> Finding.Message {
     "do not force cast to '\(name)'"
   }
 }

--- a/Sources/SwiftFormat/Rules/NeverUseForceTry.swift
+++ b/Sources/SwiftFormat/Rules/NeverUseForceTry.swift
@@ -44,6 +44,5 @@ public final class NeverUseForceTry: SyntaxLintRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static let doNotForceTry: Finding.Message = "do not use force try"
+  fileprivate static let doNotForceTry: Finding.Message = "do not use force try"
 }

--- a/Sources/SwiftFormat/Rules/NeverUseImplicitlyUnwrappedOptionals.swift
+++ b/Sources/SwiftFormat/Rules/NeverUseImplicitlyUnwrappedOptionals.swift
@@ -61,8 +61,7 @@ public final class NeverUseImplicitlyUnwrappedOptionals: SyntaxLintRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static func doNotUseImplicitUnwrapping(identifier: String) -> Finding.Message {
+  fileprivate static func doNotUseImplicitUnwrapping(identifier: String) -> Finding.Message {
     "use '\(identifier)' or '\(identifier)?' instead of '\(identifier)!'"
   }
 }

--- a/Sources/SwiftFormat/Rules/NoAccessLevelOnExtensionDeclaration.swift
+++ b/Sources/SwiftFormat/Rules/NoAccessLevelOnExtensionDeclaration.swift
@@ -105,22 +105,18 @@ public final class NoAccessLevelOnExtensionDeclaration: SyntaxFormatRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static let removeRedundantAccessKeyword: Finding.Message =
+  fileprivate static let removeRedundantAccessKeyword: Finding.Message =
     "remove this redundant 'internal' access modifier from this extension"
 
-  @_spi(Rules)
-  public static func moveAccessKeyword(keyword: String) -> Finding.Message {
+  fileprivate static func moveAccessKeyword(keyword: String) -> Finding.Message {
     "move this '\(keyword)' access modifier to precede each member inside this extension"
   }
 
-  @_spi(Rules)
-  public static func moveAccessKeywordAndMakeFileprivate(keyword: String) -> Finding.Message {
+  fileprivate static func moveAccessKeywordAndMakeFileprivate(keyword: String) -> Finding.Message {
     "remove this '\(keyword)' access modifier and declare each member inside this extension as 'fileprivate'"
   }
 
-  @_spi(Rules)
-  public static func addModifierToExtensionMember(keyword: String) -> Finding.Message {
+  fileprivate static func addModifierToExtensionMember(keyword: String) -> Finding.Message {
     "add '\(keyword)' access modifier to this declaration"
   }
 }

--- a/Sources/SwiftFormat/Rules/NoAssignmentInExpressions.swift
+++ b/Sources/SwiftFormat/Rules/NoAssignmentInExpressions.swift
@@ -157,7 +157,6 @@ public final class NoAssignmentInExpressions: SyntaxFormatRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static let moveAssignmentToOwnStatement: Finding.Message =
+  fileprivate static let moveAssignmentToOwnStatement: Finding.Message =
     "move this assignment expression into its own statement"
 }

--- a/Sources/SwiftFormat/Rules/NoBlockComments.swift
+++ b/Sources/SwiftFormat/Rules/NoBlockComments.swift
@@ -29,7 +29,6 @@ public final class NoBlockComments: SyntaxLintRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static let avoidBlockComment: Finding.Message =
+  fileprivate static let avoidBlockComment: Finding.Message =
     "replace this block comment with line comments"
 }

--- a/Sources/SwiftFormat/Rules/NoCasesWithOnlyFallthrough.swift
+++ b/Sources/SwiftFormat/Rules/NoCasesWithOnlyFallthrough.swift
@@ -224,8 +224,7 @@ extension TriviaPiece {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static var collapseCase: Finding.Message {
+  fileprivate static var collapseCase: Finding.Message {
     "combine this fallthrough-only 'case' and the following 'case' into a single 'case'"
   }
 }

--- a/Sources/SwiftFormat/Rules/NoEmptyTrailingClosureParentheses.swift
+++ b/Sources/SwiftFormat/Rules/NoEmptyTrailingClosureParentheses.swift
@@ -54,8 +54,7 @@ public final class NoEmptyTrailingClosureParentheses: SyntaxFormatRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static func removeEmptyTrailingParentheses(name: String) -> Finding.Message {
+  fileprivate static func removeEmptyTrailingParentheses(name: String) -> Finding.Message {
     "remove the empty parentheses following '\(name)'"
   }
 }

--- a/Sources/SwiftFormat/Rules/NoLabelsInCasePatterns.swift
+++ b/Sources/SwiftFormat/Rules/NoLabelsInCasePatterns.swift
@@ -75,8 +75,7 @@ public final class NoLabelsInCasePatterns: SyntaxFormatRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static func removeRedundantLabel(name: String) -> Finding.Message {
+  fileprivate static func removeRedundantLabel(name: String) -> Finding.Message {
     "remove the label '\(name)' from this 'case' pattern"
   }
 }

--- a/Sources/SwiftFormat/Rules/NoLeadingUnderscores.swift
+++ b/Sources/SwiftFormat/Rules/NoLeadingUnderscores.swift
@@ -125,8 +125,7 @@ public final class NoLeadingUnderscores: SyntaxLintRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static func doNotStartWithUnderscore(identifier: String) -> Finding.Message {
+  fileprivate static func doNotStartWithUnderscore(identifier: String) -> Finding.Message {
     "remove the leading '_' from the name '\(identifier)'"
   }
 }

--- a/Sources/SwiftFormat/Rules/NoParensAroundConditions.swift
+++ b/Sources/SwiftFormat/Rules/NoParensAroundConditions.swift
@@ -121,7 +121,6 @@ public final class NoParensAroundConditions: SyntaxFormatRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static let removeParensAroundExpression: Finding.Message =
+  fileprivate static let removeParensAroundExpression: Finding.Message =
     "remove the parentheses around this expression"
 }

--- a/Sources/SwiftFormat/Rules/NoVoidReturnOnFunctionSignature.swift
+++ b/Sources/SwiftFormat/Rules/NoVoidReturnOnFunctionSignature.swift
@@ -52,8 +52,7 @@ public final class NoVoidReturnOnFunctionSignature: SyntaxFormatRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static func removeRedundantReturn(_ type: String) -> Finding.Message {
+  fileprivate static func removeRedundantReturn(_ type: String) -> Finding.Message {
     "remove the explicit return type '\(type)' from this function"
   }
 }

--- a/Sources/SwiftFormat/Rules/OmitExplicitReturns.swift
+++ b/Sources/SwiftFormat/Rules/OmitExplicitReturns.swift
@@ -144,6 +144,6 @@ public final class OmitExplicitReturns: SyntaxFormatRule {
 }
 
 extension Finding.Message {
-  public static let omitReturnStatement: Finding.Message =
+  fileprivate static let omitReturnStatement: Finding.Message =
     "'return' can be omitted because body consists of a single expression"
 }

--- a/Sources/SwiftFormat/Rules/OneCasePerLine.swift
+++ b/Sources/SwiftFormat/Rules/OneCasePerLine.swift
@@ -137,8 +137,7 @@ public final class OneCasePerLine: SyntaxFormatRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static func moveAssociatedOrRawValueCase(name: String) -> Finding.Message {
+  fileprivate static func moveAssociatedOrRawValueCase(name: String) -> Finding.Message {
     "move '\(name)' to its own 'case' declaration"
   }
 }

--- a/Sources/SwiftFormat/Rules/OneVariableDeclarationPerLine.swift
+++ b/Sources/SwiftFormat/Rules/OneVariableDeclarationPerLine.swift
@@ -74,8 +74,7 @@ public final class OneVariableDeclarationPerLine: SyntaxFormatRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static func onlyOneVariableDeclaration(specifier: String) -> Finding.Message {
+  fileprivate static func onlyOneVariableDeclaration(specifier: String) -> Finding.Message {
     "split this variable declaration to introduce only one variable per '\(specifier)'"
   }
 }

--- a/Sources/SwiftFormat/Rules/OnlyOneTrailingClosureArgument.swift
+++ b/Sources/SwiftFormat/Rules/OnlyOneTrailingClosureArgument.swift
@@ -30,7 +30,6 @@ public final class OnlyOneTrailingClosureArgument: SyntaxLintRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static let removeTrailingClosure: Finding.Message =
+  fileprivate static let removeTrailingClosure: Finding.Message =
     "revise this function call to avoid using both closure arguments and a trailing closure"
 }

--- a/Sources/SwiftFormat/Rules/OrderedImports.swift
+++ b/Sources/SwiftFormat/Rules/OrderedImports.swift
@@ -569,17 +569,13 @@ extension Line: CustomDebugStringConvertible {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static let placeAtTopOfFile: Finding.Message = "place imports at the top of the file"
+  fileprivate static let placeAtTopOfFile: Finding.Message = "place imports at the top of the file"
 
-  @_spi(Rules)
-  public static func groupImports(before: LineType, after: LineType) -> Finding.Message {
+  fileprivate static func groupImports(before: LineType, after: LineType) -> Finding.Message {
     "place \(before) imports before \(after) imports"
   }
 
-  @_spi(Rules)
-  public static let removeDuplicateImport: Finding.Message = "remove this duplicate import"
+  fileprivate static let removeDuplicateImport: Finding.Message = "remove this duplicate import"
 
-  @_spi(Rules)
-  public static let sortImports: Finding.Message = "sort import statements lexicographically"
+  fileprivate static let sortImports: Finding.Message = "sort import statements lexicographically"
 }

--- a/Sources/SwiftFormat/Rules/ReplaceForEachWithForLoop.swift
+++ b/Sources/SwiftFormat/Rules/ReplaceForEachWithForLoop.swift
@@ -47,7 +47,7 @@ public final class ReplaceForEachWithForLoop : SyntaxLintRule {
 }
 
 extension Finding.Message {
-  public static func replaceForEachWithLoop() -> Finding.Message {
+  fileprivate static func replaceForEachWithLoop() -> Finding.Message {
     "replace use of '.forEach { ... }' with for-in loop"
   }
 }

--- a/Sources/SwiftFormat/Rules/ReturnVoidInsteadOfEmptyTuple.swift
+++ b/Sources/SwiftFormat/Rules/ReturnVoidInsteadOfEmptyTuple.swift
@@ -119,6 +119,5 @@ public final class ReturnVoidInsteadOfEmptyTuple: SyntaxFormatRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static let returnVoid: Finding.Message = "replace '()' with 'Void'"
+  fileprivate static let returnVoid: Finding.Message = "replace '()' with 'Void'"
 }

--- a/Sources/SwiftFormat/Rules/TypeNamesShouldBeCapitalized.swift
+++ b/Sources/SwiftFormat/Rules/TypeNamesShouldBeCapitalized.swift
@@ -66,8 +66,7 @@ public final class TypeNamesShouldBeCapitalized : SyntaxLintRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static func capitalizeTypeName(name: String, kind: String) -> Finding.Message {
+  fileprivate static func capitalizeTypeName(name: String, kind: String) -> Finding.Message {
     var capitalized = name
     let leadingUnderscores = capitalized.prefix { $0 == "_" }
     let charAt = leadingUnderscores.endIndex

--- a/Sources/SwiftFormat/Rules/UseEarlyExits.swift
+++ b/Sources/SwiftFormat/Rules/UseEarlyExits.swift
@@ -107,7 +107,6 @@ public final class UseEarlyExits: SyntaxFormatRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static let useGuardStatement: Finding.Message =
+  fileprivate static let useGuardStatement: Finding.Message =
     "replace this 'if/else' block with a 'guard' statement containing the early exit"
 }

--- a/Sources/SwiftFormat/Rules/UseExplicitNilCheckInConditions.swift
+++ b/Sources/SwiftFormat/Rules/UseExplicitNilCheckInConditions.swift
@@ -61,7 +61,6 @@ public final class UseExplicitNilCheckInConditions: SyntaxFormatRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static let useExplicitNilComparison: Finding.Message =
+  fileprivate static let useExplicitNilComparison: Finding.Message =
     "compare this value using `!= nil` instead of binding and discarding it"
 }

--- a/Sources/SwiftFormat/Rules/UseLetInEveryBoundCaseVariable.swift
+++ b/Sources/SwiftFormat/Rules/UseLetInEveryBoundCaseVariable.swift
@@ -66,7 +66,6 @@ public final class UseLetInEveryBoundCaseVariable: SyntaxLintRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static let useLetInBoundCaseVariables: Finding.Message =
+  fileprivate static let useLetInBoundCaseVariables: Finding.Message =
     "move this 'let' keyword inside the 'case' pattern, before each of the bound variables"
 }

--- a/Sources/SwiftFormat/Rules/UseShorthandTypeNames.swift
+++ b/Sources/SwiftFormat/Rules/UseShorthandTypeNames.swift
@@ -580,8 +580,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static func useTypeShorthand(type: String) -> Finding.Message {
+  fileprivate static func useTypeShorthand(type: String) -> Finding.Message {
     "use shorthand syntax for this '\(type)' type"
   }
 }

--- a/Sources/SwiftFormat/Rules/UseSingleLinePropertyGetter.swift
+++ b/Sources/SwiftFormat/Rules/UseSingleLinePropertyGetter.swift
@@ -41,7 +41,6 @@ public final class UseSingleLinePropertyGetter: SyntaxFormatRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static let removeExtraneousGetBlock: Finding.Message =
+  fileprivate static let removeExtraneousGetBlock: Finding.Message =
     "remove 'get {...}' around the accessor and move its body directly into the computed property"
 }

--- a/Sources/SwiftFormat/Rules/UseSynthesizedInitializer.swift
+++ b/Sources/SwiftFormat/Rules/UseSynthesizedInitializer.swift
@@ -185,8 +185,7 @@ public final class UseSynthesizedInitializer: SyntaxLintRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static let removeRedundantInitializer: Finding.Message =
+  fileprivate static let removeRedundantInitializer: Finding.Message =
     "remove this explicit initializer, which is identical to the compiler-synthesized initializer"
 }
 

--- a/Sources/SwiftFormat/Rules/UseTripleSlashForDocumentationComments.swift
+++ b/Sources/SwiftFormat/Rules/UseTripleSlashForDocumentationComments.swift
@@ -109,7 +109,6 @@ public final class UseTripleSlashForDocumentationComments: SyntaxFormatRule {
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static let avoidDocBlockComment: Finding.Message =
+  fileprivate static let avoidDocBlockComment: Finding.Message =
     "replace documentation block comments with documentation line comments"
 }

--- a/Sources/SwiftFormat/Rules/UseWhereClausesInForLoops.swift
+++ b/Sources/SwiftFormat/Rules/UseWhereClausesInForLoops.swift
@@ -122,11 +122,9 @@ fileprivate func updateWithWhereCondition(
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static let useWhereInsteadOfIf: Finding.Message =
+  fileprivate static let useWhereInsteadOfIf: Finding.Message =
     "replace this 'if' statement with a 'where' clause"
 
-  @_spi(Rules)
-  public static let useWhereInsteadOfGuard: Finding.Message =
+  fileprivate static let useWhereInsteadOfGuard: Finding.Message =
     "replace this 'guard' statement with a 'where' clause"
 }

--- a/Sources/SwiftFormat/Rules/ValidateDocumentationComments.swift
+++ b/Sources/SwiftFormat/Rules/ValidateDocumentationComments.swift
@@ -167,39 +167,32 @@ fileprivate func parametersAreEqual(
 }
 
 extension Finding.Message {
-  @_spi(Rules)
-  public static func documentReturnValue(funcName: String) -> Finding.Message {
+  fileprivate static func documentReturnValue(funcName: String) -> Finding.Message {
     "add a 'Returns:' section to document the return value of '\(funcName)'"
   }
 
-  @_spi(Rules)
-  public static func removeReturnComment(funcName: String) -> Finding.Message {
+  fileprivate static func removeReturnComment(funcName: String) -> Finding.Message {
     "remove the 'Returns:' section of '\(funcName)'; it does not return a value"
   }
 
-  @_spi(Rules)
-  public static func parametersDontMatch(funcName: String) -> Finding.Message {
+  fileprivate static func parametersDontMatch(funcName: String) -> Finding.Message {
     "change the parameters of the documentation of '\(funcName)' to match its parameters"
   }
 
-  @_spi(Rules)
-  public static let useSingularParameter: Finding.Message =
+  fileprivate static let useSingularParameter: Finding.Message =
     "replace the plural 'Parameters:' section with a singular inline 'Parameter' section"
 
-  @_spi(Rules)
-  public static let usePluralParameters: Finding.Message =
+  fileprivate static let usePluralParameters: Finding.Message =
     """
     replace the singular inline 'Parameter' section with a plural 'Parameters:' section \
     that has the parameters nested inside it
     """
 
-  @_spi(Rules)
-  public static func removeThrowsComment(funcName: String) -> Finding.Message {
+  fileprivate static func removeThrowsComment(funcName: String) -> Finding.Message {
     "remove the 'Throws:' sections of '\(funcName)'; it does not throw any errors"
   }
 
-  @_spi(Rules)
-  public static func documentErrorsThrown(funcName: String) -> Finding.Message {
+  fileprivate static func documentErrorsThrown(funcName: String) -> Finding.Message {
     "add a 'Throws:' section to document the errors thrown by '\(funcName)'"
   }
 }


### PR DESCRIPTION
Now that our tests verify the actual text of the diagnostics, we don't need these helpers to be visible outside their file. This gets rid of some noise when you're writing `diagnose` calls in rules because you'll only see the ones that are relevant.