### PR TITLE
Bump to 6.0

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,7 +20,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
     with:
       enable_cross_pr_testing: true
-      # "5.9" is excluded because of https://github.com/swiftlang/swift-format/issues/1094.
+      linux_exclude_swift_versions: "[{\"swift_version\": \"5.9\"}, {\"swift_version\": \"5.10\"}]"
       windows_exclude_swift_versions: "[{\"swift_version\": \"5.9\"}]"
   soundness:
     name: Soundness

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
@@ -146,9 +146,11 @@ let package = Package(
   ],
   products: products,
   dependencies: dependencies,
-  targets: targets
+  targets: targets,
+  swiftLanguageModes: [.v5]
 )
 
+@MainActor
 func swiftSyntaxDependencies(_ names: [String]) -> [Target.Dependency] {
   if buildDynamicSwiftSyntaxLibrary {
     return [.product(name: "_SwiftSyntaxDynamic", package: "swift-syntax")]

--- a/Plugins/FormatPlugin/plugin.swift
+++ b/Plugins/FormatPlugin/plugin.swift
@@ -16,7 +16,7 @@ import PackagePlugin
 @main
 struct FormatPlugin {
   func format(tool: PluginContext.Tool, targetDirectories: [String], configurationFilePath: String?) throws {
-    let swiftFormatExec = URL(fileURLWithPath: tool.path.string)
+    let swiftFormatExec = tool.url
 
     var arguments: [String] = ["format"]
 
@@ -58,7 +58,8 @@ extension FormatPlugin: CommandPlugin {
 
     try format(
       tool: swiftFormatTool,
-      targetDirectories: sourceCodeTargets.map(\.directory.string),
+      // This should be `directoryURL`, but it's only available in 6.1+
+      targetDirectories: sourceCodeTargets.map { String(describing: $0.directory) },
       configurationFilePath: configurationFilePath
     )
   }
@@ -76,7 +77,7 @@ extension FormatPlugin: XcodeCommandPlugin {
 
     try format(
       tool: swiftFormatTool,
-      targetDirectories: [context.xcodeProject.directory.string],
+      targetDirectories: [context.xcodeProject.directoryURL.path()],
       configurationFilePath: configurationFilePath
     )
   }

--- a/Plugins/LintPlugin/plugin.swift
+++ b/Plugins/LintPlugin/plugin.swift
@@ -16,7 +16,7 @@ import PackagePlugin
 @main
 struct LintPlugin {
   func lint(tool: PluginContext.Tool, targetDirectories: [String], configurationFilePath: String?) throws {
-    let swiftFormatExec = URL(fileURLWithPath: tool.path.string)
+    let swiftFormatExec = tool.url
 
     var arguments: [String] = ["lint"]
 
@@ -59,7 +59,8 @@ extension LintPlugin: CommandPlugin {
 
     try lint(
       tool: swiftFormatTool,
-      targetDirectories: sourceCodeTargets.map(\.directory.string),
+      // This should be `directoryURL`, but it's only available in 6.1+
+      targetDirectories: sourceCodeTargets.map { String(describing: $0.directory) },
       configurationFilePath: configurationFilePath
     )
   }
@@ -76,7 +77,7 @@ extension LintPlugin: XcodeCommandPlugin {
 
     try lint(
       tool: swiftFormatTool,
-      targetDirectories: [context.xcodeProject.directory.string],
+      targetDirectories: [context.xcodeProject.directoryURL.path()],
       configurationFilePath: configurationFilePath
     )
   }


### PR DESCRIPTION
5.9 has issues with swift-markdown's use of versioned `Package.swift` after the added use of unsafe flags (which are 6.2 only). 6.0 is over a year old now.