### PR TITLE
Remove added group around base type in `AttributedTypeSyntax`

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -2411,9 +2411,6 @@ private final class TokenStreamCreator: SyntaxVisitor {
       )
     }
 
-    before(node.baseType.firstToken(viewMode: .sourceAccurate), tokens: .open)
-    after(node.baseType.lastToken(viewMode: .sourceAccurate), tokens: .close)
-
     after(node.lastToken(viewMode: .sourceAccurate), tokens: .close)
     return .visitChildren
   }

--- a/Tests/SwiftFormatTests/PrettyPrint/FunctionTypeTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/FunctionTypeTests.swift
@@ -316,15 +316,15 @@ final class FunctionTypeTests: PrettyPrintTestCase {
       expected: """
         func f(
           _ body:
-            nonisolated(nonsending)
-            () async -> Void
+            nonisolated(nonsending) ()
+            async -> Void
         ) {}
 
         func f(
           _ body:
             @Foo @Bar
-            nonisolated(nonsending)
-            () async -> Void
+            nonisolated(nonsending) ()
+            async -> Void
         ) {}
 
         func f(
@@ -336,8 +336,8 @@ final class FunctionTypeTests: PrettyPrintTestCase {
         func f(
           _ body:
             inout @Foo @Bar
-            nonisolated(nonsending)
-            () async -> Void
+            nonisolated(nonsending) ()
+            async -> Void
         ) {}
 
         """,


### PR DESCRIPTION
Causes quite a few changes in eg. sourcekit-lsp, so presumably will in other codebases as well. Ideally we'd add this behind some new versioning in the config.

As an example of a change this causes:
```
private let logMessageToIndexLog:
  @Sendable (
    _ message: String, _ type: WindowMessageType, _ structure: LanguageServerProtocol.StructuredLogKind
  ) -> Void
```

To:
```
private let logMessageToIndexLog:
  @Sendable
    (
      _ message: String, _ type: WindowMessageType, _ structure: LanguageServerProtocol.StructuredLogKind
    ) -> Void
```