### PR TITLE
Find configuration based on CWD when formatting from stdin

### DIFF
--- a/Sources/swift-format/Frontend/ConfigurationLoader.swift
+++ b/Sources/swift-format/Frontend/ConfigurationLoader.swift
@@ -19,13 +19,13 @@ struct ConfigurationLoader {
   /// The cache of previously loaded configurations.
   private var cache = [String: Configuration]()
 
-  /// Returns the configuration found by searching in the directory (and ancestor directories)
-  /// containing the given `.swift` source file.
+  /// Returns the configuration found by walking up the file tree from `url`.
+  /// This function works for both files and directories.
   ///
   /// If no configuration file was found during the search, this method returns nil.
   ///
   /// - Throws: If a configuration file was found but an error occurred loading it.
-  mutating func configuration(forSwiftFileAt url: URL) throws -> Configuration? {
+  mutating func configuration(forPath url: URL) throws -> Configuration? {
     guard let configurationFileURL = Configuration.url(forConfigurationFileApplyingTo: url)
     else {
       return nil


### PR DESCRIPTION
See #684.

This change is useful for formatting clients that prefer to format via
stdio.

The signature of `ConfigurationLoader.configuration(forSwiftFileAt:URL)`
was changed to `configuration(forPath:URL)` since the function is useful
not just for Swift files, but any arbitrary file path.
