### PR TITLE
Ignore sentence terminators inside quotes when applying the 'BeginDocumentationCommentWithOneLineSummary' option.

### DIFF
--- a/Sources/SwiftFormat/Rules/BeginDocumentationCommentWithOneLineSummary.swift
+++ b/Sources/SwiftFormat/Rules/BeginDocumentationCommentWithOneLineSummary.swift
@@ -130,8 +130,14 @@ public final class BeginDocumentationCommentWithOneLineSummary: SyntaxLintRule {
         in: text.startIndex..<text.endIndex,
         scheme: NSLinguisticTagScheme.lexicalClass.rawValue,
         tokenRanges: &tokenRanges)
+      var isInsideQuotes = false
       let sentenceTerminatorIndices = tags.enumerated().filter {
-        $0.element == "SentenceTerminator"
+        if $0.element == "OpenQuote" {
+          isInsideQuotes = true
+        } else if $0.element == "CloseQuote" {
+          isInsideQuotes = false
+        }
+        return !isInsideQuotes && $0.element == "SentenceTerminator"
       }.map {
         tokenRanges[$0.offset].lowerBound
       }

--- a/Tests/SwiftFormatTests/Rules/BeginDocumentationCommentWithOneLineSummaryTests.swift
+++ b/Tests/SwiftFormatTests/Rules/BeginDocumentationCommentWithOneLineSummaryTests.swift
@@ -139,4 +139,24 @@ final class BeginDocumentationCommentWithOneLineSummaryTests: LintOrFormatRuleTe
       )
     #endif
   }
+    
+  func testSentenceTerminationInsideQuotes() {
+    assertLint(
+      BeginDocumentationCommentWithOneLineSummary.self,
+      """
+      /// Creates an instance with the same raw value as `x` failing iff `x.kind != Subject.kind`.
+      struct TestBackTick {}
+      
+      /// A set of `Diagnostic` that can answer the question 'was there an error?' in O(1).
+      struct TestSingleQuotes {}
+      
+      /// A set of `Diagnostic` that can answer the question “was there an error?” in O(1).
+      struct TestDoubleQuotes {}
+      
+      /// A set of `Diagnostic` that can answer the question “was there 
+      /// an error?” in O(1).
+      struct TestTwoLinesDoubleQuotes {}
+      """
+    )
+  }
 }

--- a/Tests/SwiftFormatTests/Rules/BeginDocumentationCommentWithOneLineSummaryTests.swift
+++ b/Tests/SwiftFormatTests/Rules/BeginDocumentationCommentWithOneLineSummaryTests.swift
@@ -147,15 +147,25 @@ final class BeginDocumentationCommentWithOneLineSummaryTests: LintOrFormatRuleTe
       /// Creates an instance with the same raw value as `x` failing iff `x.kind != Subject.kind`.
       struct TestBackTick {}
       
+      /// A set of `Diagnostic` that can answer the question ‘was there an error?’ in O(1).
+      struct TestSingleSmartQuotes {}
+      
       /// A set of `Diagnostic` that can answer the question 'was there an error?' in O(1).
-      struct TestSingleQuotes {}
+      struct TestSingleStraightQuotes {}
       
       /// A set of `Diagnostic` that can answer the question “was there an error?” in O(1).
-      struct TestDoubleQuotes {}
+      struct TestDoubleSmartQuotes {}
+      
+      /// A set of `Diagnostic` that can answer the question "was there an error?" in O(1).
+      struct TestDoubleStraightQuotes {}
       
       /// A set of `Diagnostic` that can answer the question “was there 
       /// an error?” in O(1).
-      struct TestTwoLinesDoubleQuotes {}
+      struct TestTwoLinesDoubleSmartQuotes {}
+      
+      /// A set of `Diagnostic` that can answer the question "was there
+      /// an error?" in O(1).
+      struct TestTwoLinesDoubleStraightQuotes {}
       """
     )
   }


### PR DESCRIPTION
Resolve #669 

When `SentenceTerminator` is present between `OpenQuote` and `CloseQuote`, changed the filtering logic to ignore it and prevent it from being recognized as a new sentence.