### PR TITLE
Fix link to Configuration documentation

### DIFF
--- a/Documentation/RuleDocumentation.md
+++ b/Documentation/RuleDocumentation.md
@@ -4,7 +4,7 @@
 
 Use the rules below in the `rules` block of your `.swift-format`
 configuration file, as described in
-[Configuration](Documentation/Configuration.md). All of these rules can be
+[Configuration](Configuration.md). All of these rules can be
 applied in the linter, but only some of them can format your source code
 automatically.
 


### PR DESCRIPTION
This pull request makes a minor documentation change to the `Documentation/RuleDocumentation.md` file, correcting a link to the configuration documentation. No functional or code changes are included.