### PR TITLE
Fix comment for multiElementCollectionTrailingCommas

### DIFF
--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -167,7 +167,7 @@ public struct Configuration: Codable, Equatable {
   ///
   /// When `true` (default), the correct form is:
   /// ```swift
-  /// let MyCollection = [1, 2,]
+  /// let MyCollection = [1, 2]
   /// ...
   /// let MyCollection = [
   ///   "a": 1,

--- a/Tests/SwiftFormatTests/PrettyPrint/CommaTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/CommaTests.swift
@@ -105,7 +105,7 @@ final class CommaTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: configuration)
   }
   
-  func testArraySingleLineCommasPresentDisabled() {
+  func testArraySingleLineCommasPresentEnabled() {
     let input =
       """
       let MyCollection = [1, 2, 3,]
@@ -124,7 +124,7 @@ final class CommaTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: configuration)
   }
   
-  func testArraySingleLineCommasPresentEnabled() {
+  func testArraySingleLineCommasPresentDisabled() {
     let input =
       """
       let MyCollection = [1, 2, 3,]


### PR DESCRIPTION
According to the test case below, I thought
```swift
let MyCollection = [1, 2,]
```
would always be
```swift
let MyCollection = [1, 2]
```
regardless of `multiElementCollectionTrailingCommas` configuration.
https://github.com/apple/swift-format/blob/5545cf668ad61840162a51de97e4bc16ad666844/Tests/SwiftFormatTests/PrettyPrint/CommaTests.swift#L108-L144

Please close this PR if I misunderstood the issue 🙏