### PR TITLE
Respect SyntaxVisitorContinueKind of rules when run in Pipeline

### DIFF
--- a/Sources/SwiftFormat/Core/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Core/Pipelines+Generated.swift
@@ -26,6 +26,10 @@ class LintPipeline: SyntaxVisitor {
   /// class type.
   var ruleCache = [ObjectIdentifier: Rule]()
 
+  /// Rules present in this dictionary skip visiting children until they leave the
+  /// syntax node stored as their value
+  var shouldSkipChildren = [ObjectIdentifier: SyntaxProtocol]()
+
   /// Creates a new lint pipeline.
   init(context: Context) {
     self.context = context
@@ -36,10 +40,16 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(TypeNamesShouldBeCapitalized.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: ActorDeclSyntax) {
+    onVisitPost(rule: TypeNamesShouldBeCapitalized.self, for: node)
+  }
 
   override func visit(_ node: AsExprSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NeverForceUnwrap.visit, for: node)
     return .visitChildren
+  }
+  override func visitPost(_ node: AsExprSyntax) {
+    onVisitPost(rule: NeverForceUnwrap.self, for: node)
   }
 
   override func visit(_ node: AssociatedTypeDeclSyntax) -> SyntaxVisitorContinueKind {
@@ -47,6 +57,11 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
     visitIfEnabled(TypeNamesShouldBeCapitalized.visit, for: node)
     return .visitChildren
+  }
+  override func visitPost(_ node: AssociatedTypeDeclSyntax) {
+    onVisitPost(rule: BeginDocumentationCommentWithOneLineSummary.self, for: node)
+    onVisitPost(rule: NoLeadingUnderscores.self, for: node)
+    onVisitPost(rule: TypeNamesShouldBeCapitalized.self, for: node)
   }
 
   override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
@@ -59,21 +74,40 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: ClassDeclSyntax) {
+    onVisitPost(rule: AllPublicDeclarationsHaveDocumentation.self, for: node)
+    onVisitPost(rule: AlwaysUseLowerCamelCase.self, for: node)
+    onVisitPost(rule: BeginDocumentationCommentWithOneLineSummary.self, for: node)
+    onVisitPost(rule: DontRepeatTypeInStaticProperties.self, for: node)
+    onVisitPost(rule: NoLeadingUnderscores.self, for: node)
+    onVisitPost(rule: TypeNamesShouldBeCapitalized.self, for: node)
+    onVisitPost(rule: UseTripleSlashForDocumentationComments.self, for: node)
+  }
 
   override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(OmitExplicitReturns.visit, for: node)
     return .visitChildren
+  }
+  override func visitPost(_ node: ClosureExprSyntax) {
+    onVisitPost(rule: OmitExplicitReturns.self, for: node)
   }
 
   override func visit(_ node: ClosureParameterSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: ClosureParameterSyntax) {
+    onVisitPost(rule: NoLeadingUnderscores.self, for: node)
+  }
 
   override func visit(_ node: ClosureSignatureSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(AlwaysUseLowerCamelCase.visit, for: node)
     visitIfEnabled(ReturnVoidInsteadOfEmptyTuple.visit, for: node)
     return .visitChildren
+  }
+  override func visitPost(_ node: ClosureSignatureSyntax) {
+    onVisitPost(rule: AlwaysUseLowerCamelCase.self, for: node)
+    onVisitPost(rule: ReturnVoidInsteadOfEmptyTuple.self, for: node)
   }
 
   override func visit(_ node: CodeBlockItemListSyntax) -> SyntaxVisitorContinueKind {
@@ -83,16 +117,29 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(UseEarlyExits.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: CodeBlockItemListSyntax) {
+    onVisitPost(rule: DoNotUseSemicolons.self, for: node)
+    onVisitPost(rule: NoAssignmentInExpressions.self, for: node)
+    onVisitPost(rule: OneVariableDeclarationPerLine.self, for: node)
+    onVisitPost(rule: UseEarlyExits.self, for: node)
+  }
 
   override func visit(_ node: CodeBlockSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(AmbiguousTrailingClosureOverload.visit, for: node)
     return .visitChildren
+  }
+  override func visitPost(_ node: CodeBlockSyntax) {
+    onVisitPost(rule: AmbiguousTrailingClosureOverload.self, for: node)
   }
 
   override func visit(_ node: ConditionElementSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NoParensAroundConditions.visit, for: node)
     visitIfEnabled(UseExplicitNilCheckInConditions.visit, for: node)
     return .visitChildren
+  }
+  override func visitPost(_ node: ConditionElementSyntax) {
+    onVisitPost(rule: NoParensAroundConditions.self, for: node)
+    onVisitPost(rule: UseExplicitNilCheckInConditions.self, for: node)
   }
 
   override func visit(_ node: DeinitializerDeclSyntax) -> SyntaxVisitorContinueKind {
@@ -101,16 +148,28 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: DeinitializerDeclSyntax) {
+    onVisitPost(rule: AllPublicDeclarationsHaveDocumentation.self, for: node)
+    onVisitPost(rule: BeginDocumentationCommentWithOneLineSummary.self, for: node)
+    onVisitPost(rule: UseTripleSlashForDocumentationComments.self, for: node)
+  }
 
   override func visit(_ node: EnumCaseElementSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(AlwaysUseLowerCamelCase.visit, for: node)
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: EnumCaseElementSyntax) {
+    onVisitPost(rule: AlwaysUseLowerCamelCase.self, for: node)
+    onVisitPost(rule: NoLeadingUnderscores.self, for: node)
+  }
 
   override func visit(_ node: EnumCaseParameterSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
     return .visitChildren
+  }
+  override func visitPost(_ node: EnumCaseParameterSyntax) {
+    onVisitPost(rule: NoLeadingUnderscores.self, for: node)
   }
 
   override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
