### PR TITLE
Fix up AttributeTypeSyntax handling

### DIFF
--- a/Tests/SwiftFormatTests/PrettyPrint/FunctionTypeTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/FunctionTypeTests.swift
@@ -283,4 +283,65 @@ final class FunctionTypeTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 17)
   }
+
+  func testFunctionTypeWithTypeSpecifier() {
+    let input =
+      """
+      func f(_ body: nonisolated(nonsending) () async -> Void) {}
+
+      func f(_ body: @Foo @Bar nonisolated(nonsending) () async -> Void) {}
+
+      func f(_ body: nonisolated(nonsending) @Foo @Bar () async -> Void) {}
+
+      func f(_ body: inout @Foo @Bar nonisolated(nonsending) () async -> Void) {}
+      """
+
+    assertPrettyPrintEqual(
+      input: input,
+      expected: """
+        func f(_ body: nonisolated(nonsending) () async -> Void) {}
+
+        func f(_ body: @Foo @Bar nonisolated(nonsending) () async -> Void) {}
+
+        func f(_ body: nonisolated(nonsending) @Foo @Bar () async -> Void) {}
+
+        func f(_ body: inout @Foo @Bar nonisolated(nonsending) () async -> Void) {}
+
+        """,
+      linelength: 80
+    )
+
+    assertPrettyPrintEqual(
+      input: input,
+      expected: """
+        func f(
+          _ body:
+            nonisolated(nonsending)
+            () async -> Void
+        ) {}
+
+        func f(
+          _ body:
+            @Foo @Bar
+            nonisolated(nonsending)
+            () async -> Void
+        ) {}
+
+        func f(
+          _ body:
+            nonisolated(nonsending)
+            @Foo @Bar () async -> Void
+        ) {}
+
+        func f(
+          _ body:
+            inout @Foo @Bar
+            nonisolated(nonsending)
+            () async -> Void
+        ) {}
+
+        """,
+      linelength: 30
+    )
+  }
 }


### PR DESCRIPTION
There's a few issues here:
1. Type specifiers can now have arguments (eg. `nonisolated(nonsending)`)
2. Some type specifiers can be specified "late", which are currently unhandled
3. We were using a mix of `.same` and `.continue` breaks (`.continue` for specifiers and `.same` for attributes)
4. Attributes were grouped separately to specifiers

Fixes https://github.com/swiftlang/swift-format/issues/1081