### PR TITLE
[OrderedImports] Fix dropped trailing comments on top-level code items.

### DIFF
--- a/Sources/SwiftFormat/Rules/OrderedImports.swift
+++ b/Sources/SwiftFormat/Rules/OrderedImports.swift
@@ -315,17 +315,17 @@ fileprivate func generateLines(codeBlockItemList: CodeBlockItemListSyntax, conte
       blockWithoutTrailingTrivia.trailingTrivia = []
       currentLine.syntaxNode = .importCodeBlock(blockWithoutTrailingTrivia, sortable: sortable)
     } else {
-      guard let syntaxNode = currentLine.syntaxNode else {
+      if let syntaxNode = currentLine.syntaxNode {
+        // Multiple code blocks can be merged, as long as there isn't an import statement.
+        switch syntaxNode {
+        case .importCodeBlock:
+          appendNewLine()
+          currentLine.syntaxNode = .nonImportCodeBlocks([block])
+        case .nonImportCodeBlocks(let existingCodeBlocks):
+          currentLine.syntaxNode = .nonImportCodeBlocks(existingCodeBlocks + [block])
+        }
+      } else {
         currentLine.syntaxNode = .nonImportCodeBlocks([block])
-        continue
-      }
-      // Multiple code blocks can be merged, as long as there isn't an import statement.
-      switch syntaxNode {
-      case .importCodeBlock:
-        appendNewLine()
-        currentLine.syntaxNode = .nonImportCodeBlocks([block])
-      case .nonImportCodeBlocks(let existingCodeBlocks):
-        currentLine.syntaxNode = .nonImportCodeBlocks(existingCodeBlocks + [block])
       }
     }
 

--- a/Tests/SwiftFormatTests/Rules/OrderedImportsTests.swift
+++ b/Tests/SwiftFormatTests/Rules/OrderedImportsTests.swift
@@ -618,4 +618,38 @@ final class OrderedImportsTests: LintOrFormatRuleTestCase {
       ]
     )
   }
+
+  func testTrailingCommentsOnTopLevelCodeItems() {
+    assertFormatting(
+      OrderedImports.self,
+      input: """
+        import Zebras
+        1️⃣import Apples
+        #if canImport(Darwin)
+          import Darwin
+        #elseif canImport(Glibc)
+          import Glibc
+        #endif  // canImport(Darwin)
+
+        foo()  // calls the foo
+        bar()  // calls the bar
+        """,
+      expected: """
+        import Apples
+        import Zebras
+
+        #if canImport(Darwin)
+          import Darwin
+        #elseif canImport(Glibc)
+          import Glibc
+        #endif  // canImport(Darwin)
+
+        foo()  // calls the foo
+        bar()  // calls the bar
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "sort import statements lexicographically"),
+      ]
+    )
+  }
 }


### PR DESCRIPTION
Also add some validation logic in format rule tests. We already run the pretty printer afterwards to verify that there aren't any invariants broken that would cause an assertion failure, but we don't compare the actual pretty-printed text to the originally transformed tree (because we don't want the output of those tests to be sensitive to pretty-printer configuration). What we *can* do, which is still an improvement, is walk the token sequence and compare the tokens and trivia in a whitespace-insensitive manner. This makes sure that we don't move trivia around in a way that the format rule would accept but that the pretty-printer wouldn't know how to handle.