### PR TITLE
build: introduce a CMake based build for swift-format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,92 @@
+#[[
+This source file is part of the swift-format open source project
+
+Copyright (c) 2024 Apple Inc. and the swift-format project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+cmake_minimum_required(VERSION 3.19.0)
+
+if(POLICY CMP0077)
+  cmake_policy(SET CMP0077 NEW)
+endif()
+if(POLICY CMP0091)
+  cmake_policy(SET CMP0091 NEW)
+endif()
+
+project(SwiftFormat
+  LANGUAGES C Swift)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
+set(CMAKE_Swift_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
+
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
+
+include(FetchContent)
+include(GNUInstallDirs)
+include(SwiftSupport)
+
+find_package(Foundation CONFIG)
+
+set(_SF_VENDOR_DEPENDENCIES)
+
+set(BUILD_EXAMPLES NO)
+set(BUILD_TESTING NO)
+
+find_package(ArgumentParser CONFIG)
+if(NOT ArgumentParser_FOUND)
+  FetchContent_Declare(ArgumentParser
+    GIT_REPOSITORY https://github.com/apple/swift-argument-parser
+    GIT_TAG 1.2.3)
+  list(APPEND _SF_VENDOR_DEPENDENCIES ArgumentParser)
+endif()
+
+find_package(cmark-gfm CONFIG)
+if(NOT cmark-gfm_FOUND)
+  FetchContent_Declare(cmark-gfm
+    GIT_REPOSITORY https://github.com/apple/swift-cmark
+    GIT_TAG gfm)
+  list(APPEND _SF_VENDOR_DEPENDENCIES cmark-gfm)
+endif()
+
+find_package(SwiftMarkdown CONFIG)
+if(NOT SwiftMarkdown_FOUND)
+  # TODO(compnerd) we need a latest version for now as we need the CMake support
+  # which is untagged.
+  FetchContent_Declare(Markdown
+    GIT_REPOSITORY https://github.com/apple/swift-markdown
+    GIT_TAG main)
+  list(APPEND _SF_VENDOR_DEPENDENCIES Markdown)
+endif()
+
+find_package(SwiftSyntax CONFIG)
+if(NOT SwiftSyntax_FOUND)
+  FetchContent_Declare(Syntax
+    GIT_REPOSITORY https://github.com/apple/swift-syntax
+    GIT_TAG main)
+  list(APPEND _SF_VENDOR_DEPENDENCIES Syntax)
+endif()
+
+if(_SF_VENDOR_DEPENDENCIES)
+  FetchContent_MakeAvailable(${_SF_VENDOR_DEPENDENCIES})
+
+  if(NOT TARGET SwiftMarkdown::Markdown)
+    add_library(SwiftMarkdown::Markdown ALIAS Markdown)
+  endif()
+
+  if(NOT TARGET SwiftSyntax::SwiftSyntax)
+    add_library(SwiftSyntax::SwiftSyntax ALIAS SwiftSyntax)
+    add_library(SwiftSyntax::SwiftSyntaxBuilder ALIAS SwiftSyntaxBuilder)
+    add_library(SwiftSyntax::SwiftOperators ALIAS SwiftOperators)
+    add_library(SwiftSyntax::SwiftParser ALIAS SwiftParser)
+    add_library(SwiftSyntax::SwiftParserDiagnostics ALIAS SwiftParserDiagnostics)
+  endif()
+endif()
+
+add_subdirectory(Sources)

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -1,0 +1,12 @@
+#[[
+This source file is part of the swift-format open source project
+
+Copyright (c) 2024 Apple Inc. and the swift-format project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+add_subdirectory(SwiftFormat)
+add_subdirectory(_SwiftFormatInstructionCounter)
+add_subdirectory(swift-format)

--- a/Sources/SwiftFormat/CMakeLists.txt
+++ b/Sources/SwiftFormat/CMakeLists.txt
@@ -1,0 +1,105 @@
+#[[
+This source file is part of the swift-format open source project
+
+Copyright (c) 2024 Apple Inc. and the swift-format project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+add_library(SwiftFormat
+  API/Configuration+Default.swift
+  API/Configuration.swift
+  API/DebugOptions.swift
+  API/Finding.swift
+  API/FindingCategorizing.swift
+  API/Indent.swift
+  API/SwiftFormatError.swift
+  API/SwiftFormatter.swift
+  API/SwiftLinter.swift
+  Core/Context.swift
+  Core/DocumentationComment.swift
+  Core/DocumentationCommentText.swift
+  Core/Finding+Convenience.swift
+  Core/FindingEmitter.swift
+  Core/FormatPipeline.swift
+  Core/FunctionDeclSyntax+Convenience.swift
+  Core/ImportsXCTestVisitor.swift
+  Core/LazySplitSequence.swift
+  Core/LintPipeline.swift
+  Core/ModifierListSyntax+Convenience.swift
+  Core/Parsing.swift
+  Core/Pipelines+Generated.swift
+  Core/RememberingIterator.swift
+  Core/Rule.swift
+  Core/RuleBasedFindingCategory.swift
+  Core/RuleMask.swift
+  Core/RuleNameCache+Generated.swift
+  Core/RuleRegistry+Generated.swift
+  Core/RuleState.swift
+  Core/SyntaxFormatRule.swift
+  Core/SyntaxLintRule.swift
+  Core/SyntaxProtocol+Convenience.swift
+  Core/Trivia+Convenience.swift
+  Core/WithSemicolonSyntax.swift
+  PrettyPrint/Comment.swift
+  PrettyPrint/Indent+Length.swift
+  PrettyPrint/PrettyPrint.swift
+  PrettyPrint/PrettyPrintFindingCategory.swift
+  PrettyPrint/Token.swift
+  PrettyPrint/TokenStreamCreator.swift
+  PrettyPrint/Verbatim.swift
+  PrettyPrint/WhitespaceFindingCategory.swift
+  PrettyPrint/WhitespaceLinter.swift
+  Rules/AllPublicDeclarationsHaveDocumentation.swift
+  Rules/AlwaysUseLiteralForEmptyCollectionInit.swift
+  Rules/AlwaysUseLowerCamelCase.swift
+  Rules/AmbiguousTrailingClosureOverload.swift
+  Rules/BeginDocumentationCommentWithOneLineSummary.swift
+  Rules/DoNotUseSemicolons.swift
+  Rules/DontRepeatTypeInStaticProperties.swift
+  Rules/FileScopedDeclarationPrivacy.swift
+  Rules/FullyIndirectEnum.swift
+  Rules/GroupNumericLiterals.swift
+  Rules/IdentifiersMustBeASCII.swift
+  Rules/NeverForceUnwrap.swift
+  Rules/NeverUseForceTry.swift
+  Rules/NeverUseImplicitlyUnwrappedOptionals.swift
+  Rules/NoAccessLevelOnExtensionDeclaration.swift
+  Rules/NoAssignmentInExpressions.swift
+  Rules/NoBlockComments.swift
+  Rules/NoCasesWithOnlyFallthrough.swift
+  Rules/NoEmptyTrailingClosureParentheses.swift
+  Rules/NoLabelsInCasePatterns.swift
+  Rules/NoLeadingUnderscores.swift
+  Rules/NoParensAroundConditions.swift
+  Rules/NoPlaygroundLiterals.swift
+  Rules/NoVoidReturnOnFunctionSignature.swift
+  Rules/OmitExplicitReturns.swift
+  Rules/OneCasePerLine.swift
+  Rules/OneVariableDeclarationPerLine.swift
+  Rules/OnlyOneTrailingClosureArgument.swift
+  Rules/OrderedImports.swift
+  Rules/ReplaceForEachWithForLoop.swift
+  Rules/ReturnVoidInsteadOfEmptyTuple.swift
+  Rules/TypeNamesShouldBeCapitalized.swift
+  Rules/UseEarlyExits.swift
+  Rules/UseExplicitNilCheckInConditions.swift
+  Rules/UseLetInEveryBoundCaseVariable.swift
+  Rules/UseShorthandTypeNames.swift
+  Rules/UseSingleLinePropertyGetter.swift
+  Rules/UseSynthesizedInitializer.swift
+  Rules/UseTripleSlashForDocumentationComments.swift
+  Rules/UseWhereClausesInForLoops.swift
+  Rules/ValidateDocumentationComments.swift)
+target_link_libraries(SwiftFormat PUBLIC
+  SwiftMarkdown::Markdown
+  SwiftSyntax::SwiftSyntax
+  SwiftSyntax::SwiftSyntaxBuilder
+  SwiftSyntax::SwiftOperators
+  SwiftSyntax::SwiftParser
+  SwiftSyntax::SwiftParserDiagnostics
+  libcmark-gfm
+  libcmark-gfm-extensions)
+
+_install_target(SwiftFormat)

--- a/Sources/_SwiftFormatInstructionCounter/CMakeLists.txt
+++ b/Sources/_SwiftFormatInstructionCounter/CMakeLists.txt
@@ -1,0 +1,13 @@
+#[[
+This source file is part of the swift-format open source project
+
+Copyright (c) 2024 Apple Inc. and the swift-format project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+add_library(_SwiftFormatInstructionCounter STATIC
+  src/InstructionsExecuted.c)
+target_include_directories(_SwiftFormatInstructionCounter PUBLIC
+  include)

--- a/Sources/_SwiftFormatInstructionCounter/include/module.modulemap
+++ b/Sources/_SwiftFormatInstructionCounter/include/module.modulemap
@@ -1,0 +1,3 @@
+module _SwiftFormatInstructionCounter {
+  header "InstructionsExecuted.h"
+}

--- a/Sources/swift-format/CMakeLists.txt
+++ b/Sources/swift-format/CMakeLists.txt
@@ -1,0 +1,37 @@
+#[[
+This source file is part of the swift-format open source project
+
+Copyright (c) 2024 Apple Inc. and the swift-format project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+add_executable(swift-format
+  PrintVersion.swift
+  SwiftFormatCommand.swift
+  VersionOptions.swift
+  Frontend/ConfigurationLoader.swift
+  Frontend/FormatFrontend.swift
+  Frontend/Frontend.swift
+  Frontend/LintFrontend.swift
+  Subcommands/DumpConfiguration.swift
+  Subcommands/Format.swift
+  Subcommands/Lint.swift
+  Subcommands/LintFormatOptions.swift
+  Subcommands/PerformanceMeasurement.swift
+  Utilities/Diagnostic.swift
+  Utilities/DiagnosticsEngine.swift
+  Utilities/FileHandleTextOutputStream.swift
+  Utilities/FileIterator.swift
+  Utilities/FormatError.swift
+  Utilities/StderrDiagnosticPrinter.swift
+  Utilities/TTY.swift)
+target_link_libraries(swift-format PRIVATE
+  _SwiftFormatInstructionCounter
+  ArgumentParser
+  SwiftFormat
+  SwiftParser
+  SwiftSyntax)
+
+_install_target(swift-format)

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -1,0 +1,20 @@
+#[[
+This source file is part of the swift-format open source project
+
+Copyright (c) 2024 Apple Inc. and the swift-format project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+set(SWIFT_FORMAT_EXPORTS_FILE
+  ${CMAKE_CURRENT_BINARY_DIR}/SwiftFormatExports.cmake)
+
+configure_file(SwiftFormatConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/SwiftFormatConfig.cmake)
+
+get_property(SWIFT_FORMAT_EXPORTS GLOBAL PROPERTY SWIFT_FORMAT_EXPORTS)
+export(TARGETS ${SWIFT_FORMAT_EXPORTS}
+  NAMESPACE SwiftFormat::
+  FILE ${SWIFT_FORMAT_EXPORTS_FILE}
+  EXPORT_LINK_INTERFACE_LIBRARIES)

--- a/cmake/modules/SwiftFormatConfig.cmake.in
+++ b/cmake/modules/SwiftFormatConfig.cmake.in
@@ -1,0 +1,12 @@
+#[[
+This source file is part of the swift-format open source project
+
+Copyright (c) 2024 Apple Inc. and the swift-format project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+if(NOT TARGET SwiftFormat)
+  include("@SWIFT_FORMAT_EXPORTS_FILE@")
+endif()

--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -1,0 +1,109 @@
+#[[
+This source file is part of the swift-format open source project
+
+Copyright (c) 2024 Apple Inc. and the swift-format project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+# Returns the current architecture name in a variable
+#
+# Usage:
+#   get_swift_host_arch(result_var_name)
+#
+# If the current architecture is supported by Swift, sets ${result_var_name}
+# with the sanitized host architecture name derived from CMAKE_SYSTEM_PROCESSOR.
+function(get_swift_host_arch result_var_name)
+  if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
+    set("${result_var_name}" "x86_64" PARENT_SCOPE)
+  elseif ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "AArch64|aarch64|arm64|ARM64")
+    if(CMAKE_SYSTEM_NAME MATCHES Darwin)
+      set("${result_var_name}" "arm64" PARENT_SCOPE)
+    else()
+      set("${result_var_name}" "aarch64" PARENT_SCOPE)
+    endif()
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64")
+    set("${result_var_name}" "powerpc64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64le")
+    set("${result_var_name}" "powerpc64le" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "s390x")
+    set("${result_var_name}" "s390x" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv6l")
+    set("${result_var_name}" "armv6" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7l")
+    set("${result_var_name}" "armv7" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7-a")
+    set("${result_var_name}" "armv7" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "amd64")
+    set("${result_var_name}" "amd64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "AMD64")
+    set("${result_var_name}" "x86_64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "IA64")
+    set("${result_var_name}" "itanium" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86")
+    set("${result_var_name}" "i686" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "i686")
+    set("${result_var_name}" "i686" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "wasm32")
+    set("${result_var_name}" "wasm32" PARENT_SCOPE)
+  else()
+    message(FATAL_ERROR "Unrecognized architecture on host system: ${CMAKE_SYSTEM_PROCESSOR}")
+  endif()
+endfunction()
+
+# Returns the os name in a variable
+#
+# Usage:
+#   get_swift_host_os(result_var_name)
+#
+#
+# Sets ${result_var_name} with the converted OS name derived from
+# CMAKE_SYSTEM_NAME.
+function(get_swift_host_os result_var_name)
+  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    set(${result_var_name} macosx PARENT_SCOPE)
+  else()
+    string(TOLOWER ${CMAKE_SYSTEM_NAME} cmake_system_name_lc)
+    set(${result_var_name} ${cmake_system_name_lc} PARENT_SCOPE)
+  endif()
+endfunction()
+
+function(_install_target module)
+  get_swift_host_os(swift_os)
+  get_target_property(type ${module} TYPE)
+
+  if(type STREQUAL STATIC_LIBRARY)
+    set(swift swift_static)
+  else()
+    set(swift swift)
+  endif()
+
+  install(TARGETS ${module}
+    ARCHIVE DESTINATION lib/${swift}/${swift_os}
+    LIBRARY DESTINATION lib/${swift}/${swift_os}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+  if(type STREQUAL EXECUTABLE)
+    return()
+  endif()
+
+  get_swift_host_arch(swift_arch)
+  get_target_property(module_name ${module} Swift_MODULE_NAME)
+  if(NOT module_name)
+    set(module_name ${module})
+  endif()
+
+  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftdoc
+      DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
+      RENAME ${swift_arch}.swiftdoc)
+    install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftmodule
+      DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
+      RENAME ${swift_arch}.swiftmodule)
+  else()
+    install(FILES
+      $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftdoc
+      $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftmodule
+      DESTINATION lib/${swift}/${swift_os}/${swift_arch})
+  endif()
+endfunction()


### PR DESCRIPTION
This is in preparation to use SwiftFormat from SourceKit-LSP which is distributed as part of the toolchain.

On Windows, we are now able to build swift-format against the shared Swift Syntax package, yielding an overall size reduction:

SPM
  swift-format.exe: 75,683,840 b
CMake
  swift-format.exe:    830,464 b
  SwiftFormat.dll:   7,818,240 b

Net Savings: 67,035,136 b