### PR TITLE
Don't lose a trailing comma in `UseExplicitNilCheckInConditions`.

### DIFF
--- a/Sources/SwiftFormat/Rules/UseExplicitNilCheckInConditions.swift
+++ b/Sources/SwiftFormat/Rules/UseExplicitNilCheckInConditions.swift
@@ -52,7 +52,10 @@ public final class UseExplicitNilCheckInConditions: SyntaxFormatRule {
         rightOperand: NilLiteralExprSyntax())
       inequalExpr.leadingTrivia = node.leadingTrivia
       inequalExpr.trailingTrivia = trailingTrivia
-      return ConditionElementSyntax(condition: .expression(ExprSyntax(inequalExpr)))
+
+      var result = node
+      result.condition = .expression(ExprSyntax(inequalExpr))
+      return result
     default:
       return node
     }

--- a/Tests/SwiftFormatTests/Rules/UseExplicitNilCheckInConditionsTests.swift
+++ b/Tests/SwiftFormatTests/Rules/UseExplicitNilCheckInConditionsTests.swift
@@ -79,4 +79,20 @@ final class UseExplicitNilCheckInConditionsTests: LintOrFormatRuleTestCase {
       ]
     )
   }
+
+  func testDoNotDropTrailingCommaInConditionList() {
+    assertFormatting(
+      UseExplicitNilCheckInConditions.self,
+      input: """
+        if 1️⃣let _ = x, 2️⃣let _ = y {}
+        """,
+      expected: """
+        if x != nil, y != nil {}
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "compare this value using `!= nil` instead of binding and discarding it"),
+        FindingSpec("2️⃣", message: "compare this value using `!= nil` instead of binding and discarding it"),
+      ]
+    )
+  }
 }


### PR DESCRIPTION
This was happening because we were creating a new `ConditionListElement` and not considering the `trailingComma` property. It's safer to just mutate the original node, preserving anything that was previously there.