### PR TITLE
Ignore symlinks and hidden (dot) files during `--recursive`.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -130,6 +130,10 @@ let package = Package(
         .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
       ]
     ),
+    .testTarget(
+      name: "swift-formatTests",
+      dependencies: ["swift-format"]
+    ),
   ]
 )
 

--- a/Sources/swift-format/Frontend/Frontend.swift
+++ b/Sources/swift-format/Frontend/Frontend.swift
@@ -130,12 +130,17 @@ class Frontend {
       "processURLs(_:) should only be called when 'urls' is non-empty.")
 
     if parallel {
-      let filesToProcess = FileIterator(urls: urls).compactMap(openAndPrepareFile)
+      let filesToProcess =
+        FileIterator(urls: urls, followSymlinks: lintFormatOptions.followSymlinks)
+        .compactMap(openAndPrepareFile)
       DispatchQueue.concurrentPerform(iterations: filesToProcess.count) { index in
         processFile(filesToProcess[index])
       }
     } else {
-      FileIterator(urls: urls).lazy.compactMap(openAndPrepareFile).forEach(processFile)
+      FileIterator(urls: urls, followSymlinks: lintFormatOptions.followSymlinks)
+        .lazy
+        .compactMap(openAndPrepareFile)
+        .forEach(processFile)
     }
   }
 

--- a/Sources/swift-format/Subcommands/LintFormatOptions.swift
+++ b/Sources/swift-format/Subcommands/LintFormatOptions.swift
@@ -71,6 +71,13 @@ struct LintFormatOptions: ParsableArguments {
       """)
   var colorDiagnostics: Bool?
 
+  /// Whether symlinks should be followed.
+  @Flag(help: """
+    Follow symbolic links passed on the command line, or found during directory traversal when \
+    using `-r/--recursive`.
+    """)
+  var followSymlinks: Bool = false
+
   /// The list of paths to Swift source files that should be formatted or linted.
   @Argument(help: "Zero or more input filenames.")
   var paths: [String] = []

--- a/Tests/swift-formatTests/Utilities/FileIteratorTests.swift
+++ b/Tests/swift-formatTests/Utilities/FileIteratorTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+
+@_spi(Testing) import swift_format
+
+final class FileIteratorTests: XCTestCase {
+  private var tmpdir: URL!
+
+  override func setUpWithError() throws {
+    tmpdir = try FileManager.default.url(
+      for: .itemReplacementDirectory,
+      in: .userDomainMask,
+      appropriateFor: FileManager.default.temporaryDirectory,
+      create: true)
+
+    // Create a simple file tree used by the tests below.
+    try touch("project/real1.swift")
+    try touch("project/real2.swift")
+    try touch("project/.hidden.swift")
+    try touch("project/.build/generated.swift")
+    try symlink("project/link.swift", to: "project/.hidden.swift")
+  }
+
+  override func tearDownWithError() throws {
+    try FileManager.default.removeItem(at: tmpdir)
+  }
+
+  func testNoFollowSymlinks() {
+    let seen = allFilesSeen(iteratingOver: [tmpdir], followSymlinks: false)
+    XCTAssertEqual(seen.count, 2)
+    XCTAssertTrue(seen.contains { $0.hasSuffix("project/real1.swift") })
+    XCTAssertTrue(seen.contains { $0.hasSuffix("project/real2.swift") })
+  }
+
+  func testFollowSymlinks() {
+    let seen = allFilesSeen(iteratingOver: [tmpdir], followSymlinks: true)
+    XCTAssertEqual(seen.count, 3)
+    XCTAssertTrue(seen.contains { $0.hasSuffix("project/real1.swift") })
+    XCTAssertTrue(seen.contains { $0.hasSuffix("project/real2.swift") })
+    // Hidden but found through the visible symlink project/link.swift
+    XCTAssertTrue(seen.contains { $0.hasSuffix("project/.hidden.swift") })
+  }
+
+  func testTraversesHiddenFilesIfExplicitlySpecified() {
+    let seen = allFilesSeen(
+      iteratingOver: [tmpURL("project/.build"), tmpURL("project/.hidden.swift")],
+      followSymlinks: false)
+    XCTAssertEqual(seen.count, 2)
+    XCTAssertTrue(seen.contains { $0.hasSuffix("project/.build/generated.swift") })
+    XCTAssertTrue(seen.contains { $0.hasSuffix("project/.hidden.swift") })
+  }
+
+  func testDoesNotFollowSymlinksIfFollowSymlinksIsFalseEvenIfExplicitlySpecified() {
+    // Symlinks are not traversed even if `followSymlinks` is false even if they are explicitly
+    // passed to the iterator. This is meant to avoid situations where a symlink could be hidden by
+    // shell expansion; for example, if the user writes `swift-format --no-follow-symlinks *`, if
+    // the current directory contains a symlink, they would probably *not* expect it to be followed.
+    let seen = allFilesSeen(iteratingOver: [tmpURL("project/link.swift")], followSymlinks: false)
+    XCTAssertTrue(seen.isEmpty)
+  }
+}
+
+extension FileIteratorTests {
+  /// Returns a URL to a file or directory in the test's temporary space.
+  private func tmpURL(_ path: String) -> URL {
+    return tmpdir.appendingPathComponent(path, isDirectory: false)
+  }
+
+  /// Create an empty file at the given path in the test's temporary space.
+  private func touch(_ path: String) throws {
+    let fileURL = tmpURL(path)
+    try FileManager.default.createDirectory(
+      at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+    FileManager.default.createFile(atPath: fileURL.path, contents: Data())
+  }
+
+  /// Create a symlink between files or directories in the test's temporary space.
+  private func symlink(_ source: String, to target: String) throws {
+    try FileManager.default.createSymbolicLink(
+      at: tmpURL(source), withDestinationURL: tmpURL(target))
+  }
+
+  /// Computes the list of all files seen by using `FileIterator` to iterate over the given URLs.
+  private func allFilesSeen(iteratingOver urls: [URL], followSymlinks: Bool) -> [String] {
+    let iterator = FileIterator(urls: urls, followSymlinks: followSymlinks)
+    var seen: [String] = []
+    for next in iterator {
+      seen.append(next.path)
+    }
+    return seen
+  }
+}


### PR DESCRIPTION
Note that hidden files will *always* be honored if they are specified explicitly among the paths on the command line. Symlinks encountered during recursive traversal *or* passed on the command line will only be followed if the flag `--follow-symlinks` is passed. This is meant to avoid symlinks being hidden by shell expansions; for example, running `swift-format *` where the current directory contains a symlink and following that symlink might be surprising to users.

This PR also adds a new test target for code in the `swift-format` binary in order to test `FileIterator` without factoring the binary's code out to a separate library target. We should use this in the future to expand coverage of other functionality like the frontends and commands.

Fixes #643.