@@ -123,6 +182,15 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: EnumDeclSyntax) {
+    onVisitPost(rule: BeginDocumentationCommentWithOneLineSummary.self, for: node)
+    onVisitPost(rule: DontRepeatTypeInStaticProperties.self, for: node)
+    onVisitPost(rule: FullyIndirectEnum.self, for: node)
+    onVisitPost(rule: NoLeadingUnderscores.self, for: node)
+    onVisitPost(rule: OneCasePerLine.self, for: node)
+    onVisitPost(rule: TypeNamesShouldBeCapitalized.self, for: node)
+    onVisitPost(rule: UseTripleSlashForDocumentationComments.self, for: node)
+  }
 
   override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(DontRepeatTypeInStaticProperties.visit, for: node)
@@ -130,15 +198,26 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: ExtensionDeclSyntax) {
+    onVisitPost(rule: DontRepeatTypeInStaticProperties.self, for: node)
+    onVisitPost(rule: NoAccessLevelOnExtensionDeclaration.self, for: node)
+    onVisitPost(rule: UseTripleSlashForDocumentationComments.self, for: node)
+  }
 
   override func visit(_ node: ForStmtSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(UseWhereClausesInForLoops.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: ForStmtSyntax) {
+    onVisitPost(rule: UseWhereClausesInForLoops.self, for: node)
+  }
 
   override func visit(_ node: ForceUnwrapExprSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NeverForceUnwrap.visit, for: node)
     return .visitChildren
+  }
+  override func visitPost(_ node: ForceUnwrapExprSyntax) {
+    onVisitPost(rule: NeverForceUnwrap.self, for: node)
   }
 
   override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
@@ -146,6 +225,11 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(OnlyOneTrailingClosureArgument.visit, for: node)
     visitIfEnabled(ReplaceForEachWithForLoop.visit, for: node)
     return .visitChildren
+  }
+  override func visitPost(_ node: FunctionCallExprSyntax) {
+    onVisitPost(rule: NoEmptyTrailingClosureParentheses.self, for: node)
+    onVisitPost(rule: OnlyOneTrailingClosureArgument.self, for: node)
+    onVisitPost(rule: ReplaceForEachWithForLoop.self, for: node)
   }
 
   override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
@@ -158,36 +242,64 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(ValidateDocumentationComments.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: FunctionDeclSyntax) {
+    onVisitPost(rule: AllPublicDeclarationsHaveDocumentation.self, for: node)
+    onVisitPost(rule: AlwaysUseLowerCamelCase.self, for: node)
+    onVisitPost(rule: BeginDocumentationCommentWithOneLineSummary.self, for: node)
+    onVisitPost(rule: NoLeadingUnderscores.self, for: node)
+    onVisitPost(rule: OmitExplicitReturns.self, for: node)
+    onVisitPost(rule: UseTripleSlashForDocumentationComments.self, for: node)
+    onVisitPost(rule: ValidateDocumentationComments.self, for: node)
+  }
 
   override func visit(_ node: FunctionParameterSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(AlwaysUseLiteralForEmptyCollectionInit.visit, for: node)
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: FunctionParameterSyntax) {
+    onVisitPost(rule: AlwaysUseLiteralForEmptyCollectionInit.self, for: node)
+    onVisitPost(rule: NoLeadingUnderscores.self, for: node)
+  }
 
   override func visit(_ node: FunctionSignatureSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NoVoidReturnOnFunctionSignature.visit, for: node)
     return .visitChildren
