### PR TITLE
Fix incorrect spacing when pretty-printing @_documentation

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -1802,6 +1802,11 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   override func visit(_ node: OriginallyDefinedInAttributeArgumentsSyntax) -> SyntaxVisitorContinueKind {
     after(node.colon.lastToken(viewMode: .sourceAccurate), tokens: .break(.same, size: 1))
     after(node.comma.lastToken(viewMode: .sourceAccurate), tokens: .break(.same, size: 1))
+      return .visitChildren
+  }
+
+  override func visit(_ node: DocumentationAttributeArgumentSyntax) -> SyntaxVisitorContinueKind {
+    after(node.colon, tokens: .break(.same, size: 1))
     return .visitChildren
   }
 

--- a/Tests/SwiftFormatTests/PrettyPrint/AttributeTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/AttributeTests.swift
@@ -43,6 +43,23 @@ final class AttributeTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 60)
   }
 
+  func testAttributeParamSpacingInDocVisibility() {
+    let input =
+      """
+      @_documentation(  visibility   :private )
+      func f() {}
+      """
+
+    let expected =
+      """
+      @_documentation(visibility: private)
+      func f() {}
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 60)
+  }
+
   func testAttributeBinPackedWrapping() {
     let input =
       """


### PR DESCRIPTION
With attribute such as `@_documentation(visibility: private)`, swift-format incorrectly prints no spacing between `visibility` and `private`.