### PR TITLE
Renamed plugin configuration parameter

### DIFF
--- a/Plugins/FormatPlugin/plugin.swift
+++ b/Plugins/FormatPlugin/plugin.swift
@@ -40,7 +40,7 @@ extension FormatPlugin: CommandPlugin {
     let targetNames = argExtractor.extractOption(named: "target")
     let targetsToFormat = targetNames.isEmpty ? context.package.targets : try context.package.targets(named: targetNames)
     
-    let configurationFilePath = argExtractor.extractOption(named: "configuration").first
+    let configurationFilePath = argExtractor.extractOption(named: "swift-format-configuration").first
     
     let sourceCodeTargets = targetsToFormat.compactMap{ $0 as? SourceModuleTarget }
     
@@ -60,7 +60,7 @@ extension FormatPlugin: XcodeCommandPlugin {
     let swiftFormatTool = try context.tool(named: "swift-format")
     
     var argExtractor = ArgumentExtractor(arguments)
-    let configurationFilePath = argExtractor.extractOption(named: "configuration").first
+    let configurationFilePath = argExtractor.extractOption(named: "swift-format-configuration").first
     
     try format(
       tool: swiftFormatTool,

--- a/Plugins/LintPlugin/plugin.swift
+++ b/Plugins/LintPlugin/plugin.swift
@@ -41,7 +41,7 @@ extension LintPlugin: CommandPlugin {
     let targetNames = argExtractor.extractOption(named: "target")
     
     let targetsToFormat = targetNames.isEmpty ? context.package.targets : try context.package.targets(named: targetNames)
-    let configurationFilePath = argExtractor.extractOption(named: "configuration").first
+    let configurationFilePath = argExtractor.extractOption(named: "swift-format-configuration").first
     
     let sourceCodeTargets = targetsToFormat.compactMap { $0 as? SourceModuleTarget }
     
@@ -60,7 +60,7 @@ extension LintPlugin: XcodeCommandPlugin {
   func performCommand(context: XcodeProjectPlugin.XcodePluginContext, arguments: [String]) throws {
     let swiftFormatTool = try context.tool(named: "swift-format")
     var argExtractor = ArgumentExtractor(arguments)
-    let configurationFilePath = argExtractor.extractOption(named: "configuration").first
+    let configurationFilePath = argExtractor.extractOption(named: "swift-format-configuration").first
     
     try lint(
       tool: swiftFormatTool,


### PR DESCRIPTION
As trivial as this is, this change is to prevent a conflict with running the plugin with the `--configuration` parameter which is recognised and parsed by the Swift Package Manager and expects to be either `debug` or `release`.

The replacement of `--swift-format-configuration` is verbose, but other choices looked too ambiguous or confusing whereas this is at least clear as to what the parameter is doing.

resolves  #668 
