### PR TITLE
Normalize release version to x.y.z in auto-update-version action

### DIFF
--- a/.github/workflows/auto_update_version.yml
+++ b/.github/workflows/auto_update_version.yml
@@ -21,13 +21,23 @@ jobs:
           ref: ${{ github.ref }}
           token: ${{ github.token }}
 
-      - name: Extract version from branch name
+      - name: Extract version from branch name (normalize to x.y.z)
         run: |
           BRANCH_NAME="${GITHUB_REF_NAME}"
-          VERSION="${BRANCH_NAME#release/}"
+          RAW_VERSION="${BRANCH_NAME#release/}"
+
+          IFS='.' read -ra PARTS <<< "$RAW_VERSION"
+
+          while [ "${#PARTS[@]}" -lt 3 ]; do
+            PARTS+=("0")
+          done
+
+          VERSION="${PARTS[0]}.${PARTS[1]}.${PARTS[2]}"
+
+          echo "RAW_VERSION=$RAW_VERSION" >> $GITHUB_ENV
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "RELEASE_BRANCH=$BRANCH_NAME" >> $GITHUB_ENV
-          echo "UPDATE_BRANCH=updateversion/$VERSION" >> $GITHUB_ENV
+          echo "UPDATE_BRANCH=updateversion/$RAW_VERSION" >> "$GITHUB_ENV"
 
       - name: Create updateversion branch
         run: |
@@ -64,7 +74,7 @@ jobs:
           gh pr create \
             --base "${{ env.RELEASE_BRANCH }}" \
             --head "${{ env.UPDATE_BRANCH }}" \
-            --title "[${{ env.VERSION }}] Update version to ${{ env.VERSION }}" \
+            --title "[${{ env.RAW_VERSION }}] Update version to ${{ env.VERSION }}" \
             --body "This PR was automatically opened by a GitHub action on creation of a release branch (\`${{ env.RELEASE_BRANCH }}\`).
             Review the version update and merge if correct, otherwise update the version manually." \
             --draft


### PR DESCRIPTION
I had previously set up the action to update the version using the raw release branch name, but it appears the version needs to follow the `x.y.z` format.(https://github.com/swiftlang/swift-format/pull/1089)

I’ve updated the workflow so that even if a release branch is created with fewer segments—such as `release/6.3`—the version is now normalized to a three-part format.

- `release/6` → `6.0.0`
- `release/6.3` → `6.3.0`
- `release/6.3.0` → `6.3.0`