### PR TITLE
Initial rough implementation of comment line wrapping.

### DIFF
--- a/Sources/SwiftFormat/API/Configuration+Default.swift
+++ b/Sources/SwiftFormat/API/Configuration+Default.swift
@@ -38,5 +38,6 @@ extension Configuration {
     self.spacesAroundRangeFormationOperators = false
     self.noAssignmentInExpressions = NoAssignmentInExpressionsConfiguration()
     self.multiElementCollectionTrailingCommas = true
+    self.wrapComments = false
   }
 }

--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -43,6 +43,7 @@ public struct Configuration: Codable, Equatable {
     case spacesAroundRangeFormationOperators
     case noAssignmentInExpressions
     case multiElementCollectionTrailingCommas
+    case wrapComments
   }
 
   /// A dictionary containing the default enabled/disabled states of rules, keyed by the rules'
@@ -186,6 +187,9 @@ public struct Configuration: Codable, Equatable {
   /// ```
   public var multiElementCollectionTrailingCommas: Bool
 
+  /// Determines if comments should wrap onto multiple lines when they exceed the line length.
+  public var wrapComments: Bool
+
   /// Creates a new `Configuration` by loading it from a configuration file.
   public init(contentsOf url: URL) throws {
     let data = try Data(contentsOf: url)
@@ -272,6 +276,10 @@ public struct Configuration: Codable, Equatable {
       try container.decodeIfPresent(
         Bool.self, forKey: .multiElementCollectionTrailingCommas)
     ?? defaults.multiElementCollectionTrailingCommas
+    self.wrapComments =
+      try container.decodeIfPresent(
+        Bool.self, forKey: .wrapComments)
+    ?? defaults.wrapComments
 
     // If the `rules` key is not present at all, default it to the built-in set
     // so that the behavior is the same as if the configuration had been
@@ -305,6 +313,7 @@ public struct Configuration: Codable, Equatable {
     try container.encode(indentSwitchCaseLabels, forKey: .indentSwitchCaseLabels)
     try container.encode(noAssignmentInExpressions, forKey: .noAssignmentInExpressions)
     try container.encode(multiElementCollectionTrailingCommas, forKey: .multiElementCollectionTrailingCommas)
+    try container.encode(wrapComments, forKey: .wrapComments)
     try container.encode(rules, forKey: .rules)
   }
 

--- a/Sources/SwiftFormat/PrettyPrint/Comment.swift
+++ b/Sources/SwiftFormat/PrettyPrint/Comment.swift
@@ -93,7 +93,7 @@ struct Comment {
       return kind.prefix + self.text.joined(separator: separator)
 
     case .docLine:
-      if !useMarkdown {
+      if useMarkdown {
         let indentation = indent.indentation()
         let usableWidth = width - indentation.count
         let lineLimit = MarkupFormatter.Options.PreferredLineLimit(maxLength: usableWidth, breakWith: .softBreak)

--- a/Sources/SwiftFormat/PrettyPrint/Comment.swift
+++ b/Sources/SwiftFormat/PrettyPrint/Comment.swift
@@ -79,7 +79,7 @@ fileprivate extension Array where Element == String {
 
   func markdownFormat(_ usableWidth: Int, linePrefix: String = "") -> [String] {
     let linePrefix = linePrefix + " "
-    let document = Document(parsing: self.map({ $0.trimmingTrailingWhitespace() }).joined(separator: "  "), options: .disableSmartOpts)
+    let document = Document(parsing: self.map({ $0.trimmingTrailingWhitespace() }).joined(separator: "\n"), options: .disableSmartOpts)
     let lineLimit = MarkupFormatter.Options.PreferredLineLimit(maxLength: usableWidth, breakWith: .softBreak)
     let options = MarkupFormatter.Options(useCodeFence: .onlyWhenLanguageIsPresent, preferredLineLimit: lineLimit, customLinePrefix: linePrefix)
     let output = document.format(options: options)
@@ -153,6 +153,7 @@ struct Comment {
         let indentation = indent.indentation()
         let usableWidth = width - indentation.count
         let wrappedLines = self.text.wrapText(usableWidth, linePrefix: kind.prefix)
+        // let wrappedLines = self.text.markdownFormat(usableWidth, linePrefix: kind.prefix)
         return wrappedLines.joined(separator: "\n" + indentation)
       } else {
         let separator = "\n" + indent.indentation() + kind.prefix

--- a/Sources/SwiftFormat/PrettyPrint/Comment.swift
+++ b/Sources/SwiftFormat/PrettyPrint/Comment.swift
@@ -30,34 +30,7 @@ extension StringProtocol {
     }
     return String(String.UnicodeScalarView(scalars[...idx]))
   }
-
-  /// Trims whitespace from the beginning of a string, returning a new string with no leading whitespace.
-  ///
-  /// If the string is only whitespace, an empty string is returned.
-  ///
-  /// - Returns: The string with trailing whitespace removed.
-  func trimmingLeadingWhitespace() -> String {
-    if isEmpty { return String() }
-    let scalars = unicodeScalars
-    var idx = scalars.index(before: scalars.endIndex)
-    while scalars[idx].properties.isWhitespace {
-      if idx == scalars.startIndex { return String() }
-      idx = scalars.index(before: idx)
-    }
-    return String(String.UnicodeScalarView(scalars[...idx]))
-  }
-
-  func trim() -> Self.SubSequence? {
-    guard let startIdx = self.firstIndex(where: { !$0.isWhitespace }),
-          let lastIdx = self.lastIndex(where: { !$0.isWhitespace }) else {
-      return nil
-    }
-    return self[startIdx...lastIdx]
-  }
-
 }
-
-
 
 struct Comment {
   enum Kind {

--- a/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
@@ -513,7 +513,7 @@ public class PrettyPrinter {
     case .comment(let comment, let wasEndOfLine):
       lastBreak = false
 
-      write(comment.print(indent: currentIndentation))
+      write(comment.print(indent: currentIndentation, width: configuration.lineLength, useMarkdown: false))
       if wasEndOfLine {
         if comment.length > spaceRemaining && !isBreakingSuppressed {
           diagnose(.moveEndOfLineComment, category: .endOfLineComment)
@@ -749,7 +749,7 @@ public class PrettyPrinter {
         print("[COMMENT DocBlock Length: \(length) EOL: \(wasEndOfLine) Idx: \(idx)]")
       }
       printDebugIndent()
-      print(comment.print(indent: debugIndent))
+      print(comment.print(indent: debugIndent, width: configuration.lineLength, useMarkdown: false))
 
     case .verbatim(let verbatim):
       printDebugIndent()

--- a/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
@@ -513,7 +513,7 @@ public class PrettyPrinter {
     case .comment(let comment, let wasEndOfLine):
       lastBreak = false
 
-      write(comment.print(indent: currentIndentation, width: configuration.lineLength, useMarkdown: false))
+      write(comment.print(indent: currentIndentation, width: configuration.lineLength, wrap: configuration.wrapComments))
       if wasEndOfLine {
         if comment.length > spaceRemaining && !isBreakingSuppressed {
           diagnose(.moveEndOfLineComment, category: .endOfLineComment)
@@ -749,7 +749,7 @@ public class PrettyPrinter {
         print("[COMMENT DocBlock Length: \(length) EOL: \(wasEndOfLine) Idx: \(idx)]")
       }
       printDebugIndent()
-      print(comment.print(indent: debugIndent, width: configuration.lineLength, useMarkdown: false))
+      print(comment.print(indent: debugIndent, width: configuration.lineLength, wrap: false))
 
     case .verbatim(let verbatim):
       printDebugIndent()

--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -3387,7 +3387,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     if let last = tokens.last {
       switch (last, token) {
       case (.break(.same, _, .soft(let count, _)), .comment(let c2, _))
-        where count == 1 && c2.kind == .docLine:
+        where count == 1 && (c2.kind == .docLine || c2.kind == .line):
         if let nextToLast = tokens.dropLast().last, case let .comment(c1, _) = nextToLast, c1.kind == c2.kind {
           var newComment = c1
           newComment.addText(c2.text)

--- a/Sources/_SwiftFormatTestSupport/Configuration+Testing.swift
+++ b/Sources/_SwiftFormatTestSupport/Configuration+Testing.swift
@@ -41,6 +41,7 @@ extension Configuration {
     config.spacesAroundRangeFormationOperators = false
     config.noAssignmentInExpressions = NoAssignmentInExpressionsConfiguration()
     config.multiElementCollectionTrailingCommas = true
+    config.wrapComments = false
     return config
   }
 }


### PR DESCRIPTION
Rough initial implementation of line wrapping comments (`.line` and `.docLine`). Encountered an issue that line comments were not being merged even though there was code to do it, because that code was being thwarted by soft breaks. Wrote two versions, one that calls into the Markdown library and one that just does simple line wrapping if comments are too long -- it will not combine short lines together the way Markdown would.

To do:

- [ ] Identify edge cases & write many tests.
- [ ] Measure the performance impact.
- [ ] Clean up the code.
- [ ] Consider if we want to format block comments (options for block comment style?)