### PR TITLE
Remove deprecated variants from parameterClause case match

### DIFF
--- a/Sources/SwiftFormat/Rules/AlwaysUseLowerCamelCase.swift
+++ b/Sources/SwiftFormat/Rules/AlwaysUseLowerCamelCase.swift
@@ -85,26 +85,6 @@ public final class AlwaysUseLowerCamelCase: SyntaxLintRule {
               secondName, allowUnderscores: false, description: identifierDescription(for: node))
           }
         }
-      } else if let parameterClause = input.as(EnumCaseParameterClauseSyntax.self) {
-        for param in parameterClause.parameters {
-          if let firstName = param.firstName {
-            diagnoseLowerCamelCaseViolations(
-              firstName, allowUnderscores: false, description: identifierDescription(for: node))
-          }
-          if let secondName = param.secondName {
-            diagnoseLowerCamelCaseViolations(
-              secondName, allowUnderscores: false, description: identifierDescription(for: node))
-          }
-        }
-      } else if let parameterClause = input.as(FunctionParameterClauseSyntax.self) {
-        for param in parameterClause.parameters {
-          diagnoseLowerCamelCaseViolations(
-            param.firstName, allowUnderscores: false, description: identifierDescription(for: node))
-          if let secondName = param.secondName {
-            diagnoseLowerCamelCaseViolations(
-              secondName, allowUnderscores: false, description: identifierDescription(for: node))
-          }
-        }
       }
     }
     return .visitChildren


### PR DESCRIPTION
parameterClause used to be able to be a `EnumCaseParameterClauseSyntax` or `FunctionParameterClauseSyntax`. These variants are no longer possible https://swiftpackageindex.com/apple/swift-syntax/509.0.1/documentation/swiftsyntax/closuresignaturesyntax.

Remove checks for these variants since they cannot occur.