### PR TITLE
Allow trailing commas on multi-line single-element collections

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
@@ -517,22 +517,24 @@ public class PrettyPrinter {
         fatalError("Found trailing comma end with no corresponding start.")
       }
 
-      // We need to specifically disable trailing commas on elements of single item collections.
+      // We need to specifically disable trailing comma insertion on elements of single item
+      // collections.
       // The syntax library can't distinguish a collection's initializer (where the elements are
       // types) from a literal (where the elements are the contents of a collection instance).
-      // We never want to add a trailing comma in an initializer so we disable trailing commas on
-      // single element collections.
+      // We never want to add a trailing comma in an initializer, but we also don't want to force
+      // the removal of a trailing comma from a single item collection literal, so we neither add
+      // nor remove already-present trailing commas on multi-line single element collections.
       if let shouldHandleCommaDelimitedRegion = shouldHandleCommaDelimitedRegion(isCollection: isCollection) {
         let shouldHaveTrailingComma =
-          startLineNumber != openCloseBreakCompensatingLineNumber && !isSingleElement
+          startLineNumber != openCloseBreakCompensatingLineNumber
           && shouldHandleCommaDelimitedRegion
-        if shouldHaveTrailingComma && !hasTrailingComma {
+        if shouldHaveTrailingComma && !hasTrailingComma && !isSingleElement {
           diagnose(.addTrailingComma, category: .trailingComma)
         } else if !shouldHaveTrailingComma && hasTrailingComma {
           diagnose(.removeTrailingComma, category: .trailingComma)
         }
 
-        let shouldWriteComma = whitespaceOnly ? hasTrailingComma : shouldHaveTrailingComma
+        let shouldWriteComma = whitespaceOnly || isSingleElement ? hasTrailingComma : shouldHaveTrailingComma
         if shouldWriteComma {
           outputBuffer.write(",")
         }

--- a/Tests/SwiftFormatTests/PrettyPrint/ArrayDeclTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/ArrayDeclTests.swift
@@ -170,8 +170,12 @@ final class ArrayDeclTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(
       input: """
         let a = [
-          "String"1️⃣,
+          "String",
         ]
+        let a = [
+          "String"
+        ]
+        let a = [11️⃣,]
         let a = [1, 2, 32️⃣,]
         let a: [String] = [
           "One", "Two", "Three", "Four", "Five",
@@ -182,6 +186,10 @@ final class ArrayDeclTests: PrettyPrintTestCase {
         let a = [
           "String",
         ]
+        let a = [
+          "String"
+        ]
+        let a = [1,]
         let a = [1, 2, 3,]
         let a: [String] = [
           "One", "Two", "Three", "Four", "Five",
@@ -275,7 +283,7 @@ final class ArrayDeclTests: PrettyPrintTestCase {
         ),
       ]
       let a = [
-        ("this ", "string", "is long")
+        ("this ", "string", "is long"),
       ]
       let a = [
         ("this ", "string", "is long")

--- a/Tests/SwiftFormatTests/PrettyPrint/DictionaryDeclTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/DictionaryDeclTests.swift
@@ -106,8 +106,12 @@ final class DictionaryDeclTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(
       input: """
         let a = [
-          1: "a"1️⃣,
+          1: "a",
         ]
+        let a = [
+          1: "a"
+        ]
+        let a = [1: "a"1️⃣,]
         let a = [1: "a", 2: "b", 3: "c"2️⃣,]
         let a: [Int: String] = [
           1: "a", 2: "b", 3: "c", 4: "d", 5: "e", 6: "f",
@@ -118,6 +122,10 @@ final class DictionaryDeclTests: PrettyPrintTestCase {
         let a = [
           1: "a",
         ]
+        let a = [
+          1: "a"
+        ]
+        let a = [1: "a",]
         let a = [1: "a", 2: "b", 3: "c",]
         let a: [Int: String] = [
           1: "a", 2: "b", 3: "c", 4: "d", 5: "e", 6: "f",
@@ -250,6 +258,7 @@ final class DictionaryDeclTests: PrettyPrintTestCase {
       let a = [key2: ("this ", "string", "is long")]
       let a = [key2: ("this ", "string", "is long"),]
       let a = [key2: ("this ", "string", "is long ")]
+      let a = [key2: ("this ", "string", "is long "),]
       let a = [key1: ("a", "z"), key2: ("b ", "y")]
       let a = [key1: ("ab", "z"), key2: ("b ", "y")]
       a = [k1: ("ab", "z"), k2: ("bc", "y")]
@@ -273,12 +282,17 @@ final class DictionaryDeclTests: PrettyPrintTestCase {
         key2: ("this ", "string", "is long")
       ]
       let a = [
-        key2: ("this ", "string", "is long")
+        key2: ("this ", "string", "is long"),
       ]
       let a = [
         key2: (
           "this ", "string", "is long "
         )
+      ]
+      let a = [
+        key2: (
+          "this ", "string", "is long "
+        ),
       ]
       let a = [
         key1: ("a", "z"), key2: ("b ", "y"),


### PR DESCRIPTION
The syntax library can't distinguish a collection literal from a sugared collection type in an expression position, and since we never want to *insert* a trailing comma in the latter case, the pretty-printer was previously coded to never print a comma in a single-element collection. Unfortunately, this resulted in the *removal* of any already-present trailing commas from multi-line single-element collections.

A trailing comma after the sole element in a multi-line single-element collection is desirable for much the same reason we would want a trailing comma after the last item of a multi-line *multi*-element collection. This commit changes the pretty-printer's behavior to *preserve* any already-present trailing commas in such cases, while still maintaining the prior behavior of never inserting a new trailing comma if one is not already present.