### PR TITLE
Use the tagged workflows for all workflows, not just PR testing

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   create_merge_pr:
     name: Create PR to merge main into release branch
-    uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@0.0.2
     with:
       base_branch: release/6.3
     permissions:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -95,7 +95,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
   test:
     name: Test in ${{ matrix.release && 'Release' || 'Debug' }} configuration
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.2
     needs: create_release_commits
     strategy:
       fail-fast: false


### PR DESCRIPTION
`main` has been broken for a while and we run the same testing in the publish job as PR testing, so we haven't been able to release a nightly. Just use the tagged github-workflows for all.