### PR TITLE
Various fixes for some 509.0.0 bugs.

### DIFF
--- a/Sources/SwiftFormat/Rules/NoEmptyTrailingClosureParentheses.swift
+++ b/Sources/SwiftFormat/Rules/NoEmptyTrailingClosureParentheses.swift
@@ -27,7 +27,10 @@ public final class NoEmptyTrailingClosureParentheses: SyntaxFormatRule {
     guard
       let trailingClosure = node.trailingClosure,
       let leftParen = node.leftParen,
-      node.arguments.isEmpty
+      let rightParen = node.rightParen,
+      node.arguments.isEmpty,
+      !leftParen.trailingTrivia.hasAnyComments,
+      !rightParen.leadingTrivia.hasAnyComments
     else {
       return super.visit(node)
     }

--- a/Tests/SwiftFormatTests/PrettyPrint/KeyPathExprTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/KeyPathExprTests.swift
@@ -131,7 +131,9 @@ final class KeyPathExprTests: PrettyPrintTestCase {
       #"""
       let x = \ReallyLongType.reallyLongProperty.anotherLongProperty
       let x = \.reeeeallyLongProperty.anotherLongProperty
+      let x = \.longProperty.a.b.c[really + long + expression]
       let x = \.longProperty.a.b.c[really + long + expression].anotherLongProperty
+      let x = \.longProperty.a.b.c[label:really + long + expression].anotherLongProperty
       """#
 
     let expected =
@@ -146,6 +148,16 @@ final class KeyPathExprTests: PrettyPrintTestCase {
       let x =
         \.longProperty.a.b.c[
           really + long
+            + expression]
+      let x =
+        \.longProperty.a.b.c[
+          really + long
+            + expression
+        ].anotherLongProperty
+      let x =
+        \.longProperty.a.b.c[
+          label: really
+            + long
             + expression
         ].anotherLongProperty
 

--- a/Tests/SwiftFormatTests/Rules/NoEmptyTrailingClosureParenthesesTests.swift
+++ b/Tests/SwiftFormatTests/Rules/NoEmptyTrailingClosureParenthesesTests.swift
@@ -83,4 +83,29 @@ final class NoEmptyTrailingClosureParenthesesTests: LintOrFormatRuleTestCase {
       ]
     )
   }
+
+  func testDoNotRemoveParensContainingOnlyComments() {
+    assertFormatting(
+      NoEmptyTrailingClosureParentheses.self,
+      input: """
+        greetEnthusiastically(/*oldArg: x*/) { "John" }
+        greetEnthusiastically(
+          /*oldArg: x*/
+        ) { "John" }
+        greetEnthusiastically(
+          // oldArg: x
+        ) { "John" }
+        """,
+      expected: """
+        greetEnthusiastically(/*oldArg: x*/) { "John" }
+        greetEnthusiastically(
+          /*oldArg: x*/
+        ) { "John" }
+        greetEnthusiastically(
+          // oldArg: x
+        ) { "John" }
+        """,
+      findings: []
+    )
+  }
 }

--- a/Tests/SwiftFormatTests/Rules/UseShorthandTypeNamesTests.swift
+++ b/Tests/SwiftFormatTests/Rules/UseShorthandTypeNamesTests.swift
@@ -692,4 +692,44 @@ final class UseShorthandTypeNamesTests: LintOrFormatRuleTestCase {
       ]
     )
   }
+
+  func testAttributedTypesInOptionalsAreParenthesized() {
+    // If we need to insert parentheses, verify that we do, but also verify that we don't insert
+    // them unnecessarily.
+    assertFormatting(
+      UseShorthandTypeNames.self,
+      input: """
+        var x: 1️⃣Optional<consuming P> = S()
+        var y: 2️⃣Optional<@Sendable (Int) -> Void> = S()
+        var z = [3️⃣Optional<consuming P>]([S()])
+        var a = [4️⃣Optional<@Sendable (Int) -> Void>]([S()])
+
+        var x: 5️⃣Optional<(consuming P)> = S()
+        var y: 6️⃣Optional<(@Sendable (Int) -> Void)> = S()
+        var z = [7️⃣Optional<(consuming P)>]([S()])
+        var a = [8️⃣Optional<(@Sendable (Int) -> Void)>]([S()])
+        """,
+      expected: """
+        var x: (consuming P)? = S()
+        var y: (@Sendable (Int) -> Void)? = S()
+        var z = [(consuming P)?]([S()])
+        var a = [(@Sendable (Int) -> Void)?]([S()])
+
+        var x: (consuming P)? = S()
+        var y: (@Sendable (Int) -> Void)? = S()
+        var z = [(consuming P)?]([S()])
+        var a = [(@Sendable (Int) -> Void)?]([S()])
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "use shorthand syntax for this 'Optional' type"),
+        FindingSpec("2️⃣", message: "use shorthand syntax for this 'Optional' type"),
+        FindingSpec("3️⃣", message: "use shorthand syntax for this 'Optional' type"),
+        FindingSpec("4️⃣", message: "use shorthand syntax for this 'Optional' type"),
+        FindingSpec("5️⃣", message: "use shorthand syntax for this 'Optional' type"),
+        FindingSpec("6️⃣", message: "use shorthand syntax for this 'Optional' type"),
+        FindingSpec("7️⃣", message: "use shorthand syntax for this 'Optional' type"),
+        FindingSpec("8️⃣", message: "use shorthand syntax for this 'Optional' type"),
+      ]
+    )
+  }
 }


### PR DESCRIPTION
- Fix shorthand for optional attributed types in `UseShorthandTypeNames` (fixes #657).
- Fix formatting of keypath subscript components with labels in the pretty printer (fixes #663).
- Do not remove parens if they contain comments in `NoEmptyTrailingClosureParentheses` (fixes #665).
