### PR TITLE
Update dependencies before a build

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,6 +17,9 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
     with:
       enable_cross_pr_testing: true
+      # Windows seems to be fetching cached repositories, perform a clean to workaround this while
+      # we determine where that's happening.
+      windows_pre_build_command: "Invoke-Program swift package purge-cache"
   soundness:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main


### PR DESCRIPTION
No idea how, but we seem to be fetching repos from caches. Just do an update for now so that we resolve to the latest versions.