### PR TITLE
[AllPublicDeclarationsHaveDocumentation] Fix behavior for `override` methods.

### DIFF
--- a/Sources/SwiftFormat/Rules/AllPublicDeclarationsHaveDocumentation.swift
+++ b/Sources/SwiftFormat/Rules/AllPublicDeclarationsHaveDocumentation.swift
@@ -77,7 +77,8 @@ public final class AllPublicDeclarationsHaveDocumentation: SyntaxLintRule {
   ) {
     guard
       DocumentationCommentText(extractedFrom: decl.leadingTrivia) == nil,
-      modifiers.contains(anyOf: [.public, .override])
+      modifiers.contains(anyOf: [.public]),
+      !modifiers.contains(anyOf: [.override])
     else {
       return
     }


### PR DESCRIPTION
This was mistakenly broken during a refactor and we didn't have test coverage for it. We didn't have test coverage for it because the tests behave differently than the rule does when executed in the whole pipeline, so we need to fix that too. I'm going to do that in a separate PR, because it might have knock-on effects elsewhere.

Fixes #651.