### PR TITLE
Don't test with swift-5.x in Publish Release workflow

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -102,6 +102,8 @@ jobs:
       matrix:
         release: [true, false]
     with:
+      linux_exclude_swift_versions: "[{\"swift_version\": \"5.9\"}, {\"swift_version\": \"5.10\"}]"
+      windows_exclude_swift_versions: "[{\"swift_version\": \"5.9\"}]"
       linux_pre_build_command: |
         git config --global --add safe.directory "$(realpath .)"
         git config --local user.name 'swift-ci'


### PR DESCRIPTION
swift-format only supports 6.x+ toolchains

Aligning with "Pull Request" workflow https://github.com/swiftlang/swift-format/blob/e3cca1fd45ed63951b2c361ffe6f709decb140ec/.github/workflows/pull_request.yml#L23-L24
