### PR TITLE
Skip the `update-version` job on a fork

### DIFF
--- a/.github/workflows/auto_update_version.yml
+++ b/.github/workflows/auto_update_version.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   update-version:
-    if: ${{ github.ref_type == 'branch' && startsWith(github.ref_name, 'release/') }}
+    if: ${{ github.repository == 'swiftlang/swift-format' && github.ref_type == 'branch' && startsWith(github.ref_name, 'release/') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
This change prevents the job from being triggered when `release/*` branches are synchronized on a fork.