### PR TITLE
Fix some typos

### DIFF
--- a/Sources/SwiftFormat/Core/Trivia+Convenience.swift
+++ b/Sources/SwiftFormat/Core/Trivia+Convenience.swift
@@ -80,7 +80,7 @@ extension Trivia {
       })
   }
 
-  /// Returns `true` if this trivia contains any backslahes (used for multiline string newline
+  /// Returns `true` if this trivia contains any backslashes (used for multiline string newline
   /// suppression).
   var containsBackslashes: Bool {
     return contains(

--- a/Sources/SwiftFormat/Rules/AlwaysUseLiteralForEmptyCollectionInit.swift
+++ b/Sources/SwiftFormat/Rules/AlwaysUseLiteralForEmptyCollectionInit.swift
@@ -86,7 +86,7 @@ public final class AlwaysUseLiteralForEmptyCollectionInit : SyntaxFormatRule {
     if replacement.typeAnnotation == nil {
       // Drop trailing trivia after pattern because ':' has to appear connected to it.
       replacement.pattern = node.pattern.with(\.trailingTrivia, [])
-      // Add explicit type annotiation: ': [<Type>]`
+      // Add explicit type annotation: ': [<Type>]`
       replacement.typeAnnotation = .init(type: type.with(\.leadingTrivia, .space)
                                                    .with(\.trailingTrivia, .space))
     }
@@ -109,7 +109,7 @@ public final class AlwaysUseLiteralForEmptyCollectionInit : SyntaxFormatRule {
     if replacement.typeAnnotation == nil {
       // Drop trailing trivia after pattern because ':' has to appear connected to it.
       replacement.pattern = node.pattern.with(\.trailingTrivia, [])
-      // Add explicit type annotiation: ': [<Type>]`
+      // Add explicit type annotation: ': [<Type>]`
       replacement.typeAnnotation = .init(type: type.with(\.leadingTrivia, .space)
                                                    .with(\.trailingTrivia, .space))
     }

--- a/Sources/_SwiftFormatTestSupport/Configuration+Testing.swift
+++ b/Sources/_SwiftFormatTestSupport/Configuration+Testing.swift
@@ -20,7 +20,7 @@ extension Configuration {
   /// different module than where `Configuration` is defined, we can't make this an initializer that
   /// would enforce that every field of `Configuration` is initialized here (we're forced to
   /// delegate to another initializer first, which defeats the purpose). So, users adding new
-  /// configuration settings shouls be sure to supply a default here for testing, otherwise they
+  /// configuration settings should be sure to supply a default here for testing, otherwise they
   /// will be implicitly relying on the real default.
   public static var forTesting: Configuration {
     var config = Configuration()

--- a/Sources/swift-format/Utilities/FileIterator.swift
+++ b/Sources/swift-format/Utilities/FileIterator.swift
@@ -132,7 +132,7 @@ public struct FileIterator: Sequence, IteratorProtocol {
       case .typeRegular:
         // We attempt to relativize the URLs based on the current working directory, not the
         // directory being iterated over, so that they can be displayed better in diagnostics. Thus,
-        // if the user passes paths that are relative to the current working diectory, they will
+        // if the user passes paths that are relative to the current working directory, they will
         // be displayed as relative paths. Otherwise, they will still be displayed as absolute
         // paths.
         let relativePath =


### PR DESCRIPTION
1. backslahes -> backsla `s` hes
2. annot `i` ation -> annotation
3. shouls -> shoul `d`
4. diectory　-> di `r` ectory