+  }
+  override func visitPost(_ node: FunctionSignatureSyntax) {
+    onVisitPost(rule: NoVoidReturnOnFunctionSignature.self, for: node)
   }
 
   override func visit(_ node: FunctionTypeSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(ReturnVoidInsteadOfEmptyTuple.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: FunctionTypeSyntax) {
+    onVisitPost(rule: ReturnVoidInsteadOfEmptyTuple.self, for: node)
+  }
 
   override func visit(_ node: GenericParameterSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
     return .visitChildren
+  }
+  override func visitPost(_ node: GenericParameterSyntax) {
+    onVisitPost(rule: NoLeadingUnderscores.self, for: node)
   }
 
   override func visit(_ node: GenericSpecializationExprSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(UseShorthandTypeNames.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: GenericSpecializationExprSyntax) {
+    onVisitPost(rule: UseShorthandTypeNames.self, for: node)
+  }
 
   override func visit(_ node: GuardStmtSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NoParensAroundConditions.visit, for: node)
     return .visitChildren
+  }
+  override func visitPost(_ node: GuardStmtSyntax) {
+    onVisitPost(rule: NoParensAroundConditions.self, for: node)
   }
 
   override func visit(_ node: IdentifierPatternSyntax) -> SyntaxVisitorContinueKind {
@@ -195,20 +307,33 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: IdentifierPatternSyntax) {
+    onVisitPost(rule: IdentifiersMustBeASCII.self, for: node)
+    onVisitPost(rule: NoLeadingUnderscores.self, for: node)
+  }
 
   override func visit(_ node: IdentifierTypeSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(UseShorthandTypeNames.visit, for: node)
     return .visitChildren
+  }
+  override func visitPost(_ node: IdentifierTypeSyntax) {
+    onVisitPost(rule: UseShorthandTypeNames.self, for: node)
   }
 
   override func visit(_ node: IfExprSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NoParensAroundConditions.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: IfExprSyntax) {
+    onVisitPost(rule: NoParensAroundConditions.self, for: node)
+  }
 
   override func visit(_ node: InfixOperatorExprSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NoAssignmentInExpressions.visit, for: node)
     return .visitChildren
+  }
+  override func visitPost(_ node: InfixOperatorExprSyntax) {
+    onVisitPost(rule: NoAssignmentInExpressions.self, for: node)
   }
 
   override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
