### PR TITLE
Add support for .swift-format-ignore files

### DIFF
--- a/Documentation/IgnoringSource.md
+++ b/Documentation/IgnoringSource.md
@@ -8,8 +8,8 @@ representation is ignored by the formatter.
 
 ## Ignore A File
 
-In the event that an entire file cannot be formatted, add a comment that contains 
-`swift-format-ignore-file` at the top of the file and the formatter will leave 
+In the event that an entire file cannot be formatted, add a comment that contains
+`swift-format-ignore-file` at the top of the file and the formatter will leave
 the file completely unchanged.
 
 ```swift
@@ -90,7 +90,7 @@ struct Foo {
 }
 ```
 In this case, only the DoNotUseSemicolons and FullyIndirectEnum rules are disabled
-throughout the file, while all other formatting rules (such as line breaking and 
+throughout the file, while all other formatting rules (such as line breaking and
 indentation) remain active.
 
 ## Understanding Nodes
@@ -113,3 +113,93 @@ top level nodes that support suppressing formatting are:
   - Any member declaration inside of a declaration (e.g. properties and
     functions declared inside of a struct/class/enum). All code nested
     syntactically inside of the ignored node is also ignored by the formatter.
+
+## File-Based Ignoring with `.swift-format-ignore`
+
+In addition to the comment-based ignoring described above, `swift-format` supports
+file-based ignoring using `.swift-format-ignore` files. These files allow you to
+specify patterns for files and directories that should be completely excluded from
+formatting and linting operations.
+
+### `.swift-format-ignore` File Format
+
+`.swift-format-ignore` files use the same pattern syntax as `.gitignore` files:
+
+```
+# This is a comment
+*.generated.swift
+build/
+**/Generated/
+!important.swift
+src/**/test*.swift
+```
+
+### Pattern Syntax
+
+The `.swift-format-ignore` files supports the following pattern syntax:
+
+- Simple patterns: `file.swift` matches any file named `file.swift` anywhere in the tree
+- Wildcard patterns: `*.swift` matches all files ending with `.swift`
+- Directory patterns: `build/` matches the `build` directory and all files within it
+- Nested wildcards: `**/*.generated` matches files with `.generated` extension at any depth
+- Negation patterns: `!important.swift` excludes `important.swift` from being ignored (even if matched by other patterns)
+- Absolute patterns: `/root.swift` matches `root.swift` only at the project root
+- Complex patterns: `src/**/test*.swift` matches files starting with `test` and ending with `.swift` anywhere under `src/`
+
+### File Discovery and Precedence
+
+`swift-format` searches for `.swift-format-ignore` files by walking up the directory
+tree from each source file being processed. Multiple ignore files can exist in a
+project, with the following precedence rules:
+
+1. Closest wins: Ignore files closer to the source file take precedence
+2. Directory traversal: The tool searches from the file's directory up to the discovery of a `.swift-format` file
+3. Pattern evaluation: Within each ignore file, patterns are evaluated in order
+4. Negation support: Later negation patterns (`!pattern`) can override earlier ignore patterns
+
+### Example Project Structure
+
+```
+project/
+├── .swift-format-ignore          # Root ignore file
+├── src/
+│   ├── .swift-format-ignore      # Overrides root for src/ directory
+│   ├── main.swift
+│   └── generated/
+│       └── Generated.swift
+├── tests/
+│   └── test.swift
+└── build/
+    └── output.swift
+```
+
+**Root `.swift-format-ignore`:**
+```
+# Ignore all generated files
+*.generated.swift
+build/
+```
+
+**`src/.swift-format-ignore`:**
+```
+# Additional rules for src directory
+generated/
+!important.generated.swift
+```
+
+### Integration with swift-format Commands
+
+The `.swift-format-ignore` functionality works automatically with all `swift-format` commands:
+
+```bash
+# Format all files except those matching ignore patterns
+swift-format --recursive src/
+
+# Lint all files except those matching ignore patterns
+swift-format lint --recursive src/
+
+# Both commands will automatically discover and respect .swift-format-ignore files
+```
+
+Files matched by `.swift-format-ignore` patterns are completely excluded from processing -
+they will not be formatted, linted, or appear in any output.

--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -293,6 +293,8 @@ public struct Configuration: Codable, Equatable {
     }
   }
 
+  package static let swiftFormatFilename = ".swift-format"
+
   public var reflowMultilineStringLiterals: MultilineStringReflowBehavior
 
   /// Determines whether to add indentation whitespace to blank lines or remove it entirely.
