### PR TITLE
Merge `main` into `release/6.0`

### DIFF
--- a/.swiftci/5_10_ubuntu2204
+++ b/.swiftci/5_10_ubuntu2204
@@ -1,0 +1,5 @@
+LinuxSwiftPackageJob {
+    swift_version_tag = "5.10-jammy"
+    repo = "swift-format"
+    branch = "main"
+}

--- a/.swiftci/5_7_ubuntu2204
+++ b/.swiftci/5_7_ubuntu2204
@@ -1,0 +1,5 @@
+LinuxSwiftPackageJob {
+    swift_version_tag = "5.7-jammy"
+    repo = "swift-format"
+    branch = "main"
+}

--- a/.swiftci/5_8_ubuntu2204
+++ b/.swiftci/5_8_ubuntu2204
@@ -1,0 +1,5 @@
+LinuxSwiftPackageJob {
+    swift_version_tag = "5.8-jammy"
+    repo = "swift-format"
+    branch = "main"
+}

--- a/.swiftci/5_9_ubuntu2204
+++ b/.swiftci/5_9_ubuntu2204
@@ -1,0 +1,5 @@
+LinuxSwiftPackageJob {
+    swift_version_tag = "5.9-jammy"
+    repo = "swift-format"
+    branch = "main"
+}

--- a/.swiftci/nightly_6_0_macos
+++ b/.swiftci/nightly_6_0_macos
@@ -1,0 +1,5 @@
+macOSSwiftPackageJob {
+    swift_version = "6.0"
+    repo = "swift-format"
+    branch = "main"
+}

--- a/.swiftci/nightly_6_0_ubuntu2204
+++ b/.swiftci/nightly_6_0_ubuntu2204
@@ -1,0 +1,5 @@
+LinuxSwiftPackageJob {
+    nightly_docker_tag = "nightly-6.0-jammy"
+    repo = "swift-format"
+    branch = "main"
+}

--- a/.swiftci/nightly_main_macos
+++ b/.swiftci/nightly_main_macos
@@ -1,0 +1,5 @@
+macOSSwiftPackageJob {
+    swift_version = "main"
+    repo = "swift-format"
+    branch = "main"
+}

--- a/.swiftci/nightly_main_ubuntu2204
+++ b/.swiftci/nightly_main_ubuntu2204
@@ -1,0 +1,5 @@
+LinuxSwiftPackageJob {
+    nightly_docker_tag = "nightly-jammy"
+    repo = "swift-format"
+    branch = "main"
+}

--- a/.swiftci/nightly_main_windows
+++ b/.swiftci/nightly_main_windows
@@ -1,0 +1,7 @@
+WindowsSwiftPackageWithDockerImageJob {
+    docker_image = "swiftlang/swift:nightly-windowsservercore-1809"
+    repo = "swift-format"
+    branch = "main"
+    sub_dir = "swift-format"
+    label = "windows-server-2019"
+}


### PR DESCRIPTION
This adds the following commits to `release/6.0`:
- [Add post merge Swift CI support for swift-format](https://github.com/apple/swift-format/commit/3062c3a0b329326a7a9230aad236bd42fc215a29)
- [Fix typo in the .swiftci windows testing file](https://github.com/apple/swift-format/commit/58c2ef514d5b8b3766d2d0957b816a8387b01fed)