### PR TITLE
Clean up rpaths of installed swift-format

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,8 @@ import PackageDescription
 let package = Package(
   name: "swift-format",
   platforms: [
-    .iOS("13.0"),
-    .macOS("10.15")
+    .macOS("12.0"),
+    .iOS("13.0")
   ],
   products: [
     .executable(
@@ -144,7 +144,7 @@ func hasEnvironmentVariable(_ name: String) -> Bool {
 
 // When building the toolchain on the CI, don't add the CI's runpath for the
 // final build before installing.
-var installAction: Bool { hasEnvironmentVariable("SOURCEKIT_LSP_CI_INSTALL") }
+var installAction: Bool { hasEnvironmentVariable("SWIFTFORMAT_CI_INSTALL") }
 
 /// Assume that all the package dependencies are checked out next to sourcekit-lsp and use that instead of fetching a
 /// remote dependency.

--- a/build-script-helper.py
+++ b/build-script-helper.py
@@ -110,26 +110,7 @@ def get_swiftpm_options(
         swift_exec, cross_compile_config=cross_compile_config
     )
     build_os = build_target.split("-")[2]
-    if build_os.startswith("macosx"):
-        args += [
-            "-Xlinker",
-            "-rpath",
-            "-Xlinker",
-            "/usr/lib/swift",
-        ]
-        args += [
-            "-Xlinker",
-            "-rpath",
-            "-Xlinker",
-            "@executable_path/../lib/swift/macosx",
-        ]
-        args += [
-            "-Xlinker",
-            "-rpath",
-            "-Xlinker",
-            "@executable_path/../lib/swift-5.5/macosx",
-        ]
-    else:
+    if not build_os.startswith("macosx"):
         # Library rpath for swift, dispatch, Foundation, etc. when installing
         args += [
             "-Xlinker",
@@ -137,6 +118,7 @@ def get_swiftpm_options(
             "-Xlinker",
             "$ORIGIN/../lib/swift/" + build_os,
         ]
+        args += ['--disable-local-rpath']
 
     if cross_compile_host:
         if build_os.startswith("macosx") and cross_compile_host.startswith("macosx-"):
@@ -151,7 +133,7 @@ def get_swiftpm_environment_variables(action: str):
     env = dict(os.environ)
     env["SWIFTCI_USE_LOCAL_DEPS"] = "1"
     if action == "install":
-        env["SOURCEKIT_LSP_CI_INSTALL"] = "1"
+        env["SWIFTFORMAT_CI_INSTALL"] = "1"
     return env
 
 


### PR DESCRIPTION
- Don’t explicitly add rpaths to `/usr/lib/swift`, `@executable_path/../lib/swift/macosx` and `@executable_path/../lib/swift-5.5/macosx` on Darwin. I don’t know what they were needed for but they don’t seem to be necessary. Also standard Swift command line tools created from Xcode don’t contain these rpaths.
- Increase the deployment target to macOS 12.0. This removes an rpath in the built binary that is an absolute path to the toolchain on the host, which was used to build swift-format.
- Set `--disable-local-rpath` on Linux. Otherwise the swift-format executable has an `$ORIGIN` rpath on Linux, which we don’t want.
- Rename `SOURCEKIT_LSP_CI_INSTALL` -> `SWIFTFORMAT_CI_INSTALL`. Just cleaning up after copy-pasting.

rdar://121400644