### PR TITLE
Fix @_originallyDefinedIn argument spacing

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -1799,6 +1799,12 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     return .visitChildren
   }
 
+  override func visit(_ node: OriginallyDefinedInAttributeArgumentsSyntax) -> SyntaxVisitorContinueKind {
+    after(node.colon.lastToken(viewMode: .sourceAccurate), tokens: .break(.same, size: 1))
+    after(node.comma.lastToken(viewMode: .sourceAccurate), tokens: .break(.same, size: 1))
+    return .visitChildren
+  }
+
   override func visit(_ node: AvailabilityLabeledArgumentSyntax) -> SyntaxVisitorContinueKind {
     before(node.label, tokens: .open)
 

--- a/Tests/SwiftFormatTests/PrettyPrint/AttributeTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/AttributeTests.swift
@@ -26,6 +26,23 @@ final class AttributeTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 60)
   }
 
+  func testAttributeParamSpacingInOriginallyDefinedIn() {
+    let input =
+      """
+      @_originallyDefinedIn( module  :"SwiftUI" , iOS 10.0  )
+      func f() {}
+      """
+
+    let expected =
+      """
+      @_originallyDefinedIn(module: "SwiftUI", iOS 10.0)
+      func f() {}
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 60)
+  }
+
   func testAttributeBinPackedWrapping() {
     let input =
       """


### PR DESCRIPTION
Pretty-print `@_originallyDefinedIn` with the correct spacing.