### PR TITLE
Keep attributed getters intact in UseSingleLinePropertyGetter

### DIFF
--- a/Sources/SwiftFormat/Rules/UseSingleLinePropertyGetter.swift
+++ b/Sources/SwiftFormat/Rules/UseSingleLinePropertyGetter.swift
@@ -28,6 +28,7 @@ public final class UseSingleLinePropertyGetter: SyntaxFormatRule {
       let body = acc.body,
       accessors.count == 1,
       acc.accessorSpecifier.tokenKind == .keyword(.get),
+      acc.attributes.isEmpty,
       acc.modifier == nil,
       acc.effectSpecifiers == nil
     else { return node }

--- a/Tests/SwiftFormatTests/Rules/UseSingleLinePropertyGetterTests.swift
+++ b/Tests/SwiftFormatTests/Rules/UseSingleLinePropertyGetterTests.swift
@@ -253,4 +253,30 @@ final class UseSingleLinePropertyGetterTests: LintOrFormatRuleTestCase {
       ]
     )
   }
+
+  func testGetterWithAttributedAccessorShouldBePreserved() {
+    assertFormatting(
+      UseSingleLinePropertyGetter.self,
+      input: """
+        struct Foo {
+          var value: Int {
+            @_lifetime(borrow self)
+            get {
+              return 1
+            }
+          }
+        }
+        """,
+      expected: """
+        struct Foo {
+          var value: Int {
+            @_lifetime(borrow self)
+            get {
+              return 1
+            }
+          }
+        }
+        """
+    )
+  }
 }


### PR DESCRIPTION
Resolve #1102 

Fix `UseSingleLinePropertyGetter` so that explicit getters are left untouched when they carry attributes (e.g. `@_lifetime`).
Since it’s not clear how to reliably distinguish between attributes that can appear at the property level and those that are accessor-only, it seems safer to avoid collapsing getters whenever attributes are present 🤔 