### PR TITLE
Remove check for prioritizeKeepingFunctionOutputTogether on enum decl.

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -1350,14 +1350,6 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: EnumCaseParameterClauseSyntax) -> SyntaxVisitorContinueKind {
-    // Prioritize keeping ") throws -> <return_type>" together. We can only do this if the function
-    // has arguments.
-    if !node.parameters.isEmpty && config.prioritizeKeepingFunctionOutputTogether {
-      // Due to visitation order, this .open corresponds to a .close added in FunctionDeclSyntax
-      // or SubscriptDeclSyntax.
-      before(node.rightParen, tokens: .open)
-    }
-
     return .visitChildren
   }
 

--- a/Tests/SwiftFormatTests/PrettyPrint/EnumDeclTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/EnumDeclTests.swift
@@ -559,4 +559,16 @@ final class EnumDeclTests: PrettyPrintTestCase {
     let input = "enum Foo { var bar: Int }"
     assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 50)
   }
+
+  func testEnumWithPrioritizeKeepingFunctionOutputTogetherFlag() {
+    let input = """
+      enum Error {
+        case alreadyOpen(Int)
+      }
+
+      """
+    var config = Configuration.forTesting
+    config.prioritizeKeepingFunctionOutputTogether = true
+    assertPrettyPrintEqual(input: input, expected: input, linelength: 50, configuration: config)
+  }
 }


### PR DESCRIPTION
Fixes #726. An enum decl won't have a corresponding `.close`, so we shouldn't add a `.open` token.