### PR TITLE
Disable Swift 5.9 CI job on Windows

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,6 +20,8 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
     with:
       enable_cross_pr_testing: true
+      # "5.9" is excluded because of https://github.com/swiftlang/swift-format/issues/1094.
+      windows_exclude_swift_versions: "[{\"swift_version\": \"5.9\"}]"
   soundness:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main


### PR DESCRIPTION
Exclude `"5.9"` from `windows_swift_versions` until #1094 is resolved on swift-markdown's side.