@@ -218,30 +343,51 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(ValidateDocumentationComments.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: InitializerDeclSyntax) {
+    onVisitPost(rule: AllPublicDeclarationsHaveDocumentation.self, for: node)
+    onVisitPost(rule: BeginDocumentationCommentWithOneLineSummary.self, for: node)
+    onVisitPost(rule: UseTripleSlashForDocumentationComments.self, for: node)
+    onVisitPost(rule: ValidateDocumentationComments.self, for: node)
+  }
 
   override func visit(_ node: IntegerLiteralExprSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(GroupNumericLiterals.visit, for: node)
     return .visitChildren
+  }
+  override func visitPost(_ node: IntegerLiteralExprSyntax) {
+    onVisitPost(rule: GroupNumericLiterals.self, for: node)
   }
 
   override func visit(_ node: MacroExpansionExprSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NoPlaygroundLiterals.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: MacroExpansionExprSyntax) {
+    onVisitPost(rule: NoPlaygroundLiterals.self, for: node)
+  }
 
   override func visit(_ node: MemberBlockItemListSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(DoNotUseSemicolons.visit, for: node)
     return .visitChildren
+  }
+  override func visitPost(_ node: MemberBlockItemListSyntax) {
+    onVisitPost(rule: DoNotUseSemicolons.self, for: node)
   }
 
   override func visit(_ node: MemberBlockSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(AmbiguousTrailingClosureOverload.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: MemberBlockSyntax) {
+    onVisitPost(rule: AmbiguousTrailingClosureOverload.self, for: node)
+  }
 
   override func visit(_ node: OptionalBindingConditionSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(AlwaysUseLowerCamelCase.visit, for: node)
     return .visitChildren
+  }
+  override func visitPost(_ node: OptionalBindingConditionSyntax) {
+    onVisitPost(rule: AlwaysUseLowerCamelCase.self, for: node)
   }
 
   override func visit(_ node: PatternBindingSyntax) -> SyntaxVisitorContinueKind {
@@ -250,10 +396,18 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(UseSingleLinePropertyGetter.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: PatternBindingSyntax) {
+    onVisitPost(rule: AlwaysUseLiteralForEmptyCollectionInit.self, for: node)
+    onVisitPost(rule: OmitExplicitReturns.self, for: node)
+    onVisitPost(rule: UseSingleLinePropertyGetter.self, for: node)
+  }
 
   override func visit(_ node: PrecedenceGroupDeclSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
     return .visitChildren
+  }
+  override func visitPost(_ node: PrecedenceGroupDeclSyntax) {
+    onVisitPost(rule: NoLeadingUnderscores.self, for: node)
   }
 
   override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
@@ -265,10 +419,21 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: ProtocolDeclSyntax) {
+    onVisitPost(rule: AllPublicDeclarationsHaveDocumentation.self, for: node)
+    onVisitPost(rule: BeginDocumentationCommentWithOneLineSummary.self, for: node)
+    onVisitPost(rule: DontRepeatTypeInStaticProperties.self, for: node)
+    onVisitPost(rule: NoLeadingUnderscores.self, for: node)
+    onVisitPost(rule: TypeNamesShouldBeCapitalized.self, for: node)
+    onVisitPost(rule: UseTripleSlashForDocumentationComments.self, for: node)
+  }
 
   override func visit(_ node: RepeatStmtSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NoParensAroundConditions.visit, for: node)
     return .visitChildren
+  }
+  override func visitPost(_ node: RepeatStmtSyntax) {
+    onVisitPost(rule: NoParensAroundConditions.self, for: node)
   }
 
   override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
@@ -281,6 +446,15 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(OrderedImports.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: SourceFileSyntax) {
+    onVisitPost(rule: AlwaysUseLowerCamelCase.self, for: node)
+    onVisitPost(rule: AmbiguousTrailingClosureOverload.self, for: node)
+    onVisitPost(rule: FileScopedDeclarationPrivacy.self, for: node)
+    onVisitPost(rule: NeverForceUnwrap.self, for: node)
+    onVisitPost(rule: NeverUseForceTry.self, for: node)
+    onVisitPost(rule: NeverUseImplicitlyUnwrappedOptionals.self, for: node)
+    onVisitPost(rule: OrderedImports.self, for: node)
+  }
 
   override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, for: node)
@@ -292,6 +466,15 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: StructDeclSyntax) {
+    onVisitPost(rule: AllPublicDeclarationsHaveDocumentation.self, for: node)
+    onVisitPost(rule: BeginDocumentationCommentWithOneLineSummary.self, for: node)
+    onVisitPost(rule: DontRepeatTypeInStaticProperties.self, for: node)
+    onVisitPost(rule: NoLeadingUnderscores.self, for: node)
+    onVisitPost(rule: TypeNamesShouldBeCapitalized.self, for: node)
+    onVisitPost(rule: UseSynthesizedInitializer.self, for: node)
+    onVisitPost(rule: UseTripleSlashForDocumentationComments.self, for: node)
+  }
 
   override func visit(_ node: SubscriptDeclSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, for: node)
@@ -300,30 +483,51 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: SubscriptDeclSyntax) {
+    onVisitPost(rule: AllPublicDeclarationsHaveDocumentation.self, for: node)
+    onVisitPost(rule: BeginDocumentationCommentWithOneLineSummary.self, for: node)
+    onVisitPost(rule: OmitExplicitReturns.self, for: node)
+    onVisitPost(rule: UseTripleSlashForDocumentationComments.self, for: node)
+  }
 
   override func visit(_ node: SwitchCaseLabelSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NoLabelsInCasePatterns.visit, for: node)
     return .visitChildren
+  }
+  override func visitPost(_ node: SwitchCaseLabelSyntax) {
+    onVisitPost(rule: NoLabelsInCasePatterns.self, for: node)
   }
 
   override func visit(_ node: SwitchCaseListSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NoCasesWithOnlyFallthrough.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: SwitchCaseListSyntax) {
+    onVisitPost(rule: NoCasesWithOnlyFallthrough.self, for: node)
+  }
 
   override func visit(_ node: SwitchExprSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NoParensAroundConditions.visit, for: node)
     return .visitChildren
