### PR TITLE
[5.10] Add fixes that were present in 509.0.0 but not release/5.10

### DIFF
--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -82,7 +82,7 @@ top-level keys and values:
 *  `spacesAroundRangeFormationOperators` _(boolean)_: Determines whether whitespace should be forced
    before and after the range formation operators `...` and `..<`.
 
-*  `multilineCollectionTrailingCommas` _(boolean)_: Determines whether multi-line collections should have trailing commas.
+*  `multiElementCollectionTrailingCommas` _(boolean)_: Determines whether multi-element collection literals should have trailing commas.
     Defaults to `true`.
 
 > TODO: Add support for enabling/disabling specific syntax transformations in

--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -82,6 +82,9 @@ top-level keys and values:
 *  `spacesAroundRangeFormationOperators` _(boolean)_: Determines whether whitespace should be forced
    before and after the range formation operators `...` and `..<`.
 
+*  `multilineCollectionTrailingCommas` _(boolean)_: Determines whether multi-line collections should have trailing commas.
+    Defaults to `true`.
+
 > TODO: Add support for enabling/disabling specific syntax transformations in
 > the pipeline.
 

--- a/Package.swift
+++ b/Package.swift
@@ -154,7 +154,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     ),
     .package(
       url: "https://github.com/apple/swift-syntax.git",
-      branch: "main"
+      branch: "release/5.10"
     ),
   ]
 } else {

--- a/Sources/SwiftFormat/API/Configuration+Default.swift
+++ b/Sources/SwiftFormat/API/Configuration+Default.swift
@@ -37,5 +37,6 @@ extension Configuration {
     self.indentSwitchCaseLabels = false
     self.spacesAroundRangeFormationOperators = false
     self.noAssignmentInExpressions = NoAssignmentInExpressionsConfiguration()
+    self.multilineCollectionTrailingCommas = true
   }
 }

--- a/Sources/SwiftFormat/API/Configuration+Default.swift
+++ b/Sources/SwiftFormat/API/Configuration+Default.swift
@@ -37,6 +37,6 @@ extension Configuration {
     self.indentSwitchCaseLabels = false
     self.spacesAroundRangeFormationOperators = false
     self.noAssignmentInExpressions = NoAssignmentInExpressionsConfiguration()
-    self.multilineCollectionTrailingCommas = true
+    self.multiElementCollectionTrailingCommas = true
   }
 }

--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -42,7 +42,7 @@ public struct Configuration: Codable, Equatable {
     case rules
     case spacesAroundRangeFormationOperators
     case noAssignmentInExpressions
-    case multilineCollectionTrailingCommas
+    case multiElementCollectionTrailingCommas
   }
 
   /// A dictionary containing the default enabled/disabled states of rules, keyed by the rules'
