### PR TITLE
Add missing encoding for `Configuration.multilineTrailingCommaBehavior`

### DIFF
--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -491,6 +491,7 @@ public struct Configuration: Codable, Equatable {
     try container.encode(indentSwitchCaseLabels, forKey: .indentSwitchCaseLabels)
     try container.encode(noAssignmentInExpressions, forKey: .noAssignmentInExpressions)
     try container.encode(multiElementCollectionTrailingCommas, forKey: .multiElementCollectionTrailingCommas)
+    try container.encode(multilineTrailingCommaBehavior, forKey: .multilineTrailingCommaBehavior)
     try container.encode(reflowMultilineStringLiterals, forKey: .reflowMultilineStringLiterals)
     try container.encode(indentBlankLines, forKey: .indentBlankLines)
     try container.encode(orderedImports, forKey: .orderedImports)


### PR DESCRIPTION
The encoding for `Configuration.multilineTrailingCommaBehavior` is currently missing, this PR added it.