### PR TITLE
Fix multi-line string wrapping in `@available` attributes.

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -1801,8 +1801,23 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
   override func visit(_ node: AvailabilityLabeledArgumentSyntax) -> SyntaxVisitorContinueKind {
     before(node.label, tokens: .open)
-    after(node.colon, tokens: .break(.continue, newlines: .elective(ignoresDiscretionary: true)))
-    after(node.value.lastToken(viewMode: .sourceAccurate), tokens: .close)
+
+    let tokensAfterColon: [Token]
+    let endTokens: [Token]
+
+    if case .string(let string) = node.value,
+      string.openingQuote.tokenKind == .multilineStringQuote
+    {
+      tokensAfterColon =
+        [.break(.open(kind: .block), newlines: .elective(ignoresDiscretionary: true))]
+      endTokens = [.break(.close(mustBreak: false), size: 0), .close]
+    } else {
+      tokensAfterColon = [.break(.continue, newlines: .elective(ignoresDiscretionary: true))]
+      endTokens = [.close]
+    }
+
+    after(node.colon, tokens: tokensAfterColon)
+    after(node.value.lastToken(viewMode: .sourceAccurate), tokens: endTokens)
     return .visitChildren
   }
 
@@ -2377,6 +2392,16 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       after(node.openingQuote, tokens: .break(breakKind, size: 0, newlines: .hard(count: 1)))
       if !node.segments.isEmpty {
         before(node.closingQuote, tokens: .break(breakKind, newlines: .hard(count: 1)))
+      }
+    }
+    return .visitChildren
+  }
+
+  override func visit(_ node: SimpleStringLiteralExprSyntax) -> SyntaxVisitorContinueKind {
+    if node.openingQuote.tokenKind == .multilineStringQuote {
+      after(node.openingQuote, tokens: .break(.same, size: 0, newlines: .hard(count: 1)))
+      if !node.segments.isEmpty {
+        before(node.closingQuote, tokens: .break(.same, newlines: .hard(count: 1)))
       }
     }
     return .visitChildren

--- a/Tests/SwiftFormatTests/PrettyPrint/AttributeTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/AttributeTests.swift
@@ -356,4 +356,58 @@ final class AttributeTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 32)
   }
+
+  func testMultilineStringLiteralInCustomAttribute() {
+    let input =
+      #"""
+      @CustomAttribute(message: """
+      This is a
+      multiline
+      string
+      """)
+      public func f() {}
+      """#
+
+    let expected =
+      #"""
+      @CustomAttribute(
+        message: """
+          This is a
+          multiline
+          string
+          """)
+      public func f() {}
+
+      """#
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 100)
+  }
+
+  func testMultilineStringLiteralInAvailableAttribute() {
+    let input =
+      #"""
+      @available(*, deprecated, message: """
+      This is a
+      multiline
+      string
+      """)
+      public func f() {}
+      """#
+
+    let expected =
+      #"""
+      @available(
+        *, deprecated,
+        message: """
+          This is a
+          multiline
+          string
+          """
+      )
+      public func f() {}
+
+      """#
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 100)
+  }
 }


### PR DESCRIPTION
Fixes #652.