### PR TITLE
[CI] Update the github-workflows tag to 0.0.6 to support macOS Tahoe

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   create_merge_pr:
     name: Create PR to merge main into release branch
-    uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@0.0.2
+    uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@0.0.6
     with:
       base_branch: release/6.3
     permissions:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -95,7 +95,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
   test:
     name: Test in ${{ matrix.release && 'Release' || 'Debug' }} configuration
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.2
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.6
     needs: create_release_commits
     strategy:
       fail-fast: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,14 +17,14 @@ concurrency:
 jobs:
   tests:
     name: Test
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.2
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.6
     with:
       enable_cross_pr_testing: true
       linux_exclude_swift_versions: "[{\"swift_version\": \"5.9\"}, {\"swift_version\": \"5.10\"}]"
       windows_exclude_swift_versions: "[{\"swift_version\": \"5.9\"}]"
   soundness:
     name: Soundness
-    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.2
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.6
     with:
       license_header_check_project_name: "Swift.org"
       api_breakage_check_allowlist_path: "api-breakages.txt"


### PR DESCRIPTION
swiftlang’s self-hosted runners are now running on Tahoe