### PR TITLE
Respect indentBlankLines when stripping whitespace inside block comment blank lines

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/Comment.swift
+++ b/Sources/SwiftFormat/PrettyPrint/Comment.swift
@@ -102,7 +102,7 @@ struct Comment {
     }
   }
 
-  func print(indent: [Indent]) -> String {
+  func print(indent: [Indent], shouldIndentBlankLines: Bool = true) -> String {
     switch self.kind {
     case .line, .docLine:
       let separator = "\n" + indent.indentation() + kind.prefix
@@ -121,9 +121,13 @@ struct Comment {
           return result
         }
         if hasLeading, let first = self.text.first, !rest.isEmpty {
+          let indentation = indent.indentation()
           let restStr = rest.map {
+            guard !$0.isEmpty else {
+              return shouldIndentBlankLines ? indentation : ""
+            }
             let stripped = $0.dropFirst(leadingIndent.text.count)
-            return indent.indentation() + stripped
+            return indentation + stripped
           }.joined(separator: separator)
           return kind.prefix + first + separator + restStr + "*/"
         }

--- a/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
@@ -484,7 +484,12 @@ public class PrettyPrinter {
           diagnose(.moveEndOfLineComment, category: .endOfLineComment)
         }
       }
-      outputBuffer.write(comment.print(indent: currentIndentation))
+      outputBuffer.write(
+        comment.print(
+          indent: currentIndentation,
+          shouldIndentBlankLines: configuration.indentBlankLines
+        )
+      )
 
     case .verbatim(let verbatim):
       outputBuffer.writeVerbatim(verbatim.print(indent: currentIndentation), length)

--- a/Tests/SwiftFormatTests/PrettyPrint/IndentBlankLinesTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/IndentBlankLinesTests.swift
@@ -303,4 +303,72 @@ final class IndentBlankLinesTests: PrettyPrintTestCase {
     config.indentBlankLines = true
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 80, configuration: config)
   }
+
+  func testBlockCommentWhenIndentBlankLinesDisabled() {
+    let input =
+      """
+      struct Foo {
+      \u{0020}\u{0020}/**\u{0020}\u{0020}
+      \u{0020}\u{0020}foo bar baz\u{0020}\u{0020}
+      \u{0020}\u{0020}\u{0020}\u{0020}\u{0020}\u{0020}
+      \u{0020}\u{0020}quxx\u{0020}\u{0020}
+      \u{0020}\u{0020}
+
+      \u{0020}\u{0020}*/\u{0020}\u{0020}
+      \u{0020}\u{0020}func foo() {}
+      }
+      """
+
+    let expected =
+      """
+      struct Foo {
+      \u{0020}\u{0020}/**
+      \u{0020}\u{0020}foo bar baz
+
+      \u{0020}\u{0020}quxx
+
+
+      \u{0020}\u{0020}*/
+      \u{0020}\u{0020}func foo() {}
+      }
+
+      """
+    var config = Configuration.forTesting
+    config.indentBlankLines = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 80, configuration: config)
+  }
+
+  func testBlockCommentWhenIndentBlankLinesEnabled() {
+    let input =
+      """
+      struct Foo {
+      \u{0020}\u{0020}/**\u{0020}\u{0020}
+      \u{0020}\u{0020}foo bar baz\u{0020}\u{0020}
+      \u{0020}\u{0020}\u{0020}\u{0020}\u{0020}\u{0020}
+      \u{0020}\u{0020}quxx\u{0020}\u{0020}
+      \u{0020}\u{0020}
+
+      \u{0020}\u{0020}*/\u{0020}\u{0020}
+      \u{0020}\u{0020}func foo() {}
+      }
+      """
+
+    let expected =
+      """
+      struct Foo {
+      \u{0020}\u{0020}/**
+      \u{0020}\u{0020}foo bar baz
+      \u{0020}\u{0020}
+      \u{0020}\u{0020}quxx
+      \u{0020}\u{0020}
+      \u{0020}\u{0020}
+      \u{0020}\u{0020}*/
+      \u{0020}\u{0020}func foo() {}
+      }
+
+      """
+    var config = Configuration.forTesting
+    config.indentBlankLines = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 80, configuration: config)
+  }
 }


### PR DESCRIPTION
Resolve #1097

I missed adding the block comment printing logic—since I don’t often use block comments, it slipped through 😓
Added `indentBlankLines` handling when printing block comments so blank lines obey the configuration, and added corresponding tests.