### PR TITLE
Various trivia-related fixes.

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -1516,7 +1516,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
   override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
     if shouldFormatterIgnore(file: node) {
-      appendFormatterIgnored(node: Syntax(node))
+      appendToken(.verbatim(Verbatim(text: "\(node)", indentingBehavior: .none)))
       return .skipChildren
     }
     after(node.shebang, tokens: .break(.same, newlines: .soft))

--- a/Sources/SwiftFormat/Rules/NoParensAroundConditions.swift
+++ b/Sources/SwiftFormat/Rules/NoParensAroundConditions.swift
@@ -28,7 +28,7 @@ import SwiftSyntax
 public final class NoParensAroundConditions: SyntaxFormatRule {
   public override func visit(_ node: IfExprSyntax) -> ExprSyntax {
     var result = node
-    result.ifKeyword.trailingTrivia = [.spaces(1)]
+    fixKeywordTrailingTrivia(&result.ifKeyword.trailingTrivia)
     result.conditions = visit(node.conditions)
     result.body = visit(node.body)
     if let elseBody = node.elseBody {
@@ -52,7 +52,7 @@ public final class NoParensAroundConditions: SyntaxFormatRule {
 
   public override func visit(_ node: GuardStmtSyntax) -> StmtSyntax {
     var result = node
-    result.guardKeyword.trailingTrivia = [.spaces(1)]
+    fixKeywordTrailingTrivia(&result.guardKeyword.trailingTrivia)
     result.conditions = visit(node.conditions)
     result.body = visit(node.body)
     return StmtSyntax(result)
@@ -64,7 +64,7 @@ public final class NoParensAroundConditions: SyntaxFormatRule {
     }
 
     var result = node
-    result.switchKeyword.trailingTrivia = [.spaces(1)]
+    fixKeywordTrailingTrivia(&result.switchKeyword.trailingTrivia)
     result.subject = newSubject
     result.cases = visit(node.cases)
     return ExprSyntax(result)
@@ -76,7 +76,7 @@ public final class NoParensAroundConditions: SyntaxFormatRule {
     }
 
     var result = node
-    result.whileKeyword.trailingTrivia = [.spaces(1)]
+    fixKeywordTrailingTrivia(&result.whileKeyword.trailingTrivia)
     result.condition = newCondition
     result.body = visit(node.body)
     return StmtSyntax(result)
@@ -84,10 +84,15 @@ public final class NoParensAroundConditions: SyntaxFormatRule {
 
   public override func visit(_ node: WhileStmtSyntax) -> StmtSyntax {
     var result = node
-    result.whileKeyword.trailingTrivia = [.spaces(1)]
+    fixKeywordTrailingTrivia(&result.whileKeyword.trailingTrivia)
     result.conditions = visit(node.conditions)
     result.body = visit(node.body)
     return StmtSyntax(result)
+  }
+
+  private func fixKeywordTrailingTrivia(_ trivia: inout Trivia) {
+    guard trivia.isEmpty else { return }
+    trivia = [.spaces(1)]
   }
 
   private func minimalSingleExpression(_ original: ExprSyntax) -> ExprSyntax? {

--- a/Tests/SwiftFormatTests/PrettyPrint/IgnoreNodeTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/IgnoreNodeTests.swift
@@ -318,36 +318,18 @@ final class IgnoreNodeTests: PrettyPrintTestCase {
       {
         var bazzle = 0 }
       """
+    assertPrettyPrintEqual(input: input, expected: input, linelength: 50)
+  }
 
-    let expected =
+  func testIgnoreWholeFileDoesNotTouchWhitespace() {
+    let input =
       """
       // swift-format-ignore-file
-      import Zoo
-      import Aoo
-      import foo
-
-          struct Foo {
-            private var baz: Bool {
-                return foo +
-                 bar + // poorly placed comment
-                  false
-            }
-
-            var a = true    // line comment
-                            // aligned line comment
-            var b = false  // correct trailing comment
-
-      var c = 0 +
-          1
-          + (2 + 3)
-      }
-
-            class Bar
-      {
-        var bazzle = 0 }
+      /// foo bar
+      \u{0020}
+      // baz
       """
-
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+    assertPrettyPrintEqual(input: input, expected: input, linelength: 100)
   }
 
   func testIgnoreWholeFileInNestedNode() {

--- a/Tests/SwiftFormatTests/Rules/NoParensAroundConditionsTests.swift
+++ b/Tests/SwiftFormatTests/Rules/NoParensAroundConditionsTests.swift
@@ -263,6 +263,77 @@ final class NoParensAroundConditionsTests: LintOrFormatRuleTestCase {
         FindingSpec("7️⃣", message: "remove the parentheses around this expression"),
       ]
     )
+  }
 
+  func testBlockCommentsBeforeConditionArePreserved() {
+    assertFormatting(
+      NoParensAroundConditions.self,
+      input: """
+        if/*foo*/1️⃣(x) {}
+        while/*foo*/2️⃣(x) {}
+        guard/*foo*/3️⃣(x), /*foo*/4️⃣(y), /*foo*/5️⃣(x == 3) else {}
+        repeat {} while/*foo*/6️⃣(x)
+        switch/*foo*/7️⃣(4) { default: break }
+        """,
+      expected: """
+        if/*foo*/x {}
+        while/*foo*/x {}
+        guard/*foo*/x, /*foo*/y, /*foo*/x == 3 else {}
+        repeat {} while/*foo*/x
+        switch/*foo*/4 { default: break }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "remove the parentheses around this expression"),
+        FindingSpec("2️⃣", message: "remove the parentheses around this expression"),
+        FindingSpec("3️⃣", message: "remove the parentheses around this expression"),
+        FindingSpec("4️⃣", message: "remove the parentheses around this expression"),
+        FindingSpec("5️⃣", message: "remove the parentheses around this expression"),
+        FindingSpec("6️⃣", message: "remove the parentheses around this expression"),
+        FindingSpec("7️⃣", message: "remove the parentheses around this expression"),
+      ]
+    )
+  }
+
+  func testCommentsAfterKeywordArePreserved() {
+    assertFormatting(
+      NoParensAroundConditions.self,
+      input: """
+        if /*foo*/ // bar
+          1️⃣(x) {}
+        while /*foo*/ // bar
+          2️⃣(x) {}
+        guard /*foo*/ // bar
+          3️⃣(x), /*foo*/ // bar
+          4️⃣(y), /*foo*/ // bar
+          5️⃣(x == 3) else {}
+        repeat {} while /*foo*/ // bar
+          6️⃣(x)
+        switch /*foo*/ // bar
+          7️⃣(4) { default: break }
+        """,
+      expected: """
+        if /*foo*/ // bar
+          x {}
+        while /*foo*/ // bar
+          x {}
+        guard /*foo*/ // bar
+          x, /*foo*/ // bar
+          y, /*foo*/ // bar
+          x == 3 else {}
+        repeat {} while /*foo*/ // bar
+          x
+        switch /*foo*/ // bar
+          4 { default: break }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "remove the parentheses around this expression"),
+        FindingSpec("2️⃣", message: "remove the parentheses around this expression"),
+        FindingSpec("3️⃣", message: "remove the parentheses around this expression"),
+        FindingSpec("4️⃣", message: "remove the parentheses around this expression"),
+        FindingSpec("5️⃣", message: "remove the parentheses around this expression"),
+        FindingSpec("6️⃣", message: "remove the parentheses around this expression"),
+        FindingSpec("7️⃣", message: "remove the parentheses around this expression"),
+      ]
+    )
   }
 }


### PR DESCRIPTION
These are fixes that got missed during the removal of the legacy trivia workaround (and one issue that's been around before that):

* `// swift-format-ignore-file` shouldn't modify anything, even whitespace.
* `NoParensAroundConditions`: Preserve trailing trivia on the statement keyword.
* `OrderedImports`: Fix trivia placement for trailing comments.