+  }
+  override func visitPost(_ node: SwitchExprSyntax) {
+    onVisitPost(rule: NoParensAroundConditions.self, for: node)
   }
 
   override func visit(_ node: TokenSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NoBlockComments.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: TokenSyntax) {
+    onVisitPost(rule: NoBlockComments.self, for: node)
+  }
 
   override func visit(_ node: TryExprSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NeverUseForceTry.visit, for: node)
     return .visitChildren
+  }
+  override func visitPost(_ node: TryExprSyntax) {
+    onVisitPost(rule: NeverUseForceTry.self, for: node)
   }
 
   override func visit(_ node: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {
@@ -334,10 +538,20 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: TypeAliasDeclSyntax) {
+    onVisitPost(rule: AllPublicDeclarationsHaveDocumentation.self, for: node)
+    onVisitPost(rule: BeginDocumentationCommentWithOneLineSummary.self, for: node)
+    onVisitPost(rule: NoLeadingUnderscores.self, for: node)
+    onVisitPost(rule: TypeNamesShouldBeCapitalized.self, for: node)
+    onVisitPost(rule: UseTripleSlashForDocumentationComments.self, for: node)
+  }
 
   override func visit(_ node: ValueBindingPatternSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(UseLetInEveryBoundCaseVariable.visit, for: node)
     return .visitChildren
+  }
+  override func visitPost(_ node: ValueBindingPatternSyntax) {
+    onVisitPost(rule: UseLetInEveryBoundCaseVariable.self, for: node)
   }
 
   override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
@@ -348,10 +562,20 @@ class LintPipeline: SyntaxVisitor {
     visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
     return .visitChildren
   }
+  override func visitPost(_ node: VariableDeclSyntax) {
+    onVisitPost(rule: AllPublicDeclarationsHaveDocumentation.self, for: node)
+    onVisitPost(rule: AlwaysUseLowerCamelCase.self, for: node)
+    onVisitPost(rule: BeginDocumentationCommentWithOneLineSummary.self, for: node)
+    onVisitPost(rule: NeverUseImplicitlyUnwrappedOptionals.self, for: node)
+    onVisitPost(rule: UseTripleSlashForDocumentationComments.self, for: node)
+  }
 
   override func visit(_ node: WhileStmtSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NoParensAroundConditions.visit, for: node)
     return .visitChildren
+  }
+  override func visitPost(_ node: WhileStmtSyntax) {
+    onVisitPost(rule: NoParensAroundConditions.self, for: node)
   }
 }
 

--- a/Sources/generate-swift-format/PipelineGenerator.swift
+++ b/Sources/generate-swift-format/PipelineGenerator.swift
@@ -54,6 +54,10 @@ final class PipelineGenerator: FileGenerator {
         /// class type.
         var ruleCache = [ObjectIdentifier: Rule]()
 
+        /// Rules present in this dictionary skip visiting children until they leave the
+        /// syntax node stored as their value
+        var shouldSkipChildren = [ObjectIdentifier: SyntaxProtocol]()
+
         /// Creates a new lint pipeline.
         init(context: Context) {
           self.context = context
@@ -85,6 +89,25 @@ final class PipelineGenerator: FileGenerator {
           }
 
         """)
+
+        handle.write(
+          """
+            override func visitPost(_ node: \(nodeType)) {
+          """
+        )
+        for ruleName in lintRules.sorted() {
+          handle.write(
+            """
+                onVisitPost(rule: \(ruleName).self, for: node)
+
+            """)
+        }
+        handle.write(
+          """
+            }
+
+          """
+        )
     }
 
     handle.write(


### PR DESCRIPTION
Pipelines+Generated.swift previously visited all enabled rules at all nodes regardless of what the rule returned for it's `SyntaxVisitorContinueKind`. However, some rules rely on returning `.skipChildren` to lint/format correctly.

To remedy this, modify the pipeline to track the the skip state of each rule. When a rule returns skip, our pipeline stops calling its visit methods until we leave the skipped node.

Alongside this change, modify tests to check both the rule in isolation and the pipeline. We were only testing the rule in isolation so our tests were respecting the `SyntaxVisitorContinueKind`, even though our pipeline was not.