### PR TITLE
Update README to specify version 510.1.0 for building from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Run `brew install swift-format` to install the latest version.
 Install `swift-format` using the following commands:
 
 ```sh
-VERSION=509.0.0  # replace this with the version you need
+VERSION=510.1.0  # replace this with the version you need
 git clone https://github.com/apple/swift-format.git
 cd swift-format
 git checkout "tags/$VERSION"


### PR DESCRIPTION
This PR updates the 'Building from Source' instructions in the README to use the latest version of `swift-format`, version 510.1.0. It ensures that contributors and users building the project from source are using the most up-to-date version, which includes the latest features and bug fixes. This update helps in maintaining the relevance and accuracy of the documentation, promoting the use of the latest stable releases.
