### PR TITLE
Fix `auto_update_version` workflow to trigger only on release branch creation

### DIFF
--- a/.github/workflows/auto_update_version.yml
+++ b/.github/workflows/auto_update_version.yml
@@ -1,12 +1,11 @@
 name: Update PrintVersion on release branch creation
 
 on:
-  create:
-    branches:
-      - "release/*"
+  create
 
 jobs:
   update-version:
+    if: ${{ github.ref_type == 'branch' && startsWith(github.ref_name, 'release/') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -16,6 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.ref }}
           token: ${{ github.token }}
 
       - name: Extract version from branch name


### PR DESCRIPTION
The issue was reported by @kkebo in https://github.com/swiftlang/swift-format/pull/1068#discussion_r2422702722 🙇 
Based on both the discussion in https://github.com/orgs/community/discussions/26286 and actual behavior, it seems that the `create` event trigger does not support conditional filters like other triggers.
I’ve updated the logic to properly distinguish release branches.

I tested and confirmed the following:
- The version is correctly extracted only for release branches.
- The workflow is skipped when creating non-release branches or tags.