@@ -163,8 +163,8 @@ public struct Configuration: Codable, Equatable {
   /// Contains exceptions for the `NoAssignmentInExpressions` rule.
   public var noAssignmentInExpressions: NoAssignmentInExpressionsConfiguration
 
-  /// Determines whether multi-line list initializers should have trailing commas.
-  public var multilineCollectionTrailingCommas: Bool
+  /// Determines whether multi-element collection literals should have trailing commas.
+  public var multiElementCollectionTrailingCommas: Bool
 
   /// Constructs a Configuration by loading it from a configuration file.
   public init(contentsOf url: URL) throws {
@@ -243,10 +243,10 @@ public struct Configuration: Codable, Equatable {
       try container.decodeIfPresent(
         NoAssignmentInExpressionsConfiguration.self, forKey: .noAssignmentInExpressions)
       ?? defaults.noAssignmentInExpressions
-    self.multilineCollectionTrailingCommas =
+    self.multiElementCollectionTrailingCommas =
       try container.decodeIfPresent(
-        Bool.self, forKey: .multilineCollectionTrailingCommas)
-    ?? defaults.multilineCollectionTrailingCommas
+        Bool.self, forKey: .multiElementCollectionTrailingCommas)
+    ?? defaults.multiElementCollectionTrailingCommas
 
     // If the `rules` key is not present at all, default it to the built-in set
     // so that the behavior is the same as if the configuration had been
@@ -279,7 +279,7 @@ public struct Configuration: Codable, Equatable {
     try container.encode(fileScopedDeclarationPrivacy, forKey: .fileScopedDeclarationPrivacy)
     try container.encode(indentSwitchCaseLabels, forKey: .indentSwitchCaseLabels)
     try container.encode(noAssignmentInExpressions, forKey: .noAssignmentInExpressions)
-    try container.encode(multilineCollectionTrailingCommas, forKey: .multilineCollectionTrailingCommas)
+    try container.encode(multiElementCollectionTrailingCommas, forKey: .multiElementCollectionTrailingCommas)
     try container.encode(rules, forKey: .rules)
   }
 

--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -42,6 +42,7 @@ public struct Configuration: Codable, Equatable {
     case rules
     case spacesAroundRangeFormationOperators
     case noAssignmentInExpressions
+    case multilineCollectionTrailingCommas
   }
 
   /// A dictionary containing the default enabled/disabled states of rules, keyed by the rules'
@@ -162,6 +163,9 @@ public struct Configuration: Codable, Equatable {
   /// Contains exceptions for the `NoAssignmentInExpressions` rule.
   public var noAssignmentInExpressions: NoAssignmentInExpressionsConfiguration
 
+  /// Determines whether multi-line list initializers should have trailing commas
+  public var multilineCollectionTrailingCommas: Bool
+
   /// Constructs a Configuration by loading it from a configuration file.
   public init(contentsOf url: URL) throws {
     let data = try Data(contentsOf: url)
@@ -239,6 +243,10 @@ public struct Configuration: Codable, Equatable {
       try container.decodeIfPresent(
         NoAssignmentInExpressionsConfiguration.self, forKey: .noAssignmentInExpressions)
       ?? defaults.noAssignmentInExpressions
+    self.multilineCollectionTrailingCommas =
+      try container.decodeIfPresent(
+        Bool.self, forKey: .multilineCollectionTrailingCommas)
+    ?? defaults.multilineCollectionTrailingCommas
 
     // If the `rules` key is not present at all, default it to the built-in set
     // so that the behavior is the same as if the configuration had been
@@ -271,6 +279,7 @@ public struct Configuration: Codable, Equatable {
     try container.encode(fileScopedDeclarationPrivacy, forKey: .fileScopedDeclarationPrivacy)
     try container.encode(indentSwitchCaseLabels, forKey: .indentSwitchCaseLabels)
     try container.encode(noAssignmentInExpressions, forKey: .noAssignmentInExpressions)
+    try container.encode(multilineCollectionTrailingCommas, forKey: .multilineCollectionTrailingCommas)
     try container.encode(rules, forKey: .rules)
   }
 

--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -163,7 +163,7 @@ public struct Configuration: Codable, Equatable {
   /// Contains exceptions for the `NoAssignmentInExpressions` rule.
   public var noAssignmentInExpressions: NoAssignmentInExpressionsConfiguration
 
-  /// Determines whether multi-line list initializers should have trailing commas
+  /// Determines whether multi-line list initializers should have trailing commas.
   public var multilineCollectionTrailingCommas: Bool
 
   /// Constructs a Configuration by loading it from a configuration file.

--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -163,7 +163,27 @@ public struct Configuration: Codable, Equatable {
   /// Contains exceptions for the `NoAssignmentInExpressions` rule.
   public var noAssignmentInExpressions: NoAssignmentInExpressionsConfiguration
 
-  /// Determines whether multi-element collection literals should have trailing commas.
+  /// Determines if multi-element collection literals should have trailing commas.
+  ///
+  /// When `true` (default), the correct form is:
+  /// ```swift
+  /// let MyCollection = [1, 2,]
+  /// ...
+  /// let MyCollection = [
+  ///   "a": 1,
+  ///   "b": 2,
+  /// ]
+  /// ```
+  ///
+  /// When `false`, the correct form is:
+  /// ```swift
+  /// let MyCollection = [1, 2]
+  /// ...
+  /// let MyCollection = [
+  ///   "a": 1,
+  ///   "b": 2
+  /// ]
+  /// ```
   public var multiElementCollectionTrailingCommas: Bool
 
   /// Constructs a Configuration by loading it from a configuration file.

--- a/Sources/SwiftFormat/Core/ModifierListSyntax+Convenience.swift
+++ b/Sources/SwiftFormat/Core/ModifierListSyntax+Convenience.swift
@@ -17,7 +17,8 @@ extension DeclModifierListSyntax {
   var accessLevelModifier: DeclModifierSyntax? {
     for modifier in self {
       switch modifier.name.tokenKind {
-      case .keyword(.public), .keyword(.private), .keyword(.fileprivate), .keyword(.internal):
+      case .keyword(.public), .keyword(.private), .keyword(.fileprivate), .keyword(.internal),
+          .keyword(.package):
         return modifier
       default:
         continue

--- a/Sources/SwiftFormat/Core/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Core/Pipelines+Generated.swift
@@ -243,7 +243,7 @@ class LintPipeline: SyntaxVisitor {
   }
 
   override func visit(_ node: PatternBindingSyntax) -> SyntaxVisitorContinueKind {
-    visitIfEnabled(AlwaysUseLiteralForEmptyArrayInit.visit, for: node)
+    visitIfEnabled(AlwaysUseLiteralForEmptyCollectionInit.visit, for: node)
     visitIfEnabled(OmitExplicitReturns.visit, for: node)
     visitIfEnabled(UseSingleLinePropertyGetter.visit, for: node)
     return .visitChildren
@@ -357,7 +357,7 @@ extension FormatPipeline {
 
   func rewrite(_ node: Syntax) -> Syntax {
     var node = node
-    node = AlwaysUseLiteralForEmptyArrayInit(context: context).rewrite(node)
+    node = AlwaysUseLiteralForEmptyCollectionInit(context: context).rewrite(node)
     node = DoNotUseSemicolons(context: context).rewrite(node)
     node = FileScopedDeclarationPrivacy(context: context).rewrite(node)
     node = FullyIndirectEnum(context: context).rewrite(node)

--- a/Sources/SwiftFormat/Core/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Core/Pipelines+Generated.swift
@@ -243,6 +243,7 @@ class LintPipeline: SyntaxVisitor {
   }
 
   override func visit(_ node: PatternBindingSyntax) -> SyntaxVisitorContinueKind {
+    visitIfEnabled(AlwaysUseLiteralForEmptyArrayInit.visit, for: node)
     visitIfEnabled(OmitExplicitReturns.visit, for: node)
     visitIfEnabled(UseSingleLinePropertyGetter.visit, for: node)
     return .visitChildren
@@ -356,6 +357,7 @@ extension FormatPipeline {
 
   func rewrite(_ node: Syntax) -> Syntax {
     var node = node
+    node = AlwaysUseLiteralForEmptyArrayInit(context: context).rewrite(node)
     node = DoNotUseSemicolons(context: context).rewrite(node)
     node = FileScopedDeclarationPrivacy(context: context).rewrite(node)
     node = FullyIndirectEnum(context: context).rewrite(node)

--- a/Sources/SwiftFormat/Core/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Core/Pipelines+Generated.swift
@@ -159,6 +159,7 @@ class LintPipeline: SyntaxVisitor {
   }
 
   override func visit(_ node: FunctionParameterSyntax) -> SyntaxVisitorContinueKind {
+    visitIfEnabled(AlwaysUseLiteralForEmptyCollectionInit.visit, for: node)
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
     return .visitChildren
   }

--- a/Sources/SwiftFormat/Core/RuleNameCache+Generated.swift
+++ b/Sources/SwiftFormat/Core/RuleNameCache+Generated.swift
@@ -16,7 +16,7 @@
 @_spi(Testing)
 public let ruleNameCache: [ObjectIdentifier: String] = [
   ObjectIdentifier(AllPublicDeclarationsHaveDocumentation.self): "AllPublicDeclarationsHaveDocumentation",
-  ObjectIdentifier(AlwaysUseLiteralForEmptyArrayInit.self): "AlwaysUseLiteralForEmptyArrayInit",
+  ObjectIdentifier(AlwaysUseLiteralForEmptyCollectionInit.self): "AlwaysUseLiteralForEmptyCollectionInit",
   ObjectIdentifier(AlwaysUseLowerCamelCase.self): "AlwaysUseLowerCamelCase",
   ObjectIdentifier(AmbiguousTrailingClosureOverload.self): "AmbiguousTrailingClosureOverload",
   ObjectIdentifier(BeginDocumentationCommentWithOneLineSummary.self): "BeginDocumentationCommentWithOneLineSummary",

--- a/Sources/SwiftFormat/Core/RuleNameCache+Generated.swift
+++ b/Sources/SwiftFormat/Core/RuleNameCache+Generated.swift
@@ -16,6 +16,7 @@
 @_spi(Testing)
 public let ruleNameCache: [ObjectIdentifier: String] = [
   ObjectIdentifier(AllPublicDeclarationsHaveDocumentation.self): "AllPublicDeclarationsHaveDocumentation",
+  ObjectIdentifier(AlwaysUseLiteralForEmptyArrayInit.self): "AlwaysUseLiteralForEmptyArrayInit",
   ObjectIdentifier(AlwaysUseLowerCamelCase.self): "AlwaysUseLowerCamelCase",
   ObjectIdentifier(AmbiguousTrailingClosureOverload.self): "AmbiguousTrailingClosureOverload",
   ObjectIdentifier(BeginDocumentationCommentWithOneLineSummary.self): "BeginDocumentationCommentWithOneLineSummary",

--- a/Sources/SwiftFormat/Core/RuleRegistry+Generated.swift
+++ b/Sources/SwiftFormat/Core/RuleRegistry+Generated.swift
@@ -15,7 +15,7 @@
 @_spi(Internal) public enum RuleRegistry {
   public static let rules: [String: Bool] = [
     "AllPublicDeclarationsHaveDocumentation": false,
-    "AlwaysUseLiteralForEmptyArrayInit": true,
+    "AlwaysUseLiteralForEmptyArrayInit": false,
     "AlwaysUseLowerCamelCase": true,
     "AmbiguousTrailingClosureOverload": true,
     "BeginDocumentationCommentWithOneLineSummary": false,

--- a/Sources/SwiftFormat/Core/RuleRegistry+Generated.swift
+++ b/Sources/SwiftFormat/Core/RuleRegistry+Generated.swift
@@ -15,7 +15,7 @@
 @_spi(Internal) public enum RuleRegistry {
   public static let rules: [String: Bool] = [
     "AllPublicDeclarationsHaveDocumentation": false,
-    "AlwaysUseLiteralForEmptyArrayInit": false,
+    "AlwaysUseLiteralForEmptyCollectionInit": false,
     "AlwaysUseLowerCamelCase": true,
     "AmbiguousTrailingClosureOverload": true,
     "BeginDocumentationCommentWithOneLineSummary": false,

--- a/Sources/SwiftFormat/Core/RuleRegistry+Generated.swift
+++ b/Sources/SwiftFormat/Core/RuleRegistry+Generated.swift
@@ -15,6 +15,7 @@
 @_spi(Internal) public enum RuleRegistry {
   public static let rules: [String: Bool] = [
     "AllPublicDeclarationsHaveDocumentation": false,
+    "AlwaysUseLiteralForEmptyArrayInit": true,
     "AlwaysUseLowerCamelCase": true,
     "AmbiguousTrailingClosureOverload": true,
     "BeginDocumentationCommentWithOneLineSummary": false,

--- a/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
@@ -557,7 +557,7 @@ public class PrettyPrinter {
       // We never want to add a trailing comma in an initializer so we disable trailing commas on
       // single element collections.
       let shouldHaveTrailingComma =
-        startLineNumber != openCloseBreakCompensatingLineNumber && !isSingleElement && configuration.multilineCollectionTrailingCommas
+        startLineNumber != openCloseBreakCompensatingLineNumber && !isSingleElement && configuration.multiElementCollectionTrailingCommas
       if shouldHaveTrailingComma && !hasTrailingComma {
         diagnose(.addTrailingComma, category: .trailingComma)
       } else if !shouldHaveTrailingComma && hasTrailingComma {

--- a/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
@@ -557,7 +557,7 @@ public class PrettyPrinter {
       // We never want to add a trailing comma in an initializer so we disable trailing commas on
       // single element collections.
       let shouldHaveTrailingComma =
-        startLineNumber != openCloseBreakCompensatingLineNumber && !isSingleElement
+        startLineNumber != openCloseBreakCompensatingLineNumber && !isSingleElement && configuration.multilineCollectionTrailingCommas
       if shouldHaveTrailingComma && !hasTrailingComma {
         diagnose(.addTrailingComma, category: .trailingComma)
       } else if !shouldHaveTrailingComma && hasTrailingComma {

--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -2293,6 +2293,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
   override func visit(_ node: GenericParameterSyntax) -> SyntaxVisitorContinueKind {
     before(node.firstToken(viewMode: .sourceAccurate), tokens: .open)
+    after(node.eachKeyword, tokens: .break)
     after(node.colon, tokens: .break)
     if let trailingComma = node.trailingComma {
       after(trailingComma, tokens: .close, .break(.same))
@@ -2309,6 +2310,28 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     } else {
       after(node.lastToken(viewMode: .sourceAccurate), tokens: .close)
     }
+    return .visitChildren
+  }
+
+  override func visit(_ node: PackElementExprSyntax) -> SyntaxVisitorContinueKind {
+    // `each` cannot be separated from the following token, or it is parsed as an identifier itself.
+    after(node.eachKeyword, tokens: .space)
+    return .visitChildren
+  }
+
+  override func visit(_ node: PackElementTypeSyntax) -> SyntaxVisitorContinueKind {
+    // `each` cannot be separated from the following token, or it is parsed as an identifier itself.
+    after(node.eachKeyword, tokens: .space)
+    return .visitChildren
+  }
+
+  override func visit(_ node: PackExpansionExprSyntax) -> SyntaxVisitorContinueKind {
+    after(node.repeatKeyword, tokens: .break)
+    return .visitChildren
+  }
+
+  override func visit(_ node: PackExpansionTypeSyntax) -> SyntaxVisitorContinueKind {
+    after(node.repeatKeyword, tokens: .break)
     return .visitChildren
   }
 

--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -2511,6 +2511,13 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     return .visitChildren
   }
 
+  override func visit(_ node: DiscardStmtSyntax) -> SyntaxVisitorContinueKind {
+    // The `discard` keyword cannot be separated from the following token or it will be parsed as
+    // an identifier.
+    after(node.discardKeyword, tokens: .space)
+    return .visitChildren
+  }
+
   override func visit(_ node: InheritanceClauseSyntax) -> SyntaxVisitorContinueKind {
     // Normally, the open-break is placed before the open token. In this case, it's intentionally
     // ordered differently so that the inheritance list can start on the current line and only

--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -2504,6 +2504,13 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     return .visitChildren
   }
 
+  override func visit(_ node: ConsumeExprSyntax) -> SyntaxVisitorContinueKind {
+    // The `consume` keyword cannot be separated from the following token or it will be parsed as
+    // an identifier.
+    after(node.consumeKeyword, tokens: .space)
+    return .visitChildren
+  }
+
   override func visit(_ node: InheritanceClauseSyntax) -> SyntaxVisitorContinueKind {
     // Normally, the open-break is placed before the open token. In this case, it's intentionally
     // ordered differently so that the inheritance list can start on the current line and only

--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -2511,6 +2511,13 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     return .visitChildren
   }
 
+  override func visit(_ node: CopyExprSyntax) -> SyntaxVisitorContinueKind {
+    // The `copy` keyword cannot be separated from the following token or it will be parsed as an
+    // identifier.
+    after(node.copyKeyword, tokens: .space)
+    return .visitChildren
+  }
+
   override func visit(_ node: DiscardStmtSyntax) -> SyntaxVisitorContinueKind {
     // The `discard` keyword cannot be separated from the following token or it will be parsed as
     // an identifier.

--- a/Sources/SwiftFormat/Rules/AlwaysUseLiteralForEmptyArrayInit.swift
+++ b/Sources/SwiftFormat/Rules/AlwaysUseLiteralForEmptyArrayInit.swift
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import SwiftSyntax
+import SwiftParser
+
+/// Never use `[<Type>]()` syntax. In call sites that should be replaced with `[]`,
+/// for initializations use explicit type combined with empty array literal `let _: [<Type>] = []`
+/// Static properties of a type that return that type should not include a reference to their type.
+///
+/// Lint:  Non-literal empty array initialization will yield a lint error.
+/// Format: All invalid use sites would be related with empty literal (with or without explicit type annotation).
+@_spi(Rules)
+public final class AlwaysUseLiteralForEmptyArrayInit : SyntaxFormatRule {
+  public override func visit(_ node: PatternBindingSyntax) -> PatternBindingSyntax {
+    guard let initializer = node.initializer else {
+      return node
+    }
+
+    // Check whether the initializer is `[<Type>]()`
+    guard let initCall = initializer.value.as(FunctionCallExprSyntax.self),
+          var arrayLiteral = initCall.calledExpression.as(ArrayExprSyntax.self),
+          initCall.arguments.isEmpty else {
+      return node
+    }
+
+    guard let elementType = getElementType(arrayLiteral) else {
+      return node
+    }
+
+    var replacement = node
+
+    var withFixIt = "[]"
+    if replacement.typeAnnotation == nil {
+      withFixIt = ": [\(elementType)] = []"
+    }
+
+    diagnose(.refactorEmptyArrayInit(replace: "\(initCall)", with: withFixIt), on: initCall)
+
+    if replacement.typeAnnotation == nil {
+      // Drop trailing trivia after pattern because ':' has to appear connected to it.
+      replacement.pattern = node.pattern.with(\.trailingTrivia, [])
+      // Add explicit type annotiation: ': [<Type>]`
+      replacement.typeAnnotation = .init(type: ArrayTypeSyntax(leadingTrivia: .space,
+                                                               element: elementType,
+                                                               trailingTrivia: .space))
+    }
+
+    // Replace initializer call with empty array literal: `[<Type>]()` -> `[]`
+    arrayLiteral.elements = ArrayElementListSyntax.init([])
+    replacement.initializer = initializer.with(\.value, ExprSyntax(arrayLiteral))
+
+    return replacement
+  }
+
+  private func getElementType(_ arrayLiteral: ArrayExprSyntax) -> TypeSyntax? {
+    guard let elementExpr = arrayLiteral.elements.firstAndOnly?.as(ArrayElementSyntax.self) else {
+      return nil
+    }
+
+    var parser = Parser(elementExpr.description)
+    let elementType = TypeSyntax.parse(from: &parser)
+    return elementType.hasError ? nil : elementType
+  }
+}
+
+extension Finding.Message {
+  public static func refactorEmptyArrayInit(replace: String, with: String) -> Finding.Message {
+    "replace '\(replace)' with '\(with)'"
+  }
+}

--- a/Sources/SwiftFormat/Rules/AlwaysUseLiteralForEmptyArrayInit.swift
+++ b/Sources/SwiftFormat/Rules/AlwaysUseLiteralForEmptyArrayInit.swift
@@ -22,6 +22,8 @@ import SwiftParser
 /// Format: All invalid use sites would be related with empty literal (with or without explicit type annotation).
 @_spi(Rules)
 public final class AlwaysUseLiteralForEmptyArrayInit : SyntaxFormatRule {
+  public override class var isOptIn: Bool { return true }
+
   public override func visit(_ node: PatternBindingSyntax) -> PatternBindingSyntax {
     guard let initializer = node.initializer else {
       return node

--- a/Sources/SwiftFormat/Rules/AlwaysUseLiteralForEmptyCollectionInit.swift
+++ b/Sources/SwiftFormat/Rules/AlwaysUseLiteralForEmptyCollectionInit.swift
@@ -21,7 +21,7 @@ import SwiftParser
 /// Lint:  Non-literal empty array initialization will yield a lint error.
 /// Format: All invalid use sites would be related with empty literal (with or without explicit type annotation).
 @_spi(Rules)
-public final class AlwaysUseLiteralForEmptyArrayInit : SyntaxFormatRule {
+public final class AlwaysUseLiteralForEmptyCollectionInit : SyntaxFormatRule {
   public override class var isOptIn: Bool { return true }
 
   public override func visit(_ node: PatternBindingSyntax) -> PatternBindingSyntax {

--- a/Sources/SwiftFormat/Rules/AlwaysUseLiteralForEmptyCollectionInit.swift
+++ b/Sources/SwiftFormat/Rules/AlwaysUseLiteralForEmptyCollectionInit.swift
@@ -166,8 +166,7 @@ public final class AlwaysUseLiteralForEmptyCollectionInit : SyntaxFormatRule {
   }
 
   private func getLiteralType(_ arrayLiteral: ArrayExprSyntax) -> TypeSyntax? {
-    guard let elementExpr = arrayLiteral.elements.firstAndOnly,
-          elementExpr.is(ArrayElementSyntax.self) else {
+    guard arrayLiteral.elements.count == 1 else {
       return nil
     }
 

--- a/Sources/SwiftFormat/Rules/NoAccessLevelOnExtensionDeclaration.swift
+++ b/Sources/SwiftFormat/Rules/NoAccessLevelOnExtensionDeclaration.swift
@@ -32,8 +32,8 @@ public final class NoAccessLevelOnExtensionDeclaration: SyntaxFormatRule {
     var result = node
 
     switch keyword {
-    // Public, private, or fileprivate keywords need to be moved to members
-    case .public, .private, .fileprivate:
+    // Public, private, fileprivate, or package keywords need to be moved to members
+    case .public, .private, .fileprivate, .package:
       // The effective access level of the members of a `private` extension is `fileprivate`, so
       // we have to update the keyword to ensure that the result is correct.
       var accessKeywordToAdd = accessKeyword

--- a/Sources/_SwiftFormatTestSupport/Configuration+Testing.swift
+++ b/Sources/_SwiftFormatTestSupport/Configuration+Testing.swift
@@ -40,7 +40,7 @@ extension Configuration {
     config.indentSwitchCaseLabels = false
     config.spacesAroundRangeFormationOperators = false
     config.noAssignmentInExpressions = NoAssignmentInExpressionsConfiguration()
-    config.multilineCollectionTrailingCommas = true
+    config.multiElementCollectionTrailingCommas = true
     return config
   }
 }

--- a/Sources/_SwiftFormatTestSupport/Configuration+Testing.swift
+++ b/Sources/_SwiftFormatTestSupport/Configuration+Testing.swift
@@ -40,6 +40,7 @@ extension Configuration {
     config.indentSwitchCaseLabels = false
     config.spacesAroundRangeFormationOperators = false
     config.noAssignmentInExpressions = NoAssignmentInExpressionsConfiguration()
+    config.multilineCollectionTrailingCommas = true
     return config
   }
 }

--- a/Tests/SwiftFormatTests/PrettyPrint/AttributeTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/AttributeTests.swift
@@ -356,4 +356,58 @@ final class AttributeTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 32)
   }
+
+  func testMultilineStringLiteralInCustomAttribute() {
+    let input =
+      #"""
+      @CustomAttribute(message: """
+      This is a
+      multiline
+      string
+      """)
+      public func f() {}
+      """#
+
+    let expected =
+      #"""
+      @CustomAttribute(
+        message: """
+          This is a
+          multiline
+          string
+          """)
+      public func f() {}
+
+      """#
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 100)
+  }
+
+  func testMultilineStringLiteralInAvailableAttribute() {
+    let input =
+      #"""
+      @available(*, deprecated, message: """
+      This is a
+      multiline
+      string
+      """)
+      public func f() {}
+      """#
+
+    let expected =
+      #"""
+      @available(
+        *, deprecated,
+        message: """
+          This is a
+          multiline
+          string
+          """
+      )
+      public func f() {}
+
+      """#
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 100)
+  }
 }

--- a/Tests/SwiftFormatTests/PrettyPrint/CommaTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/CommaTests.swift
@@ -1,10 +1,10 @@
 import SwiftFormat
 
 final class CommaTests: PrettyPrintTestCase {
-  func testCommasAbsentEnabled() {
+  func testArrayCommasAbsentEnabled() {
     let input =
       """
-      let MyList = [
+      let MyCollection = [
         1,
         2,
         3
@@ -14,7 +14,7 @@ final class CommaTests: PrettyPrintTestCase {
     
     let expected =
       """
-      let MyList = [
+      let MyCollection = [
         1,
         2,
         3,
@@ -27,10 +27,10 @@ final class CommaTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
   }
   
-  func testCommasAbsentDisabled() {
+  func testArrayCommasAbsentDisabled() {
     let input =
       """
-      let MyList = [
+      let MyCollection = [
         1,
         2,
         3
@@ -40,7 +40,7 @@ final class CommaTests: PrettyPrintTestCase {
     
     let expected =
       """
-      let MyList = [
+      let MyCollection = [
         1,
         2,
         3
@@ -53,10 +53,10 @@ final class CommaTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
   }
   
-  func testCommasPresentEnabled() {
+  func testArrayCommasPresentEnabled() {
     let input =
       """
-      let MyList = [
+      let MyCollection = [
         1,
         2,
         3,
@@ -66,7 +66,7 @@ final class CommaTests: PrettyPrintTestCase {
     
     let expected =
       """
-      let MyList = [
+      let MyCollection = [
         1,
         2,
         3,
@@ -79,10 +79,10 @@ final class CommaTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
   }
   
-  func testCommasPresentDisabled() {
+  func testArrayCommasPresentDisabled() {
     let input =
       """
-      let MyList = [
+      let MyCollection = [
         1,
         2,
         3,
@@ -92,7 +92,7 @@ final class CommaTests: PrettyPrintTestCase {
     
     let expected =
       """
-      let MyList = [
+      let MyCollection = [
         1,
         2,
         3
@@ -105,17 +105,17 @@ final class CommaTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
   }
   
-  func testCommasPresentSingleLineDisabled() {
+  func testArraySingleLineCommasPresentDisabled() {
     let input =
       """
-      let MyList = [1, 2, 3,]
+      let MyCollection = [1, 2, 3,]
       
       """
     
     // no effect expected
     let expected =
       """
-      let MyList = [1, 2, 3]
+      let MyCollection = [1, 2, 3]
       
       """
     
@@ -124,17 +124,161 @@ final class CommaTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: configuration)
   }
   
-  func testCommasPresentSingleLineEnabled() {
+  func testArraySingleLineCommasPresentEnabled() {
     let input =
       """
-      let MyList = [1, 2, 3,]
+      let MyCollection = [1, 2, 3,]
       
       """
     
     // no effect expected
     let expected =
       """
-      let MyList = [1, 2, 3]
+      let MyCollection = [1, 2, 3]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multilineCollectionTrailingCommas = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: configuration)
+  }
+  
+  func testDictionaryCommasAbsentEnabled() {
+    let input =
+      """
+      let MyCollection = [
+        "a": 1,
+        "b": 2,
+        "c": 3
+      ]
+      
+      """
+    
+    let expected =
+      """
+      let MyCollection = [
+        "a": 1,
+        "b": 2,
+        "c": 3,
+      ]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multilineCollectionTrailingCommas = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
+  }
+  
+  func testDictionaryCommasAbsentDisabled() {
+    let input =
+      """
+      let MyCollection = [
+        "a": 1,
+        "b": 2,
+        "c": 3
+      ]
+      
+      """
+    
+    let expected =
+      """
+      let MyCollection = [
+        "a": 1,
+        "b": 2,
+        "c": 3
+      ]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multilineCollectionTrailingCommas = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
+  }
+  
+  func testDictionaryCommasPresentEnabled() {
+    let input =
+      """
+      let MyCollection = [
+        "a": 1,
+        "b": 2,
+        "c": 3,
+      ]
+      
+      """
+    
+    let expected =
+      """
+      let MyCollection = [
+        "a": 1,
+        "b": 2,
+        "c": 3,
+      ]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multilineCollectionTrailingCommas = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
+  }
+  
+  func testDictionaryCommasPresentDisabled() {
+    let input =
+      """
+      let MyCollection = [
+        "a": 1,
+        "b": 2,
+        "c": 3,
+      ]
+      
+      """
+    
+    let expected =
+      """
+      let MyCollection = [
+        "a": 1,
+        "b": 2,
+        "c": 3
+      ]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multilineCollectionTrailingCommas = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
+  }
+  
+  func testDictionarySingleLineCommasPresentDisabled() {
+    let input =
+      """
+      let MyCollection = ["a": 1, "b": 2, "c": 3,]
+      
+      """
+    
+    let expected =
+      """
+      let MyCollection = [
+        "a": 1, "b": 2, "c": 3,
+      ]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multilineCollectionTrailingCommas = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: configuration)
+  }
+  
+  func testDictionarySingleLineCommasPresentEnabled() {
+    let input =
+      """
+      let MyCollection = ["a": 1, "b": 2, "c": 3,]
+      
+      """
+    
+    let expected =
+      """
+      let MyCollection = [
+        "a": 1, "b": 2, "c": 3
+      ]
       
       """
     

--- a/Tests/SwiftFormatTests/PrettyPrint/CommaTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/CommaTests.swift
@@ -1,0 +1,145 @@
+import SwiftFormat
+
+final class CommaTests: PrettyPrintTestCase {
+  func testCommasAbsentEnabled() {
+    let input =
+      """
+      let MyList = [
+        1,
+        2,
+        3
+      ]
+      
+      """
+    
+    let expected =
+      """
+      let MyList = [
+        1,
+        2,
+        3,
+      ]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multilineCollectionTrailingCommas = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
+  }
+  
+  func testCommasAbsentDisabled() {
+    let input =
+      """
+      let MyList = [
+        1,
+        2,
+        3
+      ]
+      
+      """
+    
+    let expected =
+      """
+      let MyList = [
+        1,
+        2,
+        3
+      ]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multilineCollectionTrailingCommas = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
+  }
+  
+  func testCommasPresentEnabled() {
+    let input =
+      """
+      let MyList = [
+        1,
+        2,
+        3,
+      ]
+      
+      """
+    
+    let expected =
+      """
+      let MyList = [
+        1,
+        2,
+        3,
+      ]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multilineCollectionTrailingCommas = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
+  }
+  
+  func testCommasPresentDisabled() {
+    let input =
+      """
+      let MyList = [
+        1,
+        2,
+        3,
+      ]
+      
+      """
+    
+    let expected =
+      """
+      let MyList = [
+        1,
+        2,
+        3
+      ]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multilineCollectionTrailingCommas = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
+  }
+  
+  func testCommasPresentSingleLineDisabled() {
+    let input =
+      """
+      let MyList = [1, 2, 3,]
+      
+      """
+    
+    // no effect expected
+    let expected =
+      """
+      let MyList = [1, 2, 3]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multilineCollectionTrailingCommas = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: configuration)
+  }
+  
+  func testCommasPresentSingleLineEnabled() {
+    let input =
+      """
+      let MyList = [1, 2, 3,]
+      
+      """
+    
+    // no effect expected
+    let expected =
+      """
+      let MyList = [1, 2, 3]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multilineCollectionTrailingCommas = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: configuration)
+  }
+}

--- a/Tests/SwiftFormatTests/PrettyPrint/CommaTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/CommaTests.swift
@@ -23,7 +23,7 @@ final class CommaTests: PrettyPrintTestCase {
       """
     
     var configuration = Configuration.forTesting
-    configuration.multilineCollectionTrailingCommas = true
+    configuration.multiElementCollectionTrailingCommas = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
   }
   
@@ -49,7 +49,7 @@ final class CommaTests: PrettyPrintTestCase {
       """
     
     var configuration = Configuration.forTesting
-    configuration.multilineCollectionTrailingCommas = false
+    configuration.multiElementCollectionTrailingCommas = false
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
   }
   
@@ -75,7 +75,7 @@ final class CommaTests: PrettyPrintTestCase {
       """
     
     var configuration = Configuration.forTesting
-    configuration.multilineCollectionTrailingCommas = true
+    configuration.multiElementCollectionTrailingCommas = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
   }
   
@@ -101,7 +101,7 @@ final class CommaTests: PrettyPrintTestCase {
       """
     
     var configuration = Configuration.forTesting
-    configuration.multilineCollectionTrailingCommas = false
+    configuration.multiElementCollectionTrailingCommas = false
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
   }
   
@@ -120,7 +120,7 @@ final class CommaTests: PrettyPrintTestCase {
       """
     
     var configuration = Configuration.forTesting
-    configuration.multilineCollectionTrailingCommas = true
+    configuration.multiElementCollectionTrailingCommas = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: configuration)
   }
   
@@ -139,7 +139,7 @@ final class CommaTests: PrettyPrintTestCase {
       """
     
     var configuration = Configuration.forTesting
-    configuration.multilineCollectionTrailingCommas = false
+    configuration.multiElementCollectionTrailingCommas = false
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: configuration)
   }
   
@@ -165,7 +165,7 @@ final class CommaTests: PrettyPrintTestCase {
       """
     
     var configuration = Configuration.forTesting
-    configuration.multilineCollectionTrailingCommas = true
+    configuration.multiElementCollectionTrailingCommas = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
   }
   
@@ -191,7 +191,7 @@ final class CommaTests: PrettyPrintTestCase {
       """
     
     var configuration = Configuration.forTesting
-    configuration.multilineCollectionTrailingCommas = false
+    configuration.multiElementCollectionTrailingCommas = false
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
   }
   
@@ -217,7 +217,7 @@ final class CommaTests: PrettyPrintTestCase {
       """
     
     var configuration = Configuration.forTesting
-    configuration.multilineCollectionTrailingCommas = true
+    configuration.multiElementCollectionTrailingCommas = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
   }
   
@@ -243,7 +243,7 @@ final class CommaTests: PrettyPrintTestCase {
       """
     
     var configuration = Configuration.forTesting
-    configuration.multilineCollectionTrailingCommas = false
+    configuration.multiElementCollectionTrailingCommas = false
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
   }
   
@@ -263,7 +263,7 @@ final class CommaTests: PrettyPrintTestCase {
       """
     
     var configuration = Configuration.forTesting
-    configuration.multilineCollectionTrailingCommas = true
+    configuration.multiElementCollectionTrailingCommas = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: configuration)
   }
   
@@ -283,7 +283,7 @@ final class CommaTests: PrettyPrintTestCase {
       """
     
     var configuration = Configuration.forTesting
-    configuration.multilineCollectionTrailingCommas = false
+    configuration.multiElementCollectionTrailingCommas = false
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: configuration)
   }
 }

--- a/Tests/SwiftFormatTests/PrettyPrint/ConsumeExprTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/ConsumeExprTests.swift
@@ -1,0 +1,14 @@
+final class ConsumeExprTests: PrettyPrintTestCase {
+  func testConsume() {
+    assertPrettyPrintEqual(
+      input: """
+        let x = consume y
+        """,
+      expected: """
+        let x =
+          consume y
+
+        """,
+      linelength: 16)
+  }
+}

--- a/Tests/SwiftFormatTests/PrettyPrint/CopyExprSyntax.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/CopyExprSyntax.swift
@@ -1,0 +1,14 @@
+final class CopyExprTests: PrettyPrintTestCase {
+  func testCopy() {
+    assertPrettyPrintEqual(
+      input: """
+        let x = copy y
+        """,
+      expected: """
+        let x =
+          copy y
+
+        """,
+      linelength: 13)
+  }
+}

--- a/Tests/SwiftFormatTests/PrettyPrint/DiscardStmtTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/DiscardStmtTests.swift
@@ -1,0 +1,13 @@
+final class DiscardStmtTests: PrettyPrintTestCase {
+  func testDiscard() {
+    assertPrettyPrintEqual(
+      input: """
+        discard self
+        """,
+      expected: """
+        discard self
+
+        """,
+      linelength: 9)
+  }
+}

--- a/Tests/SwiftFormatTests/PrettyPrint/ParameterPackTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/ParameterPackTests.swift
@@ -1,0 +1,46 @@
+final class ParameterPackTests: PrettyPrintTestCase {
+  func testGenericPackArgument() {
+    assertPrettyPrintEqual(
+      input: """
+        func someFunction<each P>() {}
+        struct SomeStruct<each P> {}
+        """,
+      expected: """
+        func someFunction<
+          each P
+        >() {}
+        struct SomeStruct<
+          each P
+        > {}
+
+        """,
+      linelength: 22)
+  }
+
+  func testPackExpansionsAndElements() {
+    assertPrettyPrintEqual(
+      input: """
+        repeat checkNilness(of: each value)
+        """,
+      expected: """
+        repeat checkNilness(
+          of: each value)
+
+        """,
+      linelength: 25)
+
+    assertPrettyPrintEqual(
+      input: """
+        repeat f(of: each v)
+        """,
+      expected: """
+        repeat
+          f(
+            of:
+              each v
+          )
+
+        """,
+      linelength: 7)
+  }
+}

--- a/Tests/SwiftFormatTests/Rules/AlwaysUseLiteralForEmptyArrayInitTests.swift
+++ b/Tests/SwiftFormatTests/Rules/AlwaysUseLiteralForEmptyArrayInitTests.swift
@@ -1,0 +1,48 @@
+import _SwiftFormatTestSupport
+
+@_spi(Rules) import SwiftFormat
+
+final class AlwaysUseLiteralForEmptyArrayInitTests: LintOrFormatRuleTestCase {
+  func testPatternBindings() {
+    assertFormatting(
+      AlwaysUseLiteralForEmptyArrayInit.self,
+      input: """
+        public struct Test {
+          var value1 = 1️⃣[Int]()
+
+          func test(v: [Double] = [Double]()) {
+            let _ = 2️⃣[String]()
+          }
+        }
+
+        var _: [Category<Int>] = 3️⃣[Category<Int>]()
+        let _ = 4️⃣[(Int, Array<String>)]()
+        let _: [(String, Int, Float)] = 5️⃣[(String, Int, Float)]()
+
+        let _ = [(1, 2, String)]()
+        """,
+      expected: """
+        public struct Test {
+          var value1: [Int] = []
+
+          func test(v: [Double] = [Double]()) {
+            let _: [String] = []
+          }
+        }
+
+        var _: [Category<Int>] = []
+        let _: [(Int, Array<String>)] = []
+        let _: [(String, Int, Float)] = []
+
+        let _ = [(1, 2, String)]()
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "replace '[Int]()' with ': [Int] = []'"),
+        FindingSpec("2️⃣", message: "replace '[String]()' with ': [String] = []'"),
+        FindingSpec("3️⃣", message: "replace '[Category<Int>]()' with '[]'"),
+        FindingSpec("4️⃣", message: "replace '[(Int, Array<String>)]()' with ': [(Int, Array<String>)] = []'"),
+        FindingSpec("5️⃣", message: "replace '[(String, Int, Float)]()' with '[]'"),
+      ]
+    )
+  }
+}

--- a/Tests/SwiftFormatTests/Rules/AlwaysUseLiteralForEmptyArrayInitTests.swift
+++ b/Tests/SwiftFormatTests/Rules/AlwaysUseLiteralForEmptyArrayInitTests.swift
@@ -3,7 +3,7 @@ import _SwiftFormatTestSupport
 @_spi(Rules) import SwiftFormat
 
 final class AlwaysUseLiteralForEmptyArrayInitTests: LintOrFormatRuleTestCase {
-  func testPatternBindings() {
+  func testArray() {
     assertFormatting(
       AlwaysUseLiteralForEmptyArrayInit.self,
       input: """
@@ -42,6 +42,49 @@ final class AlwaysUseLiteralForEmptyArrayInitTests: LintOrFormatRuleTestCase {
         FindingSpec("3️⃣", message: "replace '[Category<Int>]()' with '[]'"),
         FindingSpec("4️⃣", message: "replace '[(Int, Array<String>)]()' with ': [(Int, Array<String>)] = []'"),
         FindingSpec("5️⃣", message: "replace '[(String, Int, Float)]()' with '[]'"),
+      ]
+    )
+  }
+
+  func testDictionary() {
+    assertFormatting(
+      AlwaysUseLiteralForEmptyArrayInit.self,
+      input: """
+        public struct Test {
+          var value1 = 1️⃣[Int: String]()
+
+          func test(v: [Double: Int] = [Double: Int]()) {
+            let _ = 2️⃣[String: Int]()
+          }
+        }
+
+        var _: [Category<Int>: String] = 3️⃣[Category<Int>: String]()
+        let _ = 4️⃣[(Int, Array<String>): Int]()
+        let _: [String: (String, Int, Float)] = 5️⃣[String: (String, Int, Float)]()
+
+        let _ = [String: (1, 2, String)]()
+        """,
+      expected: """
+        public struct Test {
+          var value1: [Int: String] = [:]
+
+          func test(v: [Double: Int] = [Double: Int]()) {
+            let _: [String: Int] = [:]
+          }
+        }
+
+        var _: [Category<Int>: String] = [:]
+        let _: [(Int, Array<String>): Int] = [:]
+        let _: [String: (String, Int, Float)] = [:]
+
+        let _ = [String: (1, 2, String)]()
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "replace '[Int: String]()' with ': [Int: String] = [:]'"),
+        FindingSpec("2️⃣", message: "replace '[String: Int]()' with ': [String: Int] = [:]'"),
+        FindingSpec("3️⃣", message: "replace '[Category<Int>: String]()' with '[:]'"),
+        FindingSpec("4️⃣", message: "replace '[(Int, Array<String>): Int]()' with ': [(Int, Array<String>): Int] = [:]'"),
+        FindingSpec("5️⃣", message: "replace '[String: (String, Int, Float)]()' with '[:]'"),
       ]
     )
   }

--- a/Tests/SwiftFormatTests/Rules/AlwaysUseLiteralForEmptyCollectionInitTests.swift
+++ b/Tests/SwiftFormatTests/Rules/AlwaysUseLiteralForEmptyCollectionInitTests.swift
@@ -25,6 +25,20 @@ final class AlwaysUseLiteralForEmptyCollectionInitTests: LintOrFormatRuleTestCas
           subscript(_: [A] = 7️⃣[A](), x: [(Int, B)] = 8️⃣[(Int, B)]()) {
           }
         }
+
+        // All of the examples in this block could be re-written to use leading-dot syntax: `.init(...)`
+        do {
+          let _ = [Int](repeating: 0, count: 10)
+          let _: [Int] = [Int](repeating: 0, count: 10)
+
+          func testDefault(_ x: [String] = [String](repeating: "a", count: 42)) {
+          }
+
+          class TestSubscript {
+            subscript(_: Int = 42, x: [(Int, B)] = [(Int, B)](repeating: (0, B()), count: 1)) {
+            }
+          }
+        }
         """,
       expected: """
         public struct Test {
@@ -43,6 +57,20 @@ final class AlwaysUseLiteralForEmptyCollectionInitTests: LintOrFormatRuleTestCas
 
         class TestSubscript {
           subscript(_: [A] = [], x: [(Int, B)] = []) {
+          }
+        }
+
+        // All of the examples in this block could be re-written to use leading-dot syntax: `.init(...)`
+        do {
+          let _ = [Int](repeating: 0, count: 10)
+          let _: [Int] = [Int](repeating: 0, count: 10)
+
+          func testDefault(_ x: [String] = [String](repeating: "a", count: 42)) {
+          }
+
+          class TestSubscript {
+            subscript(_: Int = 42, x: [(Int, B)] = [(Int, B)](repeating: (0, B()), count: 1)) {
+            }
           }
         }
         """,
@@ -81,6 +109,20 @@ final class AlwaysUseLiteralForEmptyCollectionInitTests: LintOrFormatRuleTestCas
           subscript(_: [A: Int] = 7️⃣[A: Int](), x: [(Int, B): String] = 8️⃣[(Int, B): String]()) {
           }
         }
+
+        // All of the examples in this block could be re-written to use leading-dot syntax: `.init(...)`
+        do {
+          let _ = [String: Int](minimumCapacity: 42)
+          let _: [String: Int] = [String: Int](minimumCapacity: 42)
+
+          func testDefault(_ x: [Int: String] = [String](minimumCapacity: 1)) {
+          }
+
+          class TestSubscript {
+            subscript(_: Int = 42, x: [String: (Int, B)] = [String: (Int, B)](minimumCapacity: 2)) {
+            }
+          }
+        }
         """,
       expected: """
         public struct Test {
@@ -99,6 +141,20 @@ final class AlwaysUseLiteralForEmptyCollectionInitTests: LintOrFormatRuleTestCas
 
         class TestSubscript {
           subscript(_: [A: Int] = [:], x: [(Int, B): String] = [:]) {
+          }
+        }
+
+        // All of the examples in this block could be re-written to use leading-dot syntax: `.init(...)`
+        do {
+          let _ = [String: Int](minimumCapacity: 42)
+          let _: [String: Int] = [String: Int](minimumCapacity: 42)
+
+          func testDefault(_ x: [Int: String] = [String](minimumCapacity: 1)) {
+          }
+
+          class TestSubscript {
+            subscript(_: Int = 42, x: [String: (Int, B)] = [String: (Int, B)](minimumCapacity: 2)) {
+            }
           }
         }
         """,

--- a/Tests/SwiftFormatTests/Rules/AlwaysUseLiteralForEmptyCollectionInitTests.swift
+++ b/Tests/SwiftFormatTests/Rules/AlwaysUseLiteralForEmptyCollectionInitTests.swift
@@ -10,22 +10,27 @@ final class AlwaysUseLiteralForEmptyCollectionInitTests: LintOrFormatRuleTestCas
         public struct Test {
           var value1 = 1️⃣[Int]()
 
-          func test(v: [Double] = [Double]()) {
-            let _ = 2️⃣[String]()
+          func test(v: [Double] = 2️⃣[Double]()) {
+            let _ = 3️⃣[String]()
           }
         }
 
-        var _: [Category<Int>] = 3️⃣[Category<Int>]()
-        let _ = 4️⃣[(Int, Array<String>)]()
-        let _: [(String, Int, Float)] = 5️⃣[(String, Int, Float)]()
+        var _: [Category<Int>] = 4️⃣[Category<Int>]()
+        let _ = 5️⃣[(Int, Array<String>)]()
+        let _: [(String, Int, Float)] = 6️⃣[(String, Int, Float)]()
 
         let _ = [(1, 2, String)]()
+
+        class TestSubscript {
+          subscript(_: [A] = 7️⃣[A](), x: [(Int, B)] = 8️⃣[(Int, B)]()) {
+          }
+        }
         """,
       expected: """
         public struct Test {
           var value1: [Int] = []
 
-          func test(v: [Double] = [Double]()) {
+          func test(v: [Double] = []) {
             let _: [String] = []
           }
         }
@@ -35,13 +40,21 @@ final class AlwaysUseLiteralForEmptyCollectionInitTests: LintOrFormatRuleTestCas
         let _: [(String, Int, Float)] = []
 
         let _ = [(1, 2, String)]()
+
+        class TestSubscript {
+          subscript(_: [A] = [], x: [(Int, B)] = []) {
+          }
+        }
         """,
       findings: [
         FindingSpec("1️⃣", message: "replace '[Int]()' with ': [Int] = []'"),
-        FindingSpec("2️⃣", message: "replace '[String]()' with ': [String] = []'"),
-        FindingSpec("3️⃣", message: "replace '[Category<Int>]()' with '[]'"),
-        FindingSpec("4️⃣", message: "replace '[(Int, Array<String>)]()' with ': [(Int, Array<String>)] = []'"),
-        FindingSpec("5️⃣", message: "replace '[(String, Int, Float)]()' with '[]'"),
+        FindingSpec("2️⃣", message: "replace '[Double]()' with '[]'"),
+        FindingSpec("3️⃣", message: "replace '[String]()' with ': [String] = []'"),
+        FindingSpec("4️⃣", message: "replace '[Category<Int>]()' with '[]'"),
+        FindingSpec("5️⃣", message: "replace '[(Int, Array<String>)]()' with ': [(Int, Array<String>)] = []'"),
+        FindingSpec("6️⃣", message: "replace '[(String, Int, Float)]()' with '[]'"),
+        FindingSpec("7️⃣", message: "replace '[A]()' with '[]'"),
+        FindingSpec("8️⃣", message: "replace '[(Int, B)]()' with '[]'"),
       ]
     )
   }
@@ -53,22 +66,27 @@ final class AlwaysUseLiteralForEmptyCollectionInitTests: LintOrFormatRuleTestCas
         public struct Test {
           var value1 = 1️⃣[Int: String]()
 
-          func test(v: [Double: Int] = [Double: Int]()) {
-            let _ = 2️⃣[String: Int]()
+          func test(v: [Double: Int] = 2️⃣[Double: Int]()) {
+            let _ = 3️⃣[String: Int]()
           }
         }
 
-        var _: [Category<Int>: String] = 3️⃣[Category<Int>: String]()
-        let _ = 4️⃣[(Int, Array<String>): Int]()
-        let _: [String: (String, Int, Float)] = 5️⃣[String: (String, Int, Float)]()
+        var _: [Category<Int>: String] = 4️⃣[Category<Int>: String]()
+        let _ = 5️⃣[(Int, Array<String>): Int]()
+        let _: [String: (String, Int, Float)] = 6️⃣[String: (String, Int, Float)]()
 
         let _ = [String: (1, 2, String)]()
+
+        class TestSubscript {
+          subscript(_: [A: Int] = 7️⃣[A: Int](), x: [(Int, B): String] = 8️⃣[(Int, B): String]()) {
+          }
+        }
         """,
       expected: """
         public struct Test {
           var value1: [Int: String] = [:]
 
-          func test(v: [Double: Int] = [Double: Int]()) {
+          func test(v: [Double: Int] = [:]) {
             let _: [String: Int] = [:]
           }
         }
@@ -78,13 +96,21 @@ final class AlwaysUseLiteralForEmptyCollectionInitTests: LintOrFormatRuleTestCas
         let _: [String: (String, Int, Float)] = [:]
 
         let _ = [String: (1, 2, String)]()
+
+        class TestSubscript {
+          subscript(_: [A: Int] = [:], x: [(Int, B): String] = [:]) {
+          }
+        }
         """,
       findings: [
         FindingSpec("1️⃣", message: "replace '[Int: String]()' with ': [Int: String] = [:]'"),
-        FindingSpec("2️⃣", message: "replace '[String: Int]()' with ': [String: Int] = [:]'"),
-        FindingSpec("3️⃣", message: "replace '[Category<Int>: String]()' with '[:]'"),
-        FindingSpec("4️⃣", message: "replace '[(Int, Array<String>): Int]()' with ': [(Int, Array<String>): Int] = [:]'"),
-        FindingSpec("5️⃣", message: "replace '[String: (String, Int, Float)]()' with '[:]'"),
+        FindingSpec("2️⃣", message: "replace '[Double: Int]()' with '[:]'"),
+        FindingSpec("3️⃣", message: "replace '[String: Int]()' with ': [String: Int] = [:]'"),
+        FindingSpec("4️⃣", message: "replace '[Category<Int>: String]()' with '[:]'"),
+        FindingSpec("5️⃣", message: "replace '[(Int, Array<String>): Int]()' with ': [(Int, Array<String>): Int] = [:]'"),
+        FindingSpec("6️⃣", message: "replace '[String: (String, Int, Float)]()' with '[:]'"),
+        FindingSpec("7️⃣", message: "replace '[A: Int]()' with '[:]'"),
+        FindingSpec("8️⃣", message: "replace '[(Int, B): String]()' with '[:]'"),
       ]
     )
   }

--- a/Tests/SwiftFormatTests/Rules/AlwaysUseLiteralForEmptyCollectionInitTests.swift
+++ b/Tests/SwiftFormatTests/Rules/AlwaysUseLiteralForEmptyCollectionInitTests.swift
@@ -2,10 +2,10 @@ import _SwiftFormatTestSupport
 
 @_spi(Rules) import SwiftFormat
 
-final class AlwaysUseLiteralForEmptyArrayInitTests: LintOrFormatRuleTestCase {
+final class AlwaysUseLiteralForEmptyCollectionInitTests: LintOrFormatRuleTestCase {
   func testArray() {
     assertFormatting(
-      AlwaysUseLiteralForEmptyArrayInit.self,
+      AlwaysUseLiteralForEmptyCollectionInit.self,
       input: """
         public struct Test {
           var value1 = 1️⃣[Int]()
@@ -48,7 +48,7 @@ final class AlwaysUseLiteralForEmptyArrayInitTests: LintOrFormatRuleTestCase {
 
   func testDictionary() {
     assertFormatting(
-      AlwaysUseLiteralForEmptyArrayInit.self,
+      AlwaysUseLiteralForEmptyCollectionInit.self,
       input: """
         public struct Test {
           var value1 = 1️⃣[Int: String]()

--- a/Tests/SwiftFormatTests/Rules/NoAccessLevelOnExtensionDeclarationTests.swift
+++ b/Tests/SwiftFormatTests/Rules/NoAccessLevelOnExtensionDeclarationTests.swift
@@ -128,6 +128,31 @@ final class NoAccessLevelOnExtensionDeclarationTests: LintOrFormatRuleTestCase {
     )
   }
 
+  func testPackageAccessLevel() {
+    assertFormatting(
+      NoAccessLevelOnExtensionDeclaration.self,
+      input: """
+        1️⃣package extension Foo {
+          2️⃣func f() {}
+        }
+        """,
+      expected: """
+        extension Foo {
+          package func f() {}
+        }
+        """,
+      findings: [
+        FindingSpec(
+          "1️⃣",
+          message: "move this 'package' access modifier to precede each member inside this extension",
+          notes: [
+            NoteSpec("2️⃣", message: "add 'package' access modifier to this declaration"),
+          ]
+        ),
+      ]
+    )
+  }
+
   func testPrivateIsEffectivelyFileprivate() {
     assertFormatting(
       NoAccessLevelOnExtensionDeclaration.self,

--- a/Tests/SwiftFormatTests/Rules/UseShorthandTypeNamesTests.swift
+++ b/Tests/SwiftFormatTests/Rules/UseShorthandTypeNamesTests.swift
@@ -692,4 +692,44 @@ final class UseShorthandTypeNamesTests: LintOrFormatRuleTestCase {
       ]
     )
   }
+
+  func testAttributedTypesInOptionalsAreParenthesized() {
+    // If we need to insert parentheses, verify that we do, but also verify that we don't insert
+    // them unnecessarily.
+    assertFormatting(
+      UseShorthandTypeNames.self,
+      input: """
+        var x: 1️⃣Optional<consuming P> = S()
+        var y: 2️⃣Optional<@Sendable (Int) -> Void> = S()
+        var z = [3️⃣Optional<consuming P>]([S()])
+        var a = [4️⃣Optional<@Sendable (Int) -> Void>]([S()])
+
+        var x: 5️⃣Optional<(consuming P)> = S()
+        var y: 6️⃣Optional<(@Sendable (Int) -> Void)> = S()
+        var z = [7️⃣Optional<(consuming P)>]([S()])
+        var a = [8️⃣Optional<(@Sendable (Int) -> Void)>]([S()])
+        """,
+      expected: """
+        var x: (consuming P)? = S()
+        var y: (@Sendable (Int) -> Void)? = S()
+        var z = [(consuming P)?]([S()])
+        var a = [(@Sendable (Int) -> Void)?]([S()])
+
+        var x: (consuming P)? = S()
+        var y: (@Sendable (Int) -> Void)? = S()
+        var z = [(consuming P)?]([S()])
+        var a = [(@Sendable (Int) -> Void)?]([S()])
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "use shorthand syntax for this 'Optional' type"),
+        FindingSpec("2️⃣", message: "use shorthand syntax for this 'Optional' type"),
+        FindingSpec("3️⃣", message: "use shorthand syntax for this 'Optional' type"),
+        FindingSpec("4️⃣", message: "use shorthand syntax for this 'Optional' type"),
+        FindingSpec("5️⃣", message: "use shorthand syntax for this 'Optional' type"),
+        FindingSpec("6️⃣", message: "use shorthand syntax for this 'Optional' type"),
+        FindingSpec("7️⃣", message: "use shorthand syntax for this 'Optional' type"),
+        FindingSpec("8️⃣", message: "use shorthand syntax for this 'Optional' type"),
+      ]
+    )
+  }
 }


### PR DESCRIPTION
* **Explanation**: A few PRs were cherry-picked PRs to the 509.0.0 release of swift-format but were not cherry-picked to the `release/5.10` branch. A couple other high-priority fixes were only merged into `main` but not into `release/5.10` even though they were intended to be part of the 5.10 release. These PRs are
  * Present in 509 but not `release/5.10`
    * https://github.com/apple/swift-format/pull/619
    * https://github.com/apple/swift-format/pull/617
    * https://github.com/apple/swift-format/pull/623
  * Fixes issues that resulted in invalid Swift code or code that changes meaning
    * https://github.com/apple/swift-format/pull/656
      * Would generate invalid code for multi-line string literals in `@available` attributes
    * https://github.com/apple/swift-format/pull/666/commits/b268ae8f7651e5edec419912c7554b8811c0214e
      *  Would rewrite `Optional< @Sendable (Int) -> (Float)>` to `@Sendable (Int) -> (Float)?` which has a different semantic meaning
* **Risk**: The first three PRs are already part of the 509 release, so they have zero risk. The other two PRs are targeted fixes that only affect `@available` attributes and types prefixed with an attribute, respectively
* **Testing**: Ran test suite and newly added test cases
* **Issue**: n/a
* **Reviewer**:  n/a