### PR TITLE
Some minor frontend tweaks.

### DIFF
--- a/Sources/swift-format/PrintVersion.swift
+++ b/Sources/swift-format/PrintVersion.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -10,17 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import ArgumentParser
-
-/// Encapsulates `--version` flag behavior.
-struct VersionOptions: ParsableArguments {
-  @Flag(name: .shortAndLong, help: "Print the version and exit")
-  var version: Bool = false
-
-  func validate() throws {
-    if version {
-      printVersionInformation()
-      throw ExitCode.success
-    }
-  }
+func printVersionInformation() {
+  // TODO: Automate updates to this somehow.
+  print("main")
 }

--- a/Sources/swift-format/SwiftFormatCommand.swift
+++ b/Sources/swift-format/SwiftFormatCommand.swift
@@ -14,6 +14,7 @@ import ArgumentParser
 
 /// Collects the command line options that were passed to `swift-format` and dispatches to the
 /// appropriate subcommand.
+@main
 struct SwiftFormatCommand: ParsableCommand {
   static var configuration = CommandConfiguration(
     commandName: "swift-format",
@@ -29,5 +30,3 @@ struct SwiftFormatCommand: ParsableCommand {
   @OptionGroup()
   var versionOptions: VersionOptions
 }
-
-SwiftFormatCommand.main()


### PR DESCRIPTION
- Switch to `@main` on the top-level command.
- Move the function that prints the version information into its own file, so it can be swapped out with something else for custom builds. (It would be nice to automate this similar to what swift-testing is doing with their GitPlugin, but I don't want to steal that code verbatim just yet.)
- Make the version string on the main branch "main" instead of an older value that just happened to stick around. In the future, this should always be "main" and it can be updated on the actual release branches (or automated ideally).