### PR TITLE
Fix double space between `catch`/`where` in `where`-only `catch` clause

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -742,10 +742,19 @@ private final class TokenStreamCreator: SyntaxVisitor {
     // old (pre-SE-0276) behavior (a fixed space after the `catch` keyword).
     if node.catchItems.count > 1 {
       for catchItem in node.catchItems {
-        before(catchItem.firstToken(viewMode: .sourceAccurate), tokens: .break(.open(kind: .continuation)))
+        // If the item has no pattern (it consists solely of a `where` clause),
+        // skip emitting a break before it. `WhereClauseSyntax` will emit its
+        // own break before the `where` keyword, and emitting one here too
+        // would produce duplicate whitespace.
+        if catchItem.pattern != nil {
+          before(catchItem.firstToken(viewMode: .sourceAccurate), tokens: .break(.open(kind: .continuation)))
+        }
         after(catchItem.lastToken(viewMode: .sourceAccurate), tokens: .break(.close(mustBreak: false), size: 0))
       }
-    } else {
+    } else if let onlyItem = node.catchItems.first, onlyItem.pattern != nil {
+      // Same rationale as above: When the single catch item has no pattern,
+      // the `where` clause's own preceding break already separates it from
+      // `catch`. Emitting a space here would produce duplicate whitespace.
       before(node.catchItems.firstToken(viewMode: .sourceAccurate), tokens: .space)
     }
 

--- a/Tests/SwiftFormatTests/PrettyPrint/DoStmtTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/DoStmtTests.swift
@@ -164,6 +164,39 @@ final class DoStmtTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
   }
 
+  func testCatchWhereOnly_noBreakBeforeCatch() {
+    let input =
+      """
+      do { f() } catch where c { g() }
+      """
+
+    let expected =
+      """
+      do { f() } catch where c { g() }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 80)
+  }
+
+  func testCatchWhereOnly_breakBeforeCatch() {
+    let input =
+      """
+      do { f() } catch where c { g() }
+      """
+
+    let expected =
+      """
+      do { f() }
+      catch where c { g() }
+
+      """
+
+    var config = Configuration.forTesting
+    config.lineBreakBeforeControlFlowKeywords = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 80, configuration: config)
+  }
+
   func testDoCatch_breakBeforeCatch() {
     let input =
       """


### PR DESCRIPTION
Closes #1076.

When formatting a `catch` clause whose item consists solely of a `where` clause with no preceding pattern, `TokenStreamCreator.visit(_ node: CatchClauseSyntax)` emits a `.space` before the `catch` item's first token. With no pattern present, the first token is the `where` keyword. `TokenStreamCreator.visit(_ node: WhereClauseSyntax)` also inserts a preceding break before the same `where` keyword, producing duplicate whitespace.

This PR suppresses the `catch`-clause-level whitespace when a `catch` item has no pattern and allows `WhereClauseSyntax` to remain the sole source.

## Testing

Added `testCatchWhereOnly_noBreakBeforeCatch()` and `testCatchWhereOnly_breakBeforeCatch()` to `DoStmtTests`.

All tests pass when run locally on macOS.