@@ -514,7 +516,7 @@ public struct Configuration: Codable, Equatable {
     }
     repeat {
       candidateDirectory.deleteLastPathComponent()
-      let candidateFile = candidateDirectory.appendingPathComponent(".swift-format")
+      let candidateFile = candidateDirectory.appendingPathComponent(Self.swiftFormatFilename)
       if FileManager.default.isReadableFile(atPath: candidateFile.path) {
         return candidateFile
       }

--- a/Sources/SwiftFormat/CMakeLists.txt
+++ b/Sources/SwiftFormat/CMakeLists.txt
@@ -100,6 +100,8 @@ add_library(SwiftFormat
   Rules/UseWhereClausesInForLoops.swift
   Rules/ValidateDocumentationComments.swift
   Utilities/FileIterator.swift
+  Utilities/GitIgnorePattern.swift
+  Utilities/IgnoreManager.swift
   Utilities/URL+isRoot.swift)
 target_link_libraries(SwiftFormat PUBLIC
   SwiftMarkdown::Markdown

--- a/Sources/SwiftFormat/Utilities/FileIterator.swift
+++ b/Sources/SwiftFormat/Utilities/FileIterator.swift
@@ -47,19 +47,42 @@ public struct FileIterator: Sequence, IteratorProtocol {
   /// The file extension to check for when recursing through directories.
   private let fileSuffix = ".swift"
 
+  /// Optional ignore manager for filtering files based on .swift-format-ignore files.
+  private let ignoreManager: IgnoreManager
+
   /// Create a new file iterator over the given list of file URLs.
   ///
   /// The given URLs may be files or directories. If they are directories, the iterator will recurse
   /// into them. Symlinks are never followed on Windows platforms as Foundation doesn't support it.
   /// - Parameters:
   ///   - urls: `Array` of files or directories to iterate.
-  ///   - followSymlinks: `Bool` to indicate if symbolic links should be followed when iterating.
-  ///   - workingDirectory: `URL` that indicates the current working directory. Used for testing.
-  public init(urls: [URL], followSymlinks: Bool, workingDirectory: URL = URL(fileURLWithPath: ".")) {
+  ///   - followSymlinks: `Bool` to indicate if symbolic links sthe current working directory. Used for testing.
+  ///   - ignoreManager: Optional `IgnoreManager`hould be followed when iterating.
+  ///   - workingDirectory: `URL` that indicates  to filter files based on .swift-format-ignore files.
+  package init(
+    urls: [URL],
+    followSymlinks: Bool,
+    workingDirectory: URL = URL(fileURLWithPath: "."),
+    ignoreManager: IgnoreManager
+  ) {
     self.workingDirectory = workingDirectory
     self.urls = urls
     self.urlIterator = self.urls.makeIterator()
     self.followSymlinks = followSymlinks
+    self.ignoreManager = ignoreManager
+  }
+
+  public init(
+    urls: [URL],
+    followSymlinks: Bool,
+    workingDirectory: URL = URL(fileURLWithPath: ".")
+  ) {
+    self.init(
+      urls: urls,
+      followSymlinks: followSymlinks,
+      workingDirectory: workingDirectory,
+      ignoreManager: IgnoreManager()
+    )
   }
 
   /// Iterate through the "paths" list, and emit the file paths in it. If we encounter a directory,
@@ -85,6 +108,9 @@ public struct FileIterator: Sequence, IteratorProtocol {
           continue
 
         case .typeDirectory:
+          if self.ignoreManager.shouldIgnore(file: next, isDirectory: true) {
+            continue
+          }
           dirIterator = FileManager.default.enumerator(
             at: next,
             includingPropertiesForKeys: nil,
@@ -93,12 +119,17 @@ public struct FileIterator: Sequence, IteratorProtocol {
           currentDirectory = next
 
         default:
-          // We'll get here if the path is a file, or if it doesn't exist. In the latter case,
-          // return the path anyway; we'll turn the error we get when we try to open the file into
-          // an appropriate diagnostic instead of trying to handle it here.
+          // We'll get here if the path is a file, or if it doesn't exist.
+          if self.ignoreManager.shouldIgnore(file: next, isDirectory: false) {
+            continue
+          }
+          // If the file does not exists, return the path anyway; we'll turn the
+          // error we get when we try to open the file into an appropriate
+          // diagnostic instead of trying to handle it here.
           output = next
         }
       }
+
       if let out = output, visited.contains(out.standardizedFileURL.path) {
         output = nil
       }
@@ -145,7 +176,20 @@ public struct FileIterator: Sequence, IteratorProtocol {
         } else {
           relativePath = path
         }
-        output = URL(fileURLWithPath: relativePath, isDirectory: false, relativeTo: workingDirectory)
+        let workingDirectoryWIthTrailingSlash = URL(fileURLWithPath: "\(workingDirectory.path)/")
+        let fileURL = URL(
+          fileURLWithPath: relativePath,
+          isDirectory: false,
+          relativeTo: workingDirectoryWIthTrailingSlash
+        )
+
+        // Apply ignore filtering
+        if self.ignoreManager.shouldIgnore(file: item, isDirectory: false) {
+          output = nil
+          continue  // Skip this file and continue to next
+        }
+
+        output = fileURL
 
       default:
         break

--- a/Sources/SwiftFormat/Utilities/GitIgnorePattern.swift
+++ b/Sources/SwiftFormat/Utilities/GitIgnorePattern.swift
@@ -1,0 +1,330 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// A pattern matcher that follows gitignore-style pattern matching rules.
+///
+/// GitIgnorePattern implements pattern matching compatible with `.gitignore` files,
+/// supporting wildcards, negation, directory-only patterns, and more complex matching rules.
+@_spi(Internal)
+public struct GitIgnorePattern {
+
+  /// The original pattern string provided during initialization
+  public let pattern: String
+
+  /// Whether this pattern is a negation pattern (starts with `!`)
+  public let isNegation: Bool
+
+  /// Whether this pattern only matches directories (ends with `/`)
+  public let isDirectoryOnly: Bool
+
+  /// The processed pattern used for matching (with leading `!` and trailing `/` removed)
+  private let matchPattern: String
+
+  /// Error types that can occur during pattern parsing
+  public enum PatternError: Error, CustomStringConvertible {
+    case invalidPattern(String)
+
+    public var description: String {
+      switch self {
+      case .invalidPattern(let pattern):
+        return "Invalid gitignore pattern: '\(pattern)'"
+      }
+    }
+  }
+
+  /// Initialize a new GitIgnorePattern from the given pattern string
+  ///
+  /// - Parameter pattern: The gitignore-style pattern string
+  /// - Throws: `PatternError.invalidPattern` if the pattern is invalid
+  public init(_ pattern: String) throws {
+    self.pattern = pattern
+
+    // Handle negation patterns (starting with !)
+    if pattern.hasPrefix("!") {
+      self.isNegation = true
+      let withoutNegation = String(pattern.dropFirst())
+
+      // Handle directory-only patterns (ending with /)
+      if withoutNegation.hasSuffix("/") {
+        self.isDirectoryOnly = true
+        self.matchPattern = String(withoutNegation.dropLast())
+      } else {
+        self.isDirectoryOnly = false
+        self.matchPattern = withoutNegation
+      }
+    } else {
+      self.isNegation = false
+
+      // Handle directory-only patterns (ending with /)
+      if pattern.hasSuffix("/") {
+        self.isDirectoryOnly = true
+        self.matchPattern = String(pattern.dropLast())
+      } else {
+        self.isDirectoryOnly = false
+        self.matchPattern = pattern
+      }
+    }
+
+    // Basic validation - empty patterns are invalid
+    if matchPattern.isEmpty {
+      throw PatternError.invalidPattern(pattern)
+    }
+  }
+
+  /// Test whether the given path matches this pattern
+  ///
+  /// - Parameters:
+  ///   - path: The file path to test against this pattern
+  ///   - isDirectory: Whether the path represents a directory
+  /// - Returns: `true` if the path matches this pattern, `false` otherwise
+  public func matches(_ path: String, isDirectory: Bool) -> Bool {
+    // For directory-only patterns, we need special handling
+    if isDirectoryOnly {
+      // If we're checking a directory itself, it should match if the pattern matches
+      if isDirectory {
+        return advancedMatch(path, pattern: matchPattern)
+      }
+
+      // If we're checking a file, it should match if it's INSIDE a directory that matches the pattern
+      // For example: pattern "build/" should match "build/file.txt"
+      let pathComponents = path.components(separatedBy: "/")
+
+      // Check if any parent directory matches the pattern
+      for i in 1..<pathComponents.count {
+        let parentPath = pathComponents[..<i].joined(separator: "/")
+        if advancedMatch(parentPath, pattern: matchPattern) {
+          return true
+        }
+      }
+
+      return false
+    }
+
+    // For non-directory-only patterns, use normal matching
+    return advancedMatch(path, pattern: matchPattern, isDirectory: isDirectory)
+  }
+
+  /// Advanced pattern matching implementation supporting gitignore-style patterns
+  private func advancedMatch(_ path: String, pattern: String, isDirectory: Bool = false) -> Bool {
+    // Handle absolute patterns (starting with /)
+    if pattern.hasPrefix("/") {
+      let absolutePattern = String(pattern.dropFirst())
+      return simpleMatch(path, pattern: absolutePattern)
+    }
+
+    // Handle double asterisk patterns
+    if pattern.contains("**") {
+      return doubleAsteriskMatch(path, pattern: pattern, isDirectory: isDirectory)
+    }
+
+    // For patterns without slashes, match the filename anywhere in the path
+    // This includes patterns with wildcards like "*.swift" which should match filenames at any depth
+    if !pattern.contains("/") {
+      // Simple patterns with file extensions should only match files, not directories
+      // Simple patterns without extensions should match both files and directories
+      if isDirectory && pattern.contains(".") {
+        // If it's a directory and the pattern looks like a filename with extension, don't match
+        return false
+      }
+      let pathComponents = path.components(separatedBy: "/")
+      let filename = pathComponents.last ?? path
+      return simpleMatch(filename, pattern: pattern)
+    }
+
+    // Handle patterns with slashes (path-based patterns)
+    return simpleMatch(path, pattern: pattern)
+  }
+
+  /// Handle double asterisk (**) patterns
+  private func doubleAsteriskMatch(_ path: String, pattern: String, isDirectory: Bool) -> Bool {
+    // Split pattern by **
+    let parts = pattern.components(separatedBy: "**")
+
+    if parts.count == 2 {
+      let prefix = parts[0]
+      let suffix = parts[1]
+
+      // Pattern: **/suffix (matches suffix at any depth)
+      if prefix.isEmpty {
+        let cleanSuffix = suffix.hasPrefix("/") ? String(suffix.dropFirst()) : suffix
+        return path.hasSuffix(cleanSuffix) || simpleMatch(path, pattern: cleanSuffix)
+      }
+
+      // Pattern: prefix/** (matches everything under prefix)
+      if suffix.isEmpty || suffix == "/" {
+        let cleanPrefix = prefix.hasSuffix("/") ? String(prefix.dropLast()) : prefix
+        return path.hasPrefix(cleanPrefix + "/")
+      }
+
+      // Pattern: prefix/**/suffix (matches suffix under prefix at any depth)
+      let cleanPrefix = prefix.hasSuffix("/") ? String(prefix.dropLast()) : prefix
+      let cleanSuffix = suffix.hasPrefix("/") ? String(suffix.dropFirst()) : suffix
+
+      if path.hasPrefix(cleanPrefix + "/") {
+        let remainder = String(path.dropFirst(cleanPrefix.count + 1))
+
+        // The suffix might contain wildcards, so use pattern matching
+        // But we need to check if the suffix pattern would match directories for file patterns
+        if shouldSuffixMatch(remainder, pattern: cleanSuffix, isDirectory: isDirectory) {
+          return true
+        }
+
+        // Also check if any part of the remainder matches the suffix pattern
+        let remainderComponents = remainder.components(separatedBy: "/")
+        for i in 0..<remainderComponents.count {
+          let subPath = remainderComponents[i...].joined(separator: "/")
+          // For intermediate components, treat as files unless it's the final component
+          let isIntermediateDirectory = (i < remainderComponents.count - 1) || isDirectory
+          if shouldSuffixMatch(
+            subPath,
+            pattern: cleanSuffix,
+            isDirectory: isIntermediateDirectory && i == remainderComponents.count - 1
+          ) {
+            return true
+          }
+        }
+      }
+    }
+
+    return false
+  }
+
+  /// Helper to determine if a suffix pattern should match, considering directory vs file distinction
+  private func shouldSuffixMatch(_ path: String, pattern: String, isDirectory: Bool) -> Bool {
+    // If the pattern looks like a file pattern (contains extension) and target is directory, don't match
+    if isDirectory && pattern.contains(".") && !pattern.contains("/") {
+      // Simple pattern with extension like "*.swift" should not match directories
+      return false
+    }
+    return simpleMatch(path, pattern: pattern)
+  }
+
+  /// Simple pattern matching implementation
+  private func simpleMatch(_ path: String, pattern: String) -> Bool {
+    // Handle patterns with multiple wildcards
+    if pattern.contains("*") {
+      return wildcardMatch(path, pattern: pattern)
+    }
+
+    // Handle single character wildcard
+    if pattern.contains("?") {
+      return questionMarkMatch(path, pattern: pattern)
+    }
+
+    // Exact match
+    return path == pattern
+  }
+
+  /// Advanced wildcard matching for patterns containing `*`
+  private func wildcardMatch(_ path: String, pattern: String) -> Bool {
+    return globMatch(path, pattern: pattern)
+  }
+
+  /// Glob-style pattern matching supporting multiple wildcards
+  private func globMatch(_ path: String, pattern: String) -> Bool {
+    let pathChars = Array(path)
+    let patternChars = Array(pattern)
+
+    return globMatchRecursive(
+      path: pathChars,
+      pathIndex: 0,
+      pattern: patternChars,
+      patternIndex: 0
+    )
+  }
+
+  /// Recursive glob matching implementation
+  private func globMatchRecursive(
+    path: [Character],
+    pathIndex: Int,
+    pattern: [Character],
+    patternIndex: Int
+  ) -> Bool {
+    // If we've consumed the entire pattern, check if path is also consumed
+    if patternIndex >= pattern.count {
+      return pathIndex >= path.count
+    }
+
+    // If we've consumed the entire path but pattern remains
+    if pathIndex >= path.count {
+      // Only valid if remaining pattern is all '*'
+      for i in patternIndex..<pattern.count {
+        if pattern[i] != "*" {
+          return false
+        }
+      }
+      return true
+    }
+
+    let currentPatternChar = pattern[patternIndex]
+
+    if currentPatternChar == "*" {
+      // Try matching zero characters (skip *)
+      if globMatchRecursive(
+        path: path,
+        pathIndex: pathIndex,
+        pattern: pattern,
+        patternIndex: patternIndex + 1
+      ) {
+        return true
+      }
+
+      // Try matching one or more characters
+      for i in pathIndex..<path.count {
+        // Don't let * match across directory boundaries
+        if path[i] == "/" {
+          break
+        }
+        if globMatchRecursive(
+          path: path,
+          pathIndex: i + 1,
+          pattern: pattern,
+          patternIndex: patternIndex + 1
+        ) {
+          return true
+        }
+      }
+
+      return false
+    } else if currentPatternChar == "?" {
+      // Match exactly one character (but not /)
+      if path[pathIndex] == "/" {
+        return false
+      }
+      return globMatchRecursive(
+        path: path,
+        pathIndex: pathIndex + 1,
+        pattern: pattern,
+        patternIndex: patternIndex + 1
+      )
+    } else {
+      // Exact character match
+      if path[pathIndex] != currentPatternChar {
+        return false
+      }
+      return globMatchRecursive(
+        path: path,
+        pathIndex: pathIndex + 1,
+        pattern: pattern,
+        patternIndex: patternIndex + 1
+      )
+    }
+  }
+
+  /// Question mark wildcard matching for patterns containing `?`
+  private func questionMarkMatch(_ path: String, pattern: String) -> Bool {
+    // Use the glob matcher which handles ? properly
+    return globMatch(path, pattern: pattern)
+  }
+}

--- a/Sources/SwiftFormat/Utilities/IgnoreManager.swift
+++ b/Sources/SwiftFormat/Utilities/IgnoreManager.swift
@@ -1,0 +1,192 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Manages `.swift-format-ignore` files for excluding files from formatting and linting.
+///
+/// IgnoreManager handles discovery, loading, and caching of ignore files in a directory tree,
+/// implementing precedence rules where closer ignore files take priority.
+@_spi(Internal)
+public class IgnoreManager {
+
+  /// Errors that can occur during ignore file operations
+  public enum IgnoreError: Error, Equatable {
+    case fileNotFound
+    case invalidPattern(String)
+  }
+
+  /// Shared cache for loaded ignore files to avoid repeated I/O across all instances
+  private var ignoreFileCache: [URL: [GitIgnorePattern]] = [:]
+
+  /// Initialize a new IgnoreManager
+  public init() {}
+
+  /// Find all .swift-format-ignore files that apply to the given file path
+  ///
+  /// Walks up the directory tree from the file's directory to find ignore files,
+  /// returning them in order of precedence (closest first). Stops at project
+  /// boundaries determined by the same logic as .swift-format configuration files.
+  ///
+  /// - Parameter filePath: The file path to find ignore files for
+  /// - Returns: Array of ignore file URLs, ordered by precedence (closest first)
+  public func findIgnoreFiles(for filePath: URL) -> [URL] {
+    var ignoreFiles: [URL] = []
+    var currentDir = filePath.deletingLastPathComponent()
+
+    // Walk up the directory tree
+    while true {
+      let ignoreFile = currentDir.appendingPathComponent(".swift-format-ignore")
+
+      if FileManager.default.fileExists(atPath: ignoreFile.path) {
+        ignoreFiles.append(ignoreFile)
+      }
+
+      // Check for project boundary (.swift-format configuration file)
+      let configFile = currentDir.appendingPathComponent(Configuration.swiftFormatFilename)
+      if FileManager.default.fileExists(atPath: configFile.path) {
+        // Found a configuration file - this is a project boundary, stop here
+        break
+      }
+
+      if currentDir.isRoot {
+        break  // We've reached the root
+      }
+      let parentDir = currentDir.deletingLastPathComponent()
+      currentDir = parentDir
+    }
+
+    return ignoreFiles
+  }
+
+  /// Load patterns from a .swift-format-ignore file
+  ///
+  /// - Parameter url: URL of the ignore file to load
+  /// - Returns: Array of GitIgnorePattern objects parsed from the file
+  /// - Throws: `IgnoreError.fileNotFound` if the file doesn't exist
+  public func loadIgnoreFile(at url: URL) throws -> [GitIgnorePattern] {
+    // Check cache first (thread-safe)
+    if let cachedPatterns = self.ignoreFileCache[url] {
+      return cachedPatterns
+    }
+
+    // Check if file exists
+    guard FileManager.default.fileExists(atPath: url.path) else {
+      throw IgnoreError.fileNotFound
+    }
+
+    // Read file content
+    let content = try String(contentsOf: url, encoding: .utf8)
+    let lines = content.components(separatedBy: .newlines)
+
+    var patterns: [GitIgnorePattern] = []
+
+    for line in lines {
+      let trimmedLine = line.trimmingCharacters(in: .whitespacesAndNewlines)
+
+      // Skip empty lines and comments
+      if trimmedLine.isEmpty || trimmedLine.hasPrefix("#") {
+        continue
+      }
+
+      do {
+        let pattern = try GitIgnorePattern(trimmedLine)
+        patterns.append(pattern)
+      } catch {
+        // Skip invalid patterns for now
+        continue
+      }
+    }
+
+    // Cache the result (thread-safe)
+    self.ignoreFileCache[url] = patterns
+
+    return patterns
+  }
+
+  /// Determine if a file should be ignored based on .swift-format-ignore files
+  ///
+  /// Finds all applicable ignore files, loads their patterns, and evaluates them
+  /// in precedence order (closest ignore file wins). Each ignore file's patterns
+  /// are evaluated relative to the directory containing that ignore file.
+  ///
+  /// - Parameters:
+  ///   - file: The file URL to check
+  ///   - isFileDirectory: Whether the file is a directory
+  /// - Returns: `true` if the file should be ignored, `false` otherwise
+  public func shouldIgnore(file: URL, isDirectory: Bool) -> Bool {
+    let ignoreFiles = findIgnoreFiles(for: file)
+
+    // If no ignore files found, don't ignore
+    guard !ignoreFiles.isEmpty else {
+      return false
+    }
+
+    let standardizedFile = file.standardizedFileURL
+
+    // Process ignore files in precedence order (closest first)
+    var shouldIgnore = false
+
+    for ignoreFile in ignoreFiles.reversed() {  // Process furthest first, then closest
+      do {
+        let patterns = try loadIgnoreFile(at: ignoreFile)
+
+        // Each ignore file's patterns should be evaluated relative to the directory containing that ignore file
+        let ignoreFileDirectory = ignoreFile.deletingLastPathComponent().standardizedFileURL
+
+        guard let relativePath = getRelativePath(from: ignoreFileDirectory, to: standardizedFile) else {
+          // If we can't compute a relative path from this ignore file's directory, skip it
+          continue
+        }
+
+        // Apply patterns in order
+        for pattern in patterns {
+          if pattern.matches(relativePath, isDirectory: isDirectory) {
+            shouldIgnore = !pattern.isNegation  // Ignore unless it's a negation pattern
+          }
+        }
+      } catch {
+        // Skip files that can't be loaded
+        continue
+      }
+    }
+
+    return shouldIgnore
+  }
+
+  /// Compute relative path from base directory to target file
+  private func getRelativePath(from base: URL, to target: URL) -> String? {
+    let basePath = base.path
+    let targetPath = target.path
+
+    // Handle exact match
+    if targetPath == basePath {
+      return ""
+    }
+
+    // Check if target is under base
+    if targetPath.hasPrefix(basePath) {
+      let prefixLength = basePath.count
+      let remainingPath = String(targetPath.dropFirst(prefixLength))
+
+      // Remove leading slash if present
+      if remainingPath.hasPrefix("/") {
+        return String(remainingPath.dropFirst())
+      } else {
+        return remainingPath
+      }
+    }
+
+    // Target is not under base, return nil
+    return nil
+  }
+}

--- a/Sources/swift-format/Frontend/Frontend.swift
+++ b/Sources/swift-format/Frontend/Frontend.swift
@@ -328,16 +328,22 @@ class Frontend {
 
     if parallel {
       let filesToProcess =
-        FileIterator(urls: urls, followSymlinks: lintFormatOptions.followSymlinks)
+        FileIterator(
+          urls: urls,
+          followSymlinks: lintFormatOptions.followSymlinks
+        )
         .compactMap(openAndPrepareFile)
       DispatchQueue.concurrentPerform(iterations: filesToProcess.count) { index in
         processFile(filesToProcess[index])
       }
     } else {
-      FileIterator(urls: urls, followSymlinks: lintFormatOptions.followSymlinks)
-        .lazy
-        .compactMap(openAndPrepareFile)
-        .forEach(processFile)
+      FileIterator(
+        urls: urls,
+        followSymlinks: lintFormatOptions.followSymlinks
+      )
+      .lazy
+      .compactMap(openAndPrepareFile)
+      .forEach(processFile)
     }
   }
 

--- a/Tests/SwiftFormatTests/Frontend/FrontendIgnoreTests.swift
+++ b/Tests/SwiftFormatTests/Frontend/FrontendIgnoreTests.swift
@@ -1,0 +1,182 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+@_spi(Testing) @_spi(Internal) import SwiftFormat
+import Testing
+
+/// Tests for Frontend integration with .swift-format-ignore files
+@Suite
+struct FrontendIgnoreTests {
+
+  // MARK: - Test Setup Helpers
+
+  /// Creates a temporary directory structure for testing Frontend ignore functionality
+  /// and automatically cleans it up after the closure executes
+  private func withTestDirectory<T>(_ closure: (URL) throws -> T) throws -> T {
+    let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("SwiftFormatFrontendTests-\(UUID().uuidString)")
+
+    defer {
+      try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+    // Create test Swift files
+    let testFile1 = tempDir.appendingPathComponent("Test.swift")
+    try "class Test {}".write(to: testFile1, atomically: true, encoding: .utf8)
+
+    let ignoredFile = tempDir.appendingPathComponent("Generated.swift")
+    try "class Generated {}".write(to: ignoredFile, atomically: true, encoding: .utf8)
+
+    // Create subdirectory with files
+    let subDir = tempDir.appendingPathComponent("src")
+    try FileManager.default.createDirectory(at: subDir, withIntermediateDirectories: true)
+
+    let subFile1 = subDir.appendingPathComponent("Main.swift")
+    try "class Main {}".write(to: subFile1, atomically: true, encoding: .utf8)
+
+    let subFile2 = subDir.appendingPathComponent("Helper.swift")
+    try "class Helper {}".write(to: subFile2, atomically: true, encoding: .utf8)
+
+    // Create build directory that should be ignored
+    let buildDir = tempDir.appendingPathComponent("build")
+    try FileManager.default.createDirectory(at: buildDir, withIntermediateDirectories: true)
+
+    let buildFile = buildDir.appendingPathComponent("Build.swift")
+    try "class Build {}".write(to: buildFile, atomically: true, encoding: .utf8)
+
+    return try closure(tempDir)
+  }
+
+  // MARK: - FileIterator Integration Tests (Testing Through Frontend)
+
+  @Test func frontendUsesFileIteratorWithIgnoreManager() throws {
+    try withTestDirectory { testDir in
+      // Create .swift-format-ignore file
+      let ignoreFile = testDir.appendingPathComponent(".swift-format-ignore")
+      try "Generated.swift\nbuild/".write(to: ignoreFile, atomically: true, encoding: .utf8)
+
+      // Test that FileIterator respects ignore files when used through Frontend
+      // We'll test this by collecting all files that FileIterator would discover
+      let urls = [testDir]
+      let fileIterator = FileIterator(
+        urls: urls,
+        followSymlinks: false,
+        ignoreManager: IgnoreManager()
+      )
+
+      let discoveredFiles = Array(fileIterator).map { $0.lastPathComponent }.sorted()
+
+      // Verify that ignored files were filtered out by FileIterator
+      #expect(!discoveredFiles.contains("Generated.swift"))
+      #expect(!discoveredFiles.contains("Build.swift"))
+
+      // Verify that non-ignored files were included
+      #expect(discoveredFiles.contains("Test.swift"))
+      #expect(discoveredFiles.contains("Main.swift"))
+      #expect(discoveredFiles.contains("Helper.swift"))
+    }
+  }
+
+  @Test func frontendFileIteratorRespectsNestedIgnoreFiles() throws {
+    try withTestDirectory { testDir in
+      // Create root .swift-format-ignore
+      let rootIgnore = testDir.appendingPathComponent(".swift-format-ignore")
+      try "Generated.swift".write(to: rootIgnore, atomically: true, encoding: .utf8)
+
+      // Create nested .swift-format-ignore that has additional rules
+      let srcDir = testDir.appendingPathComponent("src")
+      let nestedIgnore = srcDir.appendingPathComponent(".swift-format-ignore")
+      try "Helper.swift".write(to: nestedIgnore, atomically: true, encoding: .utf8)
+
+      // Test FileIterator with ignore functionality
+      let urls = [testDir]
+      let fileIterator = FileIterator(
+        urls: urls,
+        followSymlinks: false,
+        ignoreManager: IgnoreManager()
+      )
+
+      let discoveredFiles = Array(fileIterator).map { $0.lastPathComponent }.sorted()
+
+      // Root ignore file should prevent Generated.swift from being discovered
+      #expect(!discoveredFiles.contains("Generated.swift"))
+
+      // Nested ignore file should prevent Helper.swift from being discovered
+      #expect(!discoveredFiles.contains("Helper.swift"))
+
+      // Other files should be discovered
+      #expect(discoveredFiles.contains("Test.swift"))
+      #expect(discoveredFiles.contains("Main.swift"))
+    }
+  }
+
+  @Test func frontendFileIteratorWithoutIgnoreManagerIncludesAllFiles() throws {
+    try withTestDirectory { testDir in
+      // Test FileIterator WITHOUT ignore functionality (current behavior)
+      let urls = [testDir]
+      let fileIterator = FileIterator(urls: urls, followSymlinks: false)
+
+      let discoveredFiles = Array(fileIterator).map { $0.lastPathComponent }.sorted()
+
+      // Without IgnoreManager, ALL Swift files should be discovered (including ignored ones)
+      #expect(discoveredFiles.contains("Generated.swift"))
+      #expect(discoveredFiles.contains("Build.swift"))
+      #expect(discoveredFiles.contains("Test.swift"))
+      #expect(discoveredFiles.contains("Main.swift"))
+      #expect(discoveredFiles.contains("Helper.swift"))
+    }
+  }
+
+  // MARK: - Frontend Integration Point Tests
+
+  @Test func frontendWillCreateIgnoreManagerWhenIntegrated() throws {
+    try withTestDirectory { testDir in
+      // This test documents the expected integration point in Frontend
+      // When Frontend.processURLs() creates FileIterator, it should:
+      // 1. Create an IgnoreManager with the appropriate base directory
+      // 2. Pass both IgnoreManager and baseDirectory to FileIterator
+
+      // For now, we test that our IgnoreManager works correctly with the expected setup
+      let urls = [testDir]
+
+      // This is what the integration should look like in Frontend.processURLs():
+      // let baseDirectory = /* determine from urls */
+      // let ignoreManager = IgnoreManager(baseDirectory: baseDirectory)
+      // let fileIterator = FileIterator(
+      //   urls: urls,
+      //   followSymlinks: lintFormatOptions.followSymlinks,
+      //   ignoreManager: ignoreManager,
+      //   baseDirectory: baseDirectory
+      // )
+
+      // Test that this setup works correctly
+      let baseDirectory = testDir
+      let ignoreManager = IgnoreManager()
+      let fileIterator = FileIterator(
+        urls: urls,
+        followSymlinks: false,
+        ignoreManager: ignoreManager
+      )
+
+      // Verify that the integration components work together
+      #expect(baseDirectory.path.contains("SwiftFormatFrontendTests"))
+
+      // FileIterator should work with these components
+      let files = Array(fileIterator)
+      #expect(!files.isEmpty)
+      #expect(files.allSatisfy { $0.pathExtension == "swift" })
+    }
+  }
+}

--- a/Tests/SwiftFormatTests/Utilities/FileIteratorIgnoreTests.swift
+++ b/Tests/SwiftFormatTests/Utilities/FileIteratorIgnoreTests.swift
@@ -1,0 +1,323 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+@_spi(Testing) import SwiftFormat
+@_spi(Internal) import SwiftFormat
+import Testing
+
+@Suite
+struct FileIteratorIgnoreTests {
+
+  // MARK: - Integration Tests
+
+  @Test func fileIteratorRespectsIgnoreFiles() throws {
+    try withTempDirectory { tempDir in
+      // Create some Swift files
+      let fileA = tempDir.appendingPathComponent("FileA.swift")
+      let fileB = tempDir.appendingPathComponent("FileB.generated.swift")
+      let fileC = tempDir.appendingPathComponent("FileC.swift")
+
+      try "// FileA".write(to: fileA, atomically: true, encoding: .utf8)
+      try "// FileB Generated".write(to: fileB, atomically: true, encoding: .utf8)
+      try "// FileC".write(to: fileC, atomically: true, encoding: .utf8)
+
+      // Create ignore file
+      let ignoreFile = tempDir.appendingPathComponent(".swift-format-ignore")
+      try "*.generated.swift".write(to: ignoreFile, atomically: true, encoding: .utf8)
+
+      // Create FileIterator with ignore support
+      var iterator = FileIterator(
+        urls: [tempDir],
+        followSymlinks: false,
+        workingDirectory: tempDir,
+        ignoreManager: IgnoreManager()
+      )
+
+      var foundFiles: [URL] = []
+      while let file = iterator.next() {
+        foundFiles.append(file)
+      }
+
+      // Should find FileA.swift and FileC.swift, but not FileB.generated.swift
+      #expect(foundFiles.count == 2)
+
+      let filenames = foundFiles.map { $0.lastPathComponent }.sorted()
+      #expect(filenames == ["FileA.swift", "FileC.swift"])
+    }
+  }
+
+  @Test func fileIteratorWithoutIgnoreManagerIncludesAllFiles() throws {
+    try withTempDirectory { tempDir in
+      // Create some Swift files
+      let fileA = tempDir.appendingPathComponent("FileA.swift")
+      let fileB = tempDir.appendingPathComponent("FileB.generated.swift")
+
+      try "// FileA".write(to: fileA, atomically: true, encoding: .utf8)
+      try "// FileB Generated".write(to: fileB, atomically: true, encoding: .utf8)
+
+      // Create FileIterator without ignore support
+      var iterator = FileIterator(urls: [tempDir], followSymlinks: false, workingDirectory: tempDir)
+
+      var foundFiles: [URL] = []
+      while let file = iterator.next() {
+        foundFiles.append(file)
+      }
+
+      // Should find both files when ignoring is disabled
+      #expect(foundFiles.count == 2)
+
+      let filenames = foundFiles.map { $0.lastPathComponent }.sorted()
+      #expect(filenames == ["FileA.swift", "FileB.generated.swift"])
+    }
+  }
+
+  @Test func fileIteratorRespectsNestedIgnoreFiles() throws {
+    try withTempDirectory { tempDir in
+      // Create nested directory structure
+      let srcDir = tempDir.appendingPathComponent("src")
+      let testDir = tempDir.appendingPathComponent("0test")
+      try FileManager.default.createDirectory(at: srcDir, withIntermediateDirectories: true)
+      try FileManager.default.createDirectory(at: testDir, withIntermediateDirectories: true)
+
+      // Create files
+      let mainFile = srcDir.appendingPathComponent("Main.swift")
+      let generatedFile = srcDir.appendingPathComponent("Generated.swift")
+      let testFile = testDir.appendingPathComponent("Test.swift")
+      let testGeneratedFile = testDir.appendingPathComponent("TestGenerated.swift")
+
+      try "// Main".write(to: mainFile, atomically: true, encoding: .utf8)
+      try "// Generated".write(to: generatedFile, atomically: true, encoding: .utf8)
+      try "// Test".write(to: testFile, atomically: true, encoding: .utf8)
+      try "// TestGenerated".write(to: testGeneratedFile, atomically: true, encoding: .utf8)
+
+      // Root ignore: ignore Generated.swift files
+      let rootIgnore = tempDir.appendingPathComponent(".swift-format-ignore")
+      try "Generated.swift".write(to: rootIgnore, atomically: true, encoding: .utf8)
+
+      // Test ignore: allow TestGenerated.swift (negation)
+      let testIgnore = testDir.appendingPathComponent(".swift-format-ignore")
+      try "!TestGenerated.swift".write(to: testIgnore, atomically: true, encoding: .utf8)
+
+      // Create FileIterator with ignore support
+      var iterator = FileIterator(
+        urls: [tempDir],
+        followSymlinks: false,
+        workingDirectory: tempDir,
+        ignoreManager: IgnoreManager()
+      )
+
+      var foundFiles: [URL] = []
+      while let file = iterator.next() {
+        foundFiles.append(file)
+      }
+
+      // Should find: Main.swift, Test.swift, TestGenerated.swift (negation overrides)
+      // Should NOT find: Generated.swift (ignored by root)
+      #expect(foundFiles.count == 3)
+
+      let filenames = foundFiles.map { $0.lastPathComponent }.sorted()
+      #expect(filenames == ["Main.swift", "Test.swift", "TestGenerated.swift"])
+    }
+  }
+
+  @Test(
+    .bug("https://github.com/swiftlang/swift-format/issues/1192")
+  )
+  func fileIteratorWithMultipleNonEmptySwiftIgoreFiles() throws {
+    try withTempDirectory { tempDir in
+      let srcDir = tempDir.appendingPathComponent("src")
+      let fixtureDir = tempDir.appendingPathComponent("Fixture")
+      let fixtureSubDir = fixtureDir.appendingPathComponent("MyFix")
+      try FileManager.default.createDirectory(at: srcDir, withIntermediateDirectories: true)
+      try FileManager.default.createDirectory(at: fixtureDir, withIntermediateDirectories: true)
+      try FileManager.default.createDirectory(at: fixtureSubDir, withIntermediateDirectories: true)
+
+      let rootFile = tempDir.appendingPathComponent("root.swift")
+      let srcFile1 = srcDir.appendingPathComponent("source1.swift")
+      let srcFile2 = srcDir.appendingPathComponent("include1.swift")
+      let fixtureSubFile1 = fixtureSubDir.appendingPathComponent("myfix-keep.swift")
+      let fixtureSubFile2 = fixtureSubDir.appendingPathComponent("myfix-negate-in-subdir.swift")
+      let fixtureFiles = (0...5).map {
+        fixtureSubDir.appendingPathComponent("myfixture_shouldIgnore_\($0).swift")
+      }
+
+      try "// root".write(to: rootFile, atomically: true, encoding: .utf8)
+      try "// source 1".write(to: srcFile1, atomically: true, encoding: .utf8)
+      try "// source 2".write(to: srcFile2, atomically: true, encoding: .utf8)
+      try "// fixture keep".write(to: fixtureSubFile1, atomically: true, encoding: .utf8)
+      try "// fixture keep negated in subdirectory".write(to: fixtureSubFile2, atomically: true, encoding: .utf8)
+      for (index, file) in fixtureFiles.enumerated() {
+        try "// fixture ignore \(index)".write(to: file, atomically: true, encoding: .utf8)
+      }
+
+      // Ignore source directory at root, but negate non-ignored files
+      let rootIgnore = tempDir.appendingPathComponent(".swift-format-ignore")
+      try """
+      src/
+      Fixture/
+      """.write(to: rootIgnore, atomically: true, encoding: .utf8)
+      let srcIgnore = srcDir.appendingPathComponent(".swift-format-ignore")
+      try "!include*.swift".write(to: srcIgnore, atomically: true, encoding: .utf8)
+      let fixtureIgnore = fixtureDir.appendingPathComponent(".swift-format-ignore")
+      try "!MyFix/*-keep.swift".write(to: fixtureIgnore, atomically: true, encoding: .utf8)
+      let fixtureSubIgnore = fixtureSubDir.appendingPathComponent(".swift-format-ignore")
+      try "!*-negate-in-subdir.swift".write(to: fixtureSubIgnore, atomically: true, encoding: .utf8)
+
+      var iterator = FileIterator(
+        urls: [tempDir],
+        followSymlinks: false,
+        workingDirectory: tempDir,
+        ignoreManager: IgnoreManager()
+      )
+
+      var foundFiles: [URL] = []
+      while let file = iterator.next() {
+        foundFiles.append(file)
+      }
+
+      // https://github.com/swiftlang/swift-format/issues/1192, Marking as intermittent as the root cause may be not be in this project
+      withKnownIssue(isIntermittent: true) {
+        // Should find: root.swift, src/source1.swift, Fixture/MyFixture/myfix-keep.swift, Fixture/MyFixture/myfix-negate-in-subdir.swift,
+        #expect(foundFiles.count == 4)
+
+        let actualFilenames = foundFiles.map { url in
+          url.standardizedFileURL.path
+        }.filter { !$0.isEmpty }.sorted()
+        #expect(
+          actualFilenames == [
+            tempDir.standardizedFileURL.appendingPathComponent("Fixture/MyFix/myfix-keep.swift").path,
+            tempDir.standardizedFileURL.appendingPathComponent("Fixture/MyFix/myfix-negate-in-subdir.swift").path,
+            tempDir.standardizedFileURL.appendingPathComponent("root.swift").path,
+            tempDir.standardizedFileURL.appendingPathComponent("src/include1.swift").path,
+          ]
+        )
+        let filenames = foundFiles.map { $0.lastPathComponent }.sorted()
+        #expect(filenames == ["include1.swift", "myfix-keep.swift", "myfix-negate-in-subdir.swift", "root.swift"])
+      } when: {
+        #if os(Windows)
+        true
+        #else
+        false
+        #endif
+      }
+
+    }
+  }
+  @Test func fileIteratorHandlesDirectoryOnlyPatterns() throws {
+    try withTempDirectory { tempDir in
+      // Create directory structure
+      let buildDir = tempDir.appendingPathComponent("build")
+      let srcDir = tempDir.appendingPathComponent("src")
+      try FileManager.default.createDirectory(at: buildDir, withIntermediateDirectories: true)
+      try FileManager.default.createDirectory(at: srcDir, withIntermediateDirectories: true)
+
+      // Create files
+      let buildFile = buildDir.appendingPathComponent("Build.swift")
+      let srcFile = srcDir.appendingPathComponent("Source.swift")
+      let rootFile = tempDir.appendingPathComponent("build.swift")  // File, not directory
+
+      try "// Build".write(to: buildFile, atomically: true, encoding: .utf8)
+      try "// Source".write(to: srcFile, atomically: true, encoding: .utf8)
+      try "// Root build file".write(to: rootFile, atomically: true, encoding: .utf8)
+
+      // Ignore build directory, but not build files
+      let ignoreFile = tempDir.appendingPathComponent(".swift-format-ignore")
+      try "build/".write(to: ignoreFile, atomically: true, encoding: .utf8)
+
+      // Create FileIterator with ignore support
+      var iterator = FileIterator(
+        urls: [tempDir],
+        followSymlinks: false,
+        workingDirectory: tempDir,
+        ignoreManager: IgnoreManager()
+      )
+
+      var foundFiles: [URL] = []
+      while let file = iterator.next() {
+        foundFiles.append(file)
+      }
+
+      // Should find: Source.swift, build.swift (file, not directory)
+      // Should NOT find: Build.swift (in ignored build/ directory)
+      #expect(foundFiles.count == 2)
+
+      let filenames = foundFiles.map { $0.lastPathComponent }.sorted()
+      #expect(filenames == ["Source.swift", "build.swift"])
+    }
+  }
+
+  @Test func fileIteratorStopsAtDirectoryWithSwiftFormatFile() throws {
+    try withTempDirectory { tempDir in
+      // Create nested directory structure: tempDir/project/src/main/
+      let projectDir = tempDir.appendingPathComponent("project")
+      let srcDir = projectDir.appendingPathComponent("src")
+      let mainDir = srcDir.appendingPathComponent("main")
+      try FileManager.default.createDirectory(at: mainDir, withIntermediateDirectories: true)
+
+      // Create Swift files
+      let mainFile = mainDir.appendingPathComponent("Main.swift")
+      let testFile = mainDir.appendingPathComponent("Root.has.this.ignore.swift")
+      let utilFile = srcDir.appendingPathComponent("src.util.test.swift")
+
+      try "// Main".write(to: mainFile, atomically: true, encoding: .utf8)
+      try "// Test Generated".write(to: testFile, atomically: true, encoding: .utf8)
+      try "// Util Test".write(to: utilFile, atomically: true, encoding: .utf8)
+
+      // Create .swift-format-ignore at root level (should be ignored due to project boundary)
+      let rootIgnore = tempDir.appendingPathComponent(".swift-format-ignore")
+      try "*.ignore.swift".write(to: rootIgnore, atomically: true, encoding: .utf8)
+
+      // Create .swift-format configuration file at project level (creates boundary)
+      let projectConfig = projectDir.appendingPathComponent(".swift-format")
+      try "{}".write(to: projectConfig, atomically: true, encoding: .utf8)
+
+      // Create .swift-format-ignore at src level (should be respected)
+      let srcIgnore = srcDir.appendingPathComponent(".swift-format-ignore")
+      try "*.test.swift".write(to: srcIgnore, atomically: true, encoding: .utf8)
+
+      // Create FileIterator with ignore support
+      var iterator = FileIterator(
+        urls: [projectDir],  // Start from project directory
+        followSymlinks: false,
+        workingDirectory: projectDir,
+        ignoreManager: IgnoreManager()
+      )
+
+      var foundFiles: [URL] = []
+      while let file = iterator.next() {
+        foundFiles.append(file)
+      }
+
+      // Should find: Main.swift, Test.generated.swift (because root ignore is not applied)
+      // Should NOT find: Util.test.swift (ignored by src ignore file)
+      #expect(foundFiles.count == 2)
+
+      let filenames = foundFiles.map { $0.standardizedFileURL.path }.sorted()
+      #expect(
+        filenames == [
+          mainFile.standardizedFileURL.path,
+          testFile.standardizedFileURL.path,
+        ]
+      )
+    }
+  }
+}
+
+// MARK: - Helper Methods
+
+private func withTempDirectory<T>(_ body: (URL) throws -> T) throws -> T {
+  let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+  try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+  defer { try? FileManager.default.removeItem(at: tempDir) }
+  return try body(tempDir)
+}

--- a/Tests/SwiftFormatTests/Utilities/GitIgnorePatternTests.swift
+++ b/Tests/SwiftFormatTests/Utilities/GitIgnorePatternTests.swift
@@ -1,0 +1,348 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(Internal) import SwiftFormat
+import Testing
+
+@Suite
+struct GitIgnorePatternTests {
+
+  // MARK: - Basic Pattern Matching Tests
+
+  @Test func exactMatch() throws {
+    let pattern = try GitIgnorePattern("test.swift")
+
+    #expect(pattern.matches("test.swift", isDirectory: false) == true)
+    #expect(pattern.matches("other.swift", isDirectory: false) == false)
+    #expect(pattern.matches("test.swif", isDirectory: false) == false)
+  }
+
+  @Test func exactMatchWithDirectory() throws {
+    let pattern = try GitIgnorePattern("src")
+
+    #expect(pattern.matches("src", isDirectory: true) == true)
+    #expect(pattern.matches("src", isDirectory: false) == true)
+    #expect(pattern.matches("source", isDirectory: true) == false)
+  }
+
+  @Test func singleWildcardPattern() throws {
+    let pattern = try GitIgnorePattern("*.swift")
+
+    #expect(pattern.matches("test.swift", isDirectory: false) == true)
+    #expect(pattern.matches("main.swift", isDirectory: false) == true)
+    #expect(pattern.matches("src/foo/testa.swift", isDirectory: false) == true)
+    #expect(pattern.matches("/absolute/pathsrc/foo/testa.swift", isDirectory: false) == true)
+    #expect(pattern.matches("test.java", isDirectory: false) == false)
+    #expect(pattern.matches("swift", isDirectory: false) == false)
+  }
+
+  @Test func questionMarkWildcard() throws {
+    let pattern = try GitIgnorePattern("test?.swift")
+
+    #expect(pattern.matches("test1.swift", isDirectory: false) == true)
+    #expect(pattern.matches("testa.swift", isDirectory: false) == true)
+    #expect(pattern.matches("src/foo/testa.swift", isDirectory: false) == true)
+    #expect(pattern.matches("/absolute/pathsrc/foo/testa.swift", isDirectory: false) == true)
+    #expect(pattern.matches("test.swift", isDirectory: false) == false)
+    #expect(pattern.matches("test12.swift", isDirectory: false) == false)
+  }
+
+  @Test func directoryOnlyPattern() throws {
+    let pattern = try GitIgnorePattern("build/")
+
+    #expect(pattern.matches("build", isDirectory: true) == true)
+    #expect(pattern.matches("build", isDirectory: false) == false)
+    #expect(pattern.matches("build.txt", isDirectory: false) == false)
+  }
+
+  // MARK: - Pattern Properties Tests
+
+  @Test func negationPatternDetection() throws {
+    let normalPattern = try GitIgnorePattern("test.swift")
+    let negationPattern = try GitIgnorePattern("!test.swift")
+
+    #expect(normalPattern.isNegation == false)
+    #expect(negationPattern.isNegation == true)
+  }
+
+  @Test func directoryOnlyPatternDetection() throws {
+    let filePattern = try GitIgnorePattern("test.swift")
+    let dirPattern = try GitIgnorePattern("build/")
+
+    #expect(filePattern.isDirectoryOnly == false)
+    #expect(dirPattern.isDirectoryOnly == true)
+  }
+
+  // MARK: - Advanced Pattern Matching Tests (These will fail initially)
+
+  @Test func doubleAsteriskPattern() throws {
+    let pattern = try GitIgnorePattern("**/test.swift")
+
+    // Should match files at any depth
+    #expect(pattern.matches("test.swift", isDirectory: false) == true)
+    #expect(pattern.matches("src/test.swift", isDirectory: false) == true)
+    #expect(pattern.matches("src/main/test.swift", isDirectory: false) == true)
+    #expect(pattern.matches("/src/main/test.swift", isDirectory: false) == true)
+    #expect(pattern.matches("test.java", isDirectory: false) == false)
+  }
+
+  @Test func doubleAsteriskDirectoryPattern() throws {
+    let pattern = try GitIgnorePattern("src/**/build")
+
+    // Should match directories under src at any depth
+    #expect(pattern.matches("src/build", isDirectory: true) == true)
+    #expect(pattern.matches("src/main/build", isDirectory: true) == true)
+    #expect(pattern.matches("src/main/java/build", isDirectory: true) == true)
+    #expect(pattern.matches("build", isDirectory: true) == false)
+    #expect(pattern.matches("other/build", isDirectory: true) == false)
+  }
+
+  @Test func trailingDoubleAsteriskPattern() throws {
+    let pattern = try GitIgnorePattern("build/**")
+
+    // Should match everything under build directory
+    #expect(pattern.matches("build/file.swift", isDirectory: false) == true)
+    #expect(pattern.matches("build/sub/file.swift", isDirectory: false) == true)
+    #expect(pattern.matches("build/sub/deep/file.swift", isDirectory: false) == true)
+    #expect(pattern.matches("build", isDirectory: true) == false)  // build itself should not match
+    #expect(pattern.matches("other/file.swift", isDirectory: false) == false)
+  }
+
+  @Test func absolutePathPattern() throws {
+    let pattern = try GitIgnorePattern("/root.swift")
+
+    // Should only match at root level
+    #expect(pattern.matches("root.swift", isDirectory: false) == true)
+    #expect(pattern.matches("src/root.swift", isDirectory: false) == false)
+    #expect(pattern.matches("sub/dir/root.swift", isDirectory: false) == false)
+  }
+
+  @Test func negationPatternBehavior() throws {
+    // This will need multiple patterns to test properly, but test basic negation matching
+    let negationPattern = try GitIgnorePattern("!important.swift")
+
+    // Negation patterns should still match the path, but be marked as negation
+    #expect(negationPattern.matches("important.swift", isDirectory: false) == true)
+    #expect(negationPattern.isNegation == true)
+    #expect(negationPattern.matches("other.swift", isDirectory: false) == false)
+  }
+
+  @Test func complexWildcardPattern() throws {
+    let pattern = try GitIgnorePattern("test*.swift")
+
+    #expect(pattern.matches("test.swift", isDirectory: false) == true)
+    #expect(pattern.matches("test1.swift", isDirectory: false) == true)
+    #expect(pattern.matches("testFile.swift", isDirectory: false) == true)
+    #expect(pattern.matches("mytest.swift", isDirectory: false) == false)
+    #expect(pattern.matches("test.java", isDirectory: false) == false)
+  }
+
+  @Test func middleWildcardPattern() throws {
+    let pattern = try GitIgnorePattern("test*file.swift")
+
+    #expect(pattern.matches("testfile.swift", isDirectory: false) == true)
+    #expect(pattern.matches("test1file.swift", isDirectory: false) == true)
+    #expect(pattern.matches("testMainfile.swift", isDirectory: false) == true)
+    #expect(pattern.matches("test.swift", isDirectory: false) == false)
+    #expect(pattern.matches("file.swift", isDirectory: false) == false)
+  }
+
+  @Test func multipleQuestionMarkPattern() throws {
+    let pattern = try GitIgnorePattern("test??.swift")
+
+    #expect(pattern.matches("test12.swift", isDirectory: false) == true)
+    #expect(pattern.matches("testAB.swift", isDirectory: false) == true)
+    #expect(pattern.matches("test1.swift", isDirectory: false) == false)
+    #expect(pattern.matches("test123.swift", isDirectory: false) == false)
+    #expect(pattern.matches("test.swift", isDirectory: false) == false)
+  }
+
+  // MARK: - Error Handling and Edge Cases
+
+  @Test func invalidEmptyPattern() throws {
+    #expect(throws: GitIgnorePattern.PatternError.self) {
+      try GitIgnorePattern("")
+    }
+  }
+
+  @Test func invalidEmptyNegationPattern() throws {
+    #expect(throws: GitIgnorePattern.PatternError.self) {
+      try GitIgnorePattern("!")
+    }
+  }
+
+  @Test func invalidEmptyDirectoryPattern() throws {
+    #expect(throws: GitIgnorePattern.PatternError.self) {
+      try GitIgnorePattern("/")
+    }
+  }
+
+  @Test func negationDirectoryPattern() throws {
+    let pattern = try GitIgnorePattern("!build/")
+
+    #expect(pattern.isNegation == true)
+    #expect(pattern.isDirectoryOnly == true)
+    #expect(pattern.matches("build", isDirectory: true) == true)
+    #expect(pattern.matches("build", isDirectory: false) == false)
+  }
+
+  @Test func wildcardDoesNotCrossDirectoryBoundary() throws {
+    let pattern = try GitIgnorePattern("src/*.swift")
+
+    #expect(pattern.matches("src/file.swift", isDirectory: false) == true)
+    #expect(pattern.matches("src/sub/file.swift", isDirectory: false) == false)
+  }
+
+  @Test func questionMarkDoesNotMatchSlash() throws {
+    let pattern = try GitIgnorePattern("test?file")
+
+    #expect(pattern.matches("testAfile", isDirectory: false) == true)
+    #expect(pattern.matches("test/file", isDirectory: false) == false)
+  }
+
+  @Test func specialCharactersInPattern() throws {
+    let pattern = try GitIgnorePattern("test[abc].swift")
+
+    // For now, this should match exactly (no character class expansion)
+    #expect(pattern.matches("test[abc].swift", isDirectory: false) == true)
+    #expect(pattern.matches("testa.swift", isDirectory: false) == false)
+  }
+
+  @Test func patternWithSpaces() throws {
+    let pattern = try GitIgnorePattern("file with spaces.swift")
+
+    #expect(pattern.matches("file with spaces.swift", isDirectory: false) == true)
+    #expect(pattern.matches("file_with_spaces.swift", isDirectory: false) == false)
+  }
+
+  // MARK: - Directory-Only Pattern Behavior
+
+  @Test func directoryOnlyPatternMatchesFilesInsideDirectory() throws {
+    let pattern = try GitIgnorePattern("build/")
+
+    #expect(pattern.isDirectoryOnly == true)
+
+    // Should match the directory itself
+    #expect(pattern.matches("build", isDirectory: true) == true)
+
+    // Should match files inside the directory
+    #expect(pattern.matches("build/file.swift", isDirectory: false) == true)
+    #expect(pattern.matches("build/subfolder/file.swift", isDirectory: false) == true)
+
+    // Should NOT match files at root with same name
+    #expect(pattern.matches("build.swift", isDirectory: false) == false)
+
+    // Should NOT match files in different directories
+    #expect(pattern.matches("src/build.swift", isDirectory: false) == false)
+    #expect(pattern.matches("src/file.swift", isDirectory: false) == false)
+  }
+
+  @Test func nestedDirectoryOnlyPattern() throws {
+    let pattern = try GitIgnorePattern("src/build/")
+
+    #expect(pattern.isDirectoryOnly)
+
+    // Should match files inside the nested directory
+    #expect(pattern.matches("src/build/file.swift", isDirectory: false) == true)
+    #expect(pattern.matches("src/build/deep/file.swift", isDirectory: false) == true)
+
+    // Should NOT match files in parent directory
+    #expect(pattern.matches("src/file.swift", isDirectory: false) == false)
+
+    // Should NOT match files in different paths
+    #expect(pattern.matches("build/file.swift", isDirectory: false) == false)
+    #expect(pattern.matches("other/src/build/file.swift", isDirectory: false) == false)
+  }
+
+  // MARK: - Simple Filename Pattern Behavior
+
+  @Test func simpleFilenamePatternMatchesAnywhere() throws {
+    let pattern = try GitIgnorePattern("Generated.swift")
+
+    #expect(pattern.isDirectoryOnly == false)
+    #expect(pattern.isNegation == false)
+
+    // Should match filename at root
+    #expect(pattern.matches("Generated.swift", isDirectory: false) == true)
+
+    // Should match filename in any subdirectory
+    #expect(pattern.matches("src/Generated.swift", isDirectory: false) == true)
+    #expect(pattern.matches("test/models/Generated.swift", isDirectory: false) == true)
+    #expect(pattern.matches("deep/nested/path/Generated.swift", isDirectory: false) == true)
+
+    // Should NOT match partial matches
+    #expect(pattern.matches("MyGenerated.swift", isDirectory: false) == false)
+    #expect(pattern.matches("Generated.swift.backup", isDirectory: false) == false)
+
+    // Should NOT match directories
+    #expect(pattern.matches("src/Generated.swift", isDirectory: true) == false)
+  }
+
+  @Test func simpleFilenamePatternVsPathPattern() throws {
+    let filenamePattern = try GitIgnorePattern("file.swift")
+    let pathPattern = try GitIgnorePattern("src/file.swift")
+
+    let testPath = "src/file.swift"
+
+    // Filename pattern should match (matches filename anywhere)
+    #expect(filenamePattern.matches(testPath, isDirectory: false) == true)
+
+    // Path pattern should match (exact path match)
+    #expect(pathPattern.matches(testPath, isDirectory: false) == true)
+
+    let differentPath = "test/file.swift"
+
+    // Filename pattern should still match (matches filename anywhere)
+    #expect(filenamePattern.matches(differentPath, isDirectory: false) == true)
+
+    // Path pattern should NOT match (different path)
+    #expect(pathPattern.matches(differentPath, isDirectory: false) == false)
+  }
+
+  @Test func doubleAsteriskWithWildcardSuffix() throws {
+    let pattern = try GitIgnorePattern("level1/level2/level3/**/*.swift")
+
+    // Should match files with wildcard suffix at any depth under the prefix
+    #expect(pattern.matches("level1/level2/level3/File.swift", isDirectory: false) == true)
+    #expect(pattern.matches("level1/level2/level3/level4/File.swift", isDirectory: false) == true)
+    #expect(pattern.matches("level1/level2/level3/level4/level5/Deep.swift", isDirectory: false) == true)
+    #expect(pattern.matches("level1/level2/level3/a/b/c/d/VeryDeep.swift", isDirectory: false) == true)
+
+    // Should not match files outside the prefix
+    #expect(pattern.matches("level1/level2/File.swift", isDirectory: false) == false)
+    #expect(pattern.matches("other/level3/File.swift", isDirectory: false) == false)
+
+    // Should not match non-Swift files
+    #expect(pattern.matches("level1/level2/level3/level4/File.java", isDirectory: false) == false)
+    #expect(pattern.matches("level1/level2/level3/File.txt", isDirectory: false) == false)
+
+    // Should not match directories
+    #expect(pattern.matches("level1/level2/level3/level4/MyDir.swift", isDirectory: true) == false)
+  }
+
+  @Test func doubleAsteriskWithComplexWildcardSuffix() throws {
+    let pattern = try GitIgnorePattern("src/**/test*.swift")
+
+    // Should match files with complex wildcard suffix
+    #expect(pattern.matches("src/test.swift", isDirectory: false) == true)
+    #expect(pattern.matches("src/testUtils.swift", isDirectory: false) == true)
+    #expect(pattern.matches("src/deep/testHelper.swift", isDirectory: false) == true)
+    #expect(pattern.matches("src/very/deep/nested/testCase.swift", isDirectory: false) == true)
+
+    // Should not match files that don't start with "test"
+    #expect(pattern.matches("src/main.swift", isDirectory: false) == false)
+    #expect(pattern.matches("src/deep/helper.swift", isDirectory: false) == false)
+
+    // Should not match files outside src
+    #expect(pattern.matches("other/test.swift", isDirectory: false) == false)
+  }
+}

--- a/Tests/SwiftFormatTests/Utilities/IgnoreEdgeCaseTests.swift
+++ b/Tests/SwiftFormatTests/Utilities/IgnoreEdgeCaseTests.swift
@@ -1,0 +1,300 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+@_spi(Internal) import SwiftFormat
+import Testing
+
+/// Tests for edge cases and error handling in .swift-format-ignore functionality
+@Suite
+struct IgnoreEdgeCaseTests {
+
+  // MARK: - Test Setup Helpers
+
+  /// Creates a temporary directory structure for testing edge cases
+  private func withTestDirectory<T>(_ closure: (URL) throws -> T) throws -> T {
+    let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("SwiftFormatEdgeCaseTests-\(UUID().uuidString)")
+
+    defer {
+      try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    return try closure(tempDir)
+  }
+
+  // MARK: - Invalid Pattern Tests
+
+  @Test func invalidPatternsShouldBeSkipped() throws {
+    try withTestDirectory { testDir in
+      // Create ignore file with mix of valid and invalid patterns
+      let ignoreFile = testDir.appendingPathComponent(".swift-format-ignore")
+      let invalidPatterns = """
+        # This is a comment
+        ValidFile.swift
+
+
+        !ValidNegation.swift
+        # Another comment
+        """
+      try invalidPatterns.write(to: ignoreFile, atomically: true, encoding: .utf8)
+
+      // Create test files
+      let validFile = testDir.appendingPathComponent("ValidFile.swift")
+      try "class ValidFile {}".write(to: validFile, atomically: true, encoding: .utf8)
+
+      let negationFile = testDir.appendingPathComponent("ValidNegation.swift")
+      try "class ValidNegation {}".write(to: negationFile, atomically: true, encoding: .utf8)
+
+      let otherFile = testDir.appendingPathComponent("Other.swift")
+      try "class Other {}".write(to: otherFile, atomically: true, encoding: .utf8)
+
+      let ignoreManager = IgnoreManager()
+
+      // Valid patterns should work
+      #expect(ignoreManager.shouldIgnore(file: validFile, isDirectory: false))
+      #expect(!ignoreManager.shouldIgnore(file: negationFile, isDirectory: false))
+      #expect(!ignoreManager.shouldIgnore(file: otherFile, isDirectory: false))
+    }
+  }
+
+  @Test func emptyIgnoreFileShouldNotCauseErrors() throws {
+    try withTestDirectory { testDir in
+      // Create empty ignore file
+      let ignoreFile = testDir.appendingPathComponent(".swift-format-ignore")
+      try "".write(to: ignoreFile, atomically: true, encoding: .utf8)
+
+      // Create test file
+      let testFile = testDir.appendingPathComponent("Test.swift")
+      try "class Test {}".write(to: testFile, atomically: true, encoding: .utf8)
+
+      let ignoreManager = IgnoreManager()
+
+      // Should not ignore any files
+      #expect(!ignoreManager.shouldIgnore(file: testFile, isDirectory: false))
+    }
+  }
+
+  @Test func ignoreFileWithOnlyCommentsAndWhitespace() throws {
+    try withTestDirectory { testDir in
+      // Create ignore file with only comments and whitespace
+      let ignoreFile = testDir.appendingPathComponent(".swift-format-ignore")
+      let content = """
+        # This is just a comment file
+
+
+        # Another comment
+
+
+        # Final comment
+        """
+      try content.write(to: ignoreFile, atomically: true, encoding: .utf8)
+
+      // Create test file
+      let testFile = testDir.appendingPathComponent("Test.swift")
+      try "class Test {}".write(to: testFile, atomically: true, encoding: .utf8)
+
+      let ignoreManager = IgnoreManager()
+
+      // Should not ignore any files
+      #expect(!ignoreManager.shouldIgnore(file: testFile, isDirectory: false))
+    }
+  }
+
+  // MARK: - Missing File Tests
+
+  @Test func nonExistentIgnoreFileShouldNotCauseErrors() throws {
+    try withTestDirectory { testDir in
+      // Create test file without any ignore file
+      let testFile = testDir.appendingPathComponent("Test.swift")
+      try "class Test {}".write(to: testFile, atomically: true, encoding: .utf8)
+
+      let ignoreManager = IgnoreManager()
+
+      // Should not ignore any files when no ignore file exists
+      #expect(!ignoreManager.shouldIgnore(file: testFile, isDirectory: false))
+    }
+  }
+
+  @Test func nonExistentFileShouldNotCauseErrors() throws {
+    try withTestDirectory { testDir in
+      // Create ignore file
+      let ignoreFile = testDir.appendingPathComponent(".swift-format-ignore")
+      try "*.swift".write(to: ignoreFile, atomically: true, encoding: .utf8)
+
+      // Test with non-existent file
+      let nonExistentFile = testDir.appendingPathComponent("NonExistent.swift")
+
+      let ignoreManager = IgnoreManager()
+
+      // Should handle non-existent files gracefully
+      #expect(ignoreManager.shouldIgnore(file: nonExistentFile, isDirectory: false))
+    }
+  }
+
+  // MARK: - Symlink Tests
+
+  @Test func symlinksShouldBeHandledCorrectly() throws {
+    try withTestDirectory { testDir in
+      // Create a real file
+      let realFile = testDir.appendingPathComponent("RealFile.swift")
+      try "class RealFile {}".write(to: realFile, atomically: true, encoding: .utf8)
+
+      // Create a symlink to the real file
+      let symlinkFile = testDir.appendingPathComponent("SymlinkFile.swift")
+      try FileManager.default.createSymbolicLink(at: symlinkFile, withDestinationURL: realFile)
+
+      // Create ignore file that ignores symlinks
+      let ignoreFile = testDir.appendingPathComponent(".swift-format-ignore")
+      try "SymlinkFile.swift".write(to: ignoreFile, atomically: true, encoding: .utf8)
+
+      let ignoreManager = IgnoreManager()
+
+      // Real file should not be ignored
+      #expect(!ignoreManager.shouldIgnore(file: realFile, isDirectory: false))
+
+      // Symlink should be ignored
+      #expect(ignoreManager.shouldIgnore(file: symlinkFile, isDirectory: false))
+    }
+  }
+
+  // MARK: - Large File Tests
+
+  @Test func largeIgnoreFileShouldBeHandledEfficiently() throws {
+    try withTestDirectory { testDir in
+      // Create large ignore file with many patterns
+      let ignoreFile = testDir.appendingPathComponent(".swift-format-ignore")
+      var patterns: [String] = []
+
+      // Generate 1000 patterns
+      for i in 0..<1000 {
+        patterns.append("Generated\(i).swift")
+        patterns.append("Test\(i).swift")
+        patterns.append("build/Output\(i).swift")
+      }
+
+      try patterns.joined(separator: "\n").write(to: ignoreFile, atomically: true, encoding: .utf8)
+
+      // Create test files
+      let matchedFile = testDir.appendingPathComponent("Generated500.swift")
+      try "class Generated500 {}".write(to: matchedFile, atomically: true, encoding: .utf8)
+
+      let unmatchedFile = testDir.appendingPathComponent("Regular.swift")
+      try "class Regular {}".write(to: unmatchedFile, atomically: true, encoding: .utf8)
+
+      let ignoreManager = IgnoreManager()
+
+      // Should handle large ignore files efficiently
+      #expect(ignoreManager.shouldIgnore(file: matchedFile, isDirectory: false))
+      #expect(!ignoreManager.shouldIgnore(file: unmatchedFile, isDirectory: false))
+    }
+  }
+
+  // MARK: - Path Edge Cases
+
+  @Test func specialCharactersInPathsShouldBeHandled() throws {
+    try withTestDirectory { testDir in
+      // Create directories and files with special characters
+      let specialDir = testDir.appendingPathComponent("special-chars & spaces")
+      try FileManager.default.createDirectory(at: specialDir, withIntermediateDirectories: true)
+
+      let specialFile = specialDir.appendingPathComponent("file with spaces & symbols.swift")
+      try "class SpecialFile {}".write(to: specialFile, atomically: true, encoding: .utf8)
+
+      // Create ignore file
+      let ignoreFile = testDir.appendingPathComponent(".swift-format-ignore")
+      try "special-chars & spaces/file with spaces & symbols.swift".write(
+        to: ignoreFile,
+        atomically: true,
+        encoding: .utf8
+      )
+
+      let ignoreManager = IgnoreManager()
+
+      // Should handle special characters correctly
+      #expect(ignoreManager.shouldIgnore(file: specialFile, isDirectory: false))
+    }
+  }
+
+  // MARK: - Caching Tests
+
+  @Test func ignoreManagerShouldCacheLoadedFiles() throws {
+    try withTestDirectory { testDir in
+      // Create ignore file
+      let ignoreFile = testDir.appendingPathComponent(".swift-format-ignore")
+      try "*.generated".write(to: ignoreFile, atomically: true, encoding: .utf8)
+
+      // Create test files
+      let file1 = testDir.appendingPathComponent("File1.generated")
+      let file2 = testDir.appendingPathComponent("File2.generated")
+      try "content1".write(to: file1, atomically: true, encoding: .utf8)
+      try "content2".write(to: file2, atomically: true, encoding: .utf8)
+
+      let ignoreManager = IgnoreManager()
+
+      // First call should load and cache the ignore file
+      #expect(ignoreManager.shouldIgnore(file: file1, isDirectory: false))
+
+      // Second call should use cached version
+      #expect(ignoreManager.shouldIgnore(file: file2, isDirectory: false))
+
+      // Verify caching by modifying the file after first load
+      try "# modified content\n*.different".write(to: ignoreFile, atomically: true, encoding: .utf8)
+
+      // Should still use cached version
+      #expect(ignoreManager.shouldIgnore(file: file1, isDirectory: false))
+    }
+  }
+
+  // MARK: - Unicode and Encoding Tests
+
+  @Test func unicodeCharactersInPatternsAndPathsShouldWork() throws {
+    try withTestDirectory { testDir in
+      // Create file with unicode characters
+      let unicodeFile = testDir.appendingPathComponent("测试文件.swift")
+      try "class TestFile {}".write(to: unicodeFile, atomically: true, encoding: .utf8)
+
+      // Create ignore file with unicode pattern
+      let ignoreFile = testDir.appendingPathComponent(".swift-format-ignore")
+      try "测试文件.swift".write(to: ignoreFile, atomically: true, encoding: .utf8)
+
+      let ignoreManager = IgnoreManager()
+
+      // Should handle unicode correctly
+      #expect(ignoreManager.shouldIgnore(file: unicodeFile, isDirectory: false))
+    }
+  }
+
+  // MARK: - Nested Directory Edge Cases
+
+  @Test func deeplyNestedDirectoriesShouldWork() throws {
+    try withTestDirectory { testDir in
+      // Create deeply nested structure
+      let deepPath = "level1/level2/level3/level4/level5"
+      let deepDir = testDir.appendingPathComponent(deepPath)
+      try FileManager.default.createDirectory(at: deepDir, withIntermediateDirectories: true)
+
+      let deepFile = deepDir.appendingPathComponent("Deep.swift")
+      try "class Deep {}".write(to: deepFile, atomically: true, encoding: .utf8)
+
+      // Create ignore file at root
+      let ignoreFile = testDir.appendingPathComponent(".swift-format-ignore")
+      try "level1/level2/level3/**/*.swift".write(to: ignoreFile, atomically: true, encoding: .utf8)
+
+      let ignoreManager = IgnoreManager()
+
+      // Should match files in deeply nested directories
+      #expect(ignoreManager.shouldIgnore(file: deepFile, isDirectory: false))
+    }
+  }
+}

--- a/Tests/SwiftFormatTests/Utilities/IgnoreManagerTests.swift
+++ b/Tests/SwiftFormatTests/Utilities/IgnoreManagerTests.swift
@@ -1,0 +1,267 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+@_spi(Internal) import SwiftFormat
+import Testing
+
+@Suite
+struct IgnoreManagerTests {
+
+  // MARK: - File Discovery Tests
+
+  @Suite
+  struct FindIgnoreFilesTests {
+    @Test func findIgnoreFilesInSingleDirectory() throws {
+      try withTempDirectory { tempDir in
+        // Create a .swift-format-ignore file
+        let ignoreFile = tempDir.appendingPathComponent(".swift-format-ignore")
+        try "*.generated.swift".write(to: ignoreFile, atomically: true, encoding: .utf8)
+
+        let manager = IgnoreManager()
+        let foundFiles = manager.findIgnoreFiles(for: tempDir.appendingPathComponent("test.swift"))
+
+        #expect(foundFiles.count == 1)
+        #expect(foundFiles.first == ignoreFile)
+      }
+    }
+
+    @Test func findIgnoreFilesForNonExistingFileReturnEmptyArray() throws {
+      try withTempDirectory { tempDir in
+        let manager = IgnoreManager()
+        let foundFiles = manager.findIgnoreFiles(for: tempDir.appendingPathComponent("test.swift"))
+
+        #expect(foundFiles.count == 0)
+        #expect(foundFiles.isEmpty == true)
+      }
+    }
+
+    @Test func findIgnoreFilesWalkingUpDirectoryTree() throws {
+      try withTempDirectory { tempDir in
+        // Create nested directory structure: tempDir/src/main/
+        let srcDir = tempDir.appendingPathComponent("src")
+        let mainDir = srcDir.appendingPathComponent("main")
+        try FileManager.default.createDirectory(at: mainDir, withIntermediateDirectories: true)
+
+        // Create ignore files at different levels
+        let rootIgnore = tempDir.appendingPathComponent(".swift-format-ignore")
+        let srcIgnore = srcDir.appendingPathComponent(".swift-format-ignore")
+
+        try "*.generated.swift".write(to: rootIgnore, atomically: true, encoding: .utf8)
+        try "*.test.swift".write(to: srcIgnore, atomically: true, encoding: .utf8)
+
+        let manager = IgnoreManager()
+        let testFile = mainDir.appendingPathComponent("MyFile.swift")
+        let foundFiles = manager.findIgnoreFiles(for: testFile)
+
+        // Should find both files, with closest first (src, then root)
+        #expect(foundFiles.count == 2)
+        #expect(foundFiles[0] == srcIgnore)  // Closest
+        #expect(foundFiles[1] == rootIgnore)  // Further
+      }
+    }
+
+    @Test func stopAtDirectoryWithSwiftFormatFile() throws {
+      try withTempDirectory { tempDir in
+        // Create nested directory structure: tempDir/project/src/main/
+        let projectDir = tempDir.appendingPathComponent("project")
+        let srcDir = projectDir.appendingPathComponent("src")
+        let mainDir = srcDir.appendingPathComponent("main")
+        try FileManager.default.createDirectory(at: mainDir, withIntermediateDirectories: true)
+
+        // Create .swift-format-ignore at root level
+        let rootIgnore = tempDir.appendingPathComponent(".swift-format-ignore")
+        try "*.generated.swift".write(to: rootIgnore, atomically: true, encoding: .utf8)
+
+        // Create .swift-format configuration file at project level
+        let projectConfig = projectDir.appendingPathComponent(".swift-format")
+        try "{}".write(to: projectConfig, atomically: true, encoding: .utf8)
+
+        // Create .swift-format-ignore at src level
+        let srcIgnore = srcDir.appendingPathComponent(".swift-format-ignore")
+        try "*.test.swift".write(to: srcIgnore, atomically: true, encoding: .utf8)
+
+        let manager = IgnoreManager()
+        let testFile = mainDir.appendingPathComponent("MyFile.test.swift")
+        let foundFiles = manager.findIgnoreFiles(for: testFile)
+
+        // Should only find the src ignore file and not traverse past the project directory
+        // that contains the .swift-format file
+        #expect(foundFiles.count == 1)
+        #expect(foundFiles[0] == srcIgnore)
+        // Should NOT include the root ignore file since we stopped at project directory
+        #expect(!foundFiles.contains(rootIgnore))
+      }
+    }
+
+    @Test func noIgnoreFilesFound() throws {
+      try withTempDirectory { tempDir in
+        let manager = IgnoreManager()
+        let foundFiles = manager.findIgnoreFiles(for: tempDir.appendingPathComponent("test.swift"))
+
+        #expect(foundFiles.isEmpty)
+      }
+    }
+  }
+
+  // MARK: - File Loading Tests
+
+  @Suite
+  struct LoadIgnoreFileTests {
+    @Test func loadValidIgnoreFile() throws {
+      try withTempDirectory { tempDir in
+        let ignoreFile = tempDir.appendingPathComponent(".swift-format-ignore")
+        let content = """
+          *.generated.swift
+          build/
+          !important.generated.swift
+          # This is a comment
+
+          test/**/*.tmp
+          """
+        try content.write(to: ignoreFile, atomically: true, encoding: .utf8)
+
+        let manager = IgnoreManager()
+        let patterns = try manager.loadIgnoreFile(at: ignoreFile)
+
+        #expect(patterns.count == 4)  // Should ignore comments and blank lines
+        #expect(patterns[0].pattern == "*.generated.swift")
+        #expect(patterns[1].pattern == "build/")
+        #expect(patterns[2].pattern == "!important.generated.swift")
+        #expect(patterns[2].isNegation == true)
+        #expect(patterns[3].pattern == "test/**/*.tmp")
+      }
+    }
+
+    @Test func loadSkipInvalidPatternInIgnoreFile() throws {
+      try withTempDirectory { tempDir in
+        let ignoreFile = tempDir.appendingPathComponent(".swift-format-ignore")
+        try "!".write(to: ignoreFile, atomically: true, encoding: .utf8)
+
+        let manager = IgnoreManager()
+        let patterns = try manager.loadIgnoreFile(at: ignoreFile)
+
+        #expect(patterns.isEmpty)
+      }
+    }
+
+    @Test func loadEmptyIgnoreFile() throws {
+      try withTempDirectory { tempDir in
+        let ignoreFile = tempDir.appendingPathComponent(".swift-format-ignore")
+        try "".write(to: ignoreFile, atomically: true, encoding: .utf8)
+
+        let manager = IgnoreManager()
+        let patterns = try manager.loadIgnoreFile(at: ignoreFile)
+
+        #expect(patterns.isEmpty)
+      }
+    }
+
+    @Test func loadNonexistentIgnoreFile() throws {
+      try withTempDirectory { tempDir in
+        let ignoreFile = tempDir.appendingPathComponent(".swift-format-ignore")
+        let manager = IgnoreManager()
+
+        #expect(throws: IgnoreManager.IgnoreError.fileNotFound) {
+          try manager.loadIgnoreFile(at: ignoreFile)
+        }
+      }
+    }
+  }
+
+  // MARK: - shouldIgnore Integration Tests
+  @Suite
+  struct ShouldIgnoreTests {
+    @Test func shouldIgnoreBasicPattern() throws {
+      try withTempDirectory { tempDir in
+        // Create ignore file
+        let ignoreFile = tempDir.appendingPathComponent(".swift-format-ignore")
+        try "*.generated.swift".write(to: ignoreFile, atomically: true, encoding: .utf8)
+
+        let manager = IgnoreManager()
+
+        // Test files
+        let generatedFile = tempDir.appendingPathComponent("Model.generated.swift")
+        let normalFile = tempDir.appendingPathComponent("Model.swift")
+
+        #expect(manager.shouldIgnore(file: generatedFile, isDirectory: false) == true)
+        #expect(manager.shouldIgnore(file: normalFile, isDirectory: false) == false)
+      }
+    }
+
+    @Test func shouldIgnoreWithNegationPattern() throws {
+      try withTempDirectory { tempDir in
+        // Create ignore file with negation
+        let ignoreFile = tempDir.appendingPathComponent(".swift-format-ignore")
+        let content = """
+          *.generated.swift
+          !important.generated.swift
+          """
+        try content.write(to: ignoreFile, atomically: true, encoding: .utf8)
+
+        let manager = IgnoreManager()
+
+        let generatedFile = tempDir.appendingPathComponent("Model.generated.swift")
+        let importantFile = tempDir.appendingPathComponent("important.generated.swift")
+        let normalFile = tempDir.appendingPathComponent("Model.swift")
+
+        #expect(manager.shouldIgnore(file: generatedFile, isDirectory: false) == true)
+        #expect(manager.shouldIgnore(file: importantFile, isDirectory: false) == false)  // Negated
+        #expect(manager.shouldIgnore(file: normalFile, isDirectory: false) == false)
+      }
+    }
+
+    @Test func shouldIgnoreWithPrecedence() throws {
+      try withTempDirectory { tempDir in
+        // Create nested structure
+        let srcDir = tempDir.appendingPathComponent("src")
+        try FileManager.default.createDirectory(at: srcDir, withIntermediateDirectories: true)
+
+        // Root ignore: ignore all .test.swift
+        let rootIgnore = tempDir.appendingPathComponent(".swift-format-ignore")
+        try "*.test.swift".write(to: rootIgnore, atomically: true, encoding: .utf8)
+
+        // Src ignore: allow .test.swift (negation takes precedence)
+        let srcIgnore = srcDir.appendingPathComponent(".swift-format-ignore")
+        try "!*.test.swift".write(to: srcIgnore, atomically: true, encoding: .utf8)
+
+        let manager = IgnoreManager()
+
+        let rootTestFile = tempDir.appendingPathComponent("App.test.swift")
+        let srcTestFile = srcDir.appendingPathComponent("Model.test.swift")
+
+        #expect(manager.shouldIgnore(file: rootTestFile, isDirectory: false) == true)  // Root rule applies
+        #expect(
+          manager.shouldIgnore(file: srcTestFile, isDirectory: false) == false  // Src negation takes precedence
+        )
+      }
+    }
+
+    @Test func shouldIgnoreWithNoIgnoreFilesDetectedReturnsFalse() async throws {
+      try withTempDirectory { tempDir in
+        let rootTestFile = tempDir.appendingPathComponent("App.test.swift")
+        let manager = IgnoreManager()
+
+        #expect(manager.shouldIgnore(file: rootTestFile, isDirectory: false) == false)
+      }
+    }
+  }
+}
+
+// MARK: - Helper Methods
+
+private func withTempDirectory<T>(_ body: (URL) throws -> T) throws -> T {
+  let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+  try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+  defer { try? FileManager.default.removeItem(at: tempDir) }
+  return try body(tempDir)
+}


### PR DESCRIPTION
Add supports for file-based ignoring using `.swift-format-ignore` files. These files allow a developer to specify patterns for files and directories that should be completely excluded from formatting and linting operations.

Fixes: #870
Issue: rdar://139269456