### PR TITLE
Preserve user newline before a function call's member-access callee

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -1050,9 +1050,22 @@ private final class TokenStreamCreator: SyntaxVisitor {
         // When this function call is wrapped by a keyword-modified expression, the group applied
         // when visiting that wrapping expression is sufficient. Adding another group here in that
         // case can result in unnecessarily breaking after the modifier keyword.
-        if !(base.firstToken(viewMode: .sourceAccurate)?.previousToken(viewMode: .all)?.parent?.isProtocol(
-          KeywordModifiedExprSyntaxProtocol.self
-        ) ?? false) {
+        let wrappedByKeywordModifier =
+          base.firstToken(viewMode: .sourceAccurate)?.previousToken(viewMode: .all)?.parent?.isProtocol(
+            KeywordModifiedExprSyntaxProtocol.self
+          ) ?? false
+        // The group below keeps `Identifier.method` together when the call breaks. 
+        // Skip when the user wrote a newline before the period — the resulting soft break
+        // would inflate the group and force a preceding break (e.g. after `=`) to fire.
+        let hasDiscretionaryBreakBeforePeriod =
+          config.respectsExistingLineBreaks
+          && calledMemberAccessExpr.period.leadingTrivia.contains { piece in
+            switch piece {
+            case .newlines, .carriageReturns, .carriageReturnLineFeeds: return true
+            default: return false
+            }
+          }
+        if !wrappedByKeywordModifier && !hasDiscretionaryBreakBeforePeriod {
           before(base.firstToken(viewMode: .sourceAccurate), tokens: .open)
           after(calledMemberAccessExpr.declName.baseName.lastToken(viewMode: .sourceAccurate), tokens: .close)
         }

--- a/Tests/SwiftFormatTests/PrettyPrint/MemberAccessExprTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/MemberAccessExprTests.swift
@@ -192,6 +192,47 @@ final class MemberAccessExprTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 100)
   }
 
+  func testCalleeMemberAccessGroupAppliesWhenLineBreaksAreNotRespected() {
+    let input =
+      """
+      var button = View
+        .A()
+      """
+
+    let expected =
+      """
+      var button = View.A()
+
+      """
+
+    var configuration = Configuration.forTesting
+    configuration.respectsExistingLineBreaks = false
+    assertPrettyPrintEqual(
+      input: input,
+      expected: expected,
+      linelength: 100,
+      configuration: configuration
+    )
+  }
+
+  func testDiscretionaryNewlineBeforeCalleeStillBreaksOverflowingLines() {
+    let input =
+      """
+      var aVeryLongVariableName = SomeAbsurdlyLongTypeNameThatExceedsTheLine
+        .method()
+      """
+
+    let expected =
+      """
+      var aVeryLongVariableName =
+        SomeAbsurdlyLongTypeNameThatExceedsTheLine
+        .method()
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 60)
+  }
+
   func testOperatorChainedMemberAccessExprs() {
     let input =
       """

--- a/Tests/SwiftFormatTests/PrettyPrint/MemberAccessExprTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/MemberAccessExprTests.swift
@@ -169,6 +169,29 @@ final class MemberAccessExprTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 30)
   }
 
+  func testDiscretionaryNewlineBeforeCalleeMemberAccessIsRespected() {
+    let input =
+      """
+      var button = View
+        .A()
+
+      var button = View
+        .Button { Text("ABC") }
+      """
+
+    let expected =
+      """
+      var button = View
+        .A()
+
+      var button = View
+        .Button { Text("ABC") }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 100)
+  }
+
   func testOperatorChainedMemberAccessExprs() {
     let input =
       """


### PR DESCRIPTION
## What does this PR change

When `respectsExistingLineBreaks` is enabled and the user writes a newline between an identifier and the `.method(...)` that follows it, the formatter inserts a spurious break after `=` that pushes the identifier onto its own line.

For example, given a Combine usage:

```swift
let subscription = numbers
  .map { $0 * $0 }
  .filter { $0 > 10 }
  .sink { value in print("Received: \(value)") }
```

As-is the formatter produces:

```diff
-let subscription = numbers
+let subscription =
+  numbers
   .map { $0 * $0 }
   .filter { $0 > 10 }
   .sink { value in print("Received: \(value)") }
```

To-be the formatter respects it:

```diff
let subscription = numbers
  .map { $0 * $0 }
  .filter { $0 > 10 }
  .sink { value in print("Received: \(value)") }
```

After this change, the user's intent is preserved.

> [!NOTE]
> - The fix only applies when the user intentionally adds a line break between `numbers` and `.map`. <br /> If no newline is present, behavior is unchanged.
> - When the first line still exceeds the line length limit, the break between `=` and `numbers` is still produced (verified by regression test).

## Scope

This change skips the soft break when the period's leading trivia contains a newline and `respectsExistingLineBreaks` is enabled. 

Other shapes are unaffected: 
- function calls without member-access callees
- member-access chains where the base isn't a plain identifier (e.g. `a.b.c.d()`)
- keyword-modified expressions (`try Foo.bar()`)
- `respectsExistingLineBreaks: false` mode 

all retain their existing behavior.

## Backward compatibility

Files already saved and formatted with previous version remain unchanged because `respectsExistingLineBreaks` continues to honor existing newlines.