### PR TITLE
Make sure there is a break after an #endif.

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -3911,6 +3911,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
         before(clause.poundKeyword, tokens: .break(.contextual, size: 0))
       }
       before(postfixIfExpr.config.poundEndif, tokens: .break(.contextual, size: 0))
+      after(postfixIfExpr.config.poundEndif, tokens: .break(.same, size: 0))
 
       return insertContextualBreaks(base, isTopLevel: false)
     } else if let callingExpr = expr.asProtocol(CallingExprSyntaxProtocol.self) {

--- a/Tests/SwiftFormatTests/PrettyPrint/IfConfigTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/IfConfigTests.swift
@@ -516,4 +516,19 @@ final class IfConfigTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
   }
+
+  func testPostfixPoundIfInParameterList() {
+    let input =
+      """
+      print(
+        32
+          #if true
+            .foo
+          #endif
+        , 22
+      )
+
+      """
+    assertPrettyPrintEqual(input: input, expected: input, linelength: 45)
+  }
 }


### PR DESCRIPTION
You wouldn't normally allow a line break just before the comma in a parameter list, but if the preceding line is an #endif, we have to be sure to include the break or we'll generate invalid code. Fix #705.