### PR TITLE
Fix a bug where an unfolded `SequenceExpr` would make it to the pretty-printer.

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -2079,7 +2079,11 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: SequenceExprSyntax) -> SyntaxVisitorContinueKind {
-    preconditionFailure("SequenceExpr should have already been folded.")
+    preconditionFailure(
+      """
+      SequenceExpr should have already been folded; found at byte offsets \
+      \(node.position.utf8Offset)..<\(node.endPosition.utf8Offset)
+      """)
   }
 
   override func visit(_ node: AssignmentExprSyntax) -> SyntaxVisitorContinueKind {

--- a/Sources/SwiftFormat/Rules/UseExplicitNilCheckInConditions.swift
+++ b/Sources/SwiftFormat/Rules/UseExplicitNilCheckInConditions.swift
@@ -41,10 +41,18 @@ public final class UseExplicitNilCheckInConditions: SyntaxFormatRule {
       // trivia of the original node, since that token is being removed entirely.
       var value = initializerClause.value
       let trailingTrivia = value.trailingTrivia
-      value.trailingTrivia = []
+      value.trailingTrivia = [.spaces(1)]
 
-      return ConditionElementSyntax(
-        condition: .expression("\(node.leadingTrivia)\(value) != nil\(trailingTrivia)"))
+      var operatorExpr = BinaryOperatorExprSyntax(text: "!=")
+      operatorExpr.trailingTrivia = [.spaces(1)]
+
+      var inequalExpr = InfixOperatorExprSyntax(
+        leftOperand: value,
+        operator: operatorExpr,
+        rightOperand: NilLiteralExprSyntax())
+      inequalExpr.leadingTrivia = node.leadingTrivia
+      inequalExpr.trailingTrivia = trailingTrivia
+      return ConditionElementSyntax(condition: .expression(ExprSyntax(inequalExpr)))
     default:
       return node
     }

--- a/Sources/SwiftFormat/Rules/UseShorthandTypeNames.swift
+++ b/Sources/SwiftFormat/Rules/UseShorthandTypeNames.swift
@@ -478,7 +478,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
     effectSpecifiers: TypeEffectSpecifiersSyntax?,
     arrow: TokenSyntax,
     returnType: TypeSyntax
-  ) -> SequenceExprSyntax? {
+  ) -> InfixOperatorExprSyntax? {
     guard
       let parameterExprs = expressionRepresentation(of: parameters),
       let returnTypeExpr = expressionRepresentation(of: returnType)
@@ -493,11 +493,10 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
     let arrowExpr = ArrowExprSyntax(
       effectSpecifiers: effectSpecifiers,
       arrow: arrow)
-
-    return SequenceExprSyntax(
-      elements: ExprListSyntax([
-        ExprSyntax(tupleExpr), ExprSyntax(arrowExpr), returnTypeExpr,
-      ]))
+    return InfixOperatorExprSyntax(
+      leftOperand: tupleExpr,
+      operator: arrowExpr,
+      rightOperand: returnTypeExpr)
   }
 
   /// Returns the leading and trailing trivia from the front and end of the entire given node.

--- a/Tests/SwiftFormatTests/Rules/LintOrFormatRuleTestCase.swift
+++ b/Tests/SwiftFormatTests/Rules/LintOrFormatRuleTestCase.swift
@@ -100,5 +100,16 @@ class LintOrFormatRuleTestCase: DiagnosingTestCase {
       context: context,
       file: file,
       line: line)
+
+    // Verify that the pretty printer can consume the transformed tree (e.g., it does not contain
+    // any unfolded `SequenceExpr`s). We don't need to check the actual output here (we don't want
+    // the rule tests to be pretty-printer dependent), but this will catch invariants that aren't
+    // satisfied.
+    _ = PrettyPrinter(
+      context: context,
+      node: Syntax(actual),
+      printTokenStream: false,
+      whitespaceOnly: false
+    ).prettyPrint()
   }
 }


### PR DESCRIPTION
Since the `UseExplicitNilCheckInConditions` rule was using string interpolation based parsing, it returned a `SequenceExpr` instead of an `InfixOperatorExpr`. This unfolded expression then made it to the pretty printer, which it didn't expect (because the input is folded before being processed by the rules, but not after that).

In this case, creating the new expression directly as nodes is barely more work than using the string-based parsing and then folding it, so I just did that.

Tests didn't catch this because the sequence expr is valid Swift code when stringified (for comparison in unit tests). To address this, we now do a pretty-printer pass on all the format rule outputs. We don't assert based on the pretty-printed output (that's not really a "unit" test anymore), but it at least causes a test crash if the output wasn't suitable for pretty printing.

Doing so caught a similar latent bug in `UseShorthandTypeNames`.