### PR TITLE
print lint location and message in plain bold instead of white

### DIFF
--- a/Sources/swift-format/Utilities/StderrDiagnosticPrinter.swift
+++ b/Sources/swift-format/Utilities/StderrDiagnosticPrinter.swift
@@ -65,12 +65,12 @@ final class StderrDiagnosticPrinter {
 
       switch diagnostic.severity {
       case .error: stderr.write("\(ansiSGR(.boldRed))error: ")
-      case .warning: stderr.write("\(ansiSGR(.boldMagenta))warning: ")
+      case .warning: stderr.write("\(ansiSGR(.boldYellow))warning: ")
       case .note: stderr.write("\(ansiSGR(.boldGray))note: ")
       }
 
       if let category = diagnostic.category {
-        stderr.write("\(ansiSGR(.boldYellow))[\(category)] ")
+        stderr.write("\(ansiSGR(.boldMagenta))[\(category)] ")
       }
       stderr.write("\(ansiSGR(.reset))\(ansiSGR(.bold))\(diagnostic.message)\(ansiSGR(.reset))\n")
     }


### PR DESCRIPTION
fixes #1087

When colorized lint diagnostics were introduced, the source-location and message were printed in ANSI bold white, which caused an issue when using swift-format in a light-mode terminal theme. This PR changes the behavior to instead print these components in bold plain-color text, allowing them to inherit their color from the active terminal theme.

Using the same example i screenshotted in the above-linked issue, this is what the output looks like now:

<img width="971" height="277" alt="image" src="https://github.com/user-attachments/assets/cb308257-88c0-428e-b72d-9a67dc1a3304" />
