### PR TITLE
Fix `@_expose` attribute argument spacing

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -1802,6 +1802,11 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     return .visitChildren
   }
 
+  override func visit(_ node: ExposeAttributeArgumentsSyntax) -> SyntaxVisitorContinueKind {
+    after(node.comma, tokens: .break(.same, size: 1))
+    return .visitChildren
+  }
+
   override func visit(_ node: AvailabilityLabeledArgumentSyntax) -> SyntaxVisitorContinueKind {
     before(node.label, tokens: .open)
 

--- a/Tests/SwiftFormatTests/PrettyPrint/AttributeTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/AttributeTests.swift
@@ -444,4 +444,28 @@ final class AttributeTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 100)
   }
+
+  func testAttributeParamSpacingInExpose() {
+    let input =
+      """
+      @_expose( wasm  , "foo"  )
+      func f() {}
+
+      @_expose( Cxx  ,   "bar")
+      func b() {}
+
+      """
+
+    let expected =
+      """
+      @_expose(wasm, "foo")
+      func f() {}
+
+      @_expose(Cxx, "bar")
+      func b() {}
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 100)
+  }
 }


### PR DESCRIPTION
Pretty-print the `@_expose` with the correct spacing. It was formatted as `@_expose(wasm,"foo")` instead of `@_expose(wasm, "foo")`.