### PR TITLE
Package plugin cannot be used if dependency versions are unstable

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -163,7 +163,7 @@ var dependencies: [Package.Dependency] {
     return [
       .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.2"),
       .package(url: "https://github.com/apple/swift-markdown.git", from: "0.2.0"),
-      .package(url: "https://github.com/apple/swift-syntax.git", branch: "main"),
+      .package(url: "https://github.com/apple/swift-syntax.git", "510.0.0"..<"511.0.0"),
     ]
   }
 }


### PR DESCRIPTION
## WHY

- Currently version 510.0.0 cannot be used by package command plugin.  #447  #449
  - `Resolve Packages` command is failed.

```
Showing Recent Messages
Failed to resolve dependencies Dependencies could not be resolved because 'MyApp' depends on 'swift-format' 510.0.0..<511.0.0.
'swift-format' >= 510.0.0 cannot be used because no versions of 'swift-format' match the requirement 510.0.1..<511.0.0 and package 'swift-format' is required using a stable-version but 'swift-format' depends on an unstable-version package 'swift-syntax'.
```

- swift-format depends on unstable version (branch: `main`) of swift-syntax.
  - I would like to see dependencies in the stable version if it is not during development. What do you think?

## HOW

- Use stable version of apple-syntax
  - The patch version is set to go up automatically.
