### PR TITLE
Avoid stranding keyword introducers on own line before their operands

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
@@ -587,7 +587,37 @@ public class PrettyPrinter {
     // Keep track of the indices of the .open and .break token locations.
     var delimIndexStack = [Int]()
     // Keep a running total of the token lengths.
+    //
+    // `total` includes the `maxLineLength` injection contributed by forced breaks (soft and
+    // hard). It is used to compute the span length for ordinary breaks and `.open` groups,
+    // so that an enclosing context sees a length large enough to force wrapping when its
+    // span contains a forced break.
+    //
+    // `suffixTotal` excludes those injections, counting only the literal content emitted by
+    // the token stream. Last-resort elective breaks (`.elective(ignoresDiscretionary: true)`)
+    // compute their span length against `suffixTotal` instead of `total`, so that forced
+    // breaks occurring later in the same span do not force them to fire. The span itself
+    // (the range from the break to the next break or enclosing `.close`) is identical to
+    // that of any other break. Only the counter differs.
     var total = 0
+    var suffixTotal = 0
+
+    /// Returns `true` if the break at `tokenIndex` is a last-resort elective
+    /// (`.elective(ignoresDiscretionary: true)`).
+    func isLastResortElectiveBreak(at tokenIndex: Int) -> Bool {
+      if case .break(_, _, .elective(ignoresDiscretionary: true)) = tokens[tokenIndex] {
+        return true
+      }
+      return false
+    }
+
+    /// Returns the counter value to use when closing the length of the break or group at
+    /// `tokenIndex`. Last-resort elective breaks use `suffixTotal` so that `maxLineLength`
+    /// injections from forced breaks within their scope do not contribute to their length.
+    /// Everything else uses `total`.
+    func closingCounter(for tokenIndex: Int) -> Int {
+      return isLastResortElectiveBreak(at: tokenIndex) ? suffixTotal : total
+    }
 
     // Calculate token lengths
     for (i, token) in tokens.enumerated() {
@@ -599,7 +629,9 @@ public class PrettyPrinter {
         lengths.append(0)
 
       // Open tokens have lengths equal to the total of the contents of its group. The value is
-      // calculated when close tokens are encountered.
+      // calculated when close tokens are encountered. `.open` groups always track against the
+      // injecting `total`, so that a forced break inside the group makes the group's length
+      // exceed `maxLineLength` and the group's inconsistent breaks fire.
       case .open:
         lengths.append(-total)
         delimIndexStack.append(i)
@@ -614,7 +646,7 @@ public class PrettyPrinter {
           print("Bad index 1")
           return ""
         }
-        lengths[index] += total
+        lengths[index] += closingCounter(for: index)
 
         // TODO(dabelknap): Handle the unwrapping more gracefully
         if case .break = tokens[index] {
@@ -622,7 +654,7 @@ public class PrettyPrinter {
             print("Bad index 2")
             return ""
           }
-          lengths[index] += total
+          lengths[index] += closingCounter(for: index)
         }
 
       // Break lengths are equal to its size plus the token or group following it. Calculate the
@@ -656,43 +688,63 @@ public class PrettyPrinter {
           /// some text \
           /// this is exactly the right length
           /// """
+          let closing = closingCounter(for: index)
           if case .escaped = newline, case .escaped = lastNewline {
-            lengths[index] += total + 1
+            lengths[index] += closing + 1
           } else {
-            lengths[index] += total
+            lengths[index] += closing
           }
           delimIndexStack.removeLast()
         }
-        lengths.append(-total)
+
+        // Last-resort elective breaks track against `suffixTotal` so that `maxLineLength`
+        // injections from forced breaks within their scope do not contribute to their length.
+        // All other breaks track against `total`.
+        if case .elective(ignoresDiscretionary: true) = newline {
+          lengths.append(-suffixTotal)
+        } else {
+          lengths.append(-total)
+        }
         delimIndexStack.append(i)
 
         switch newline {
         case .elective, .escaped:
+          // Literal content. Advance both counters by `size`.
           total += size
+          suffixTotal += size
         default:
-          // `size` is never used in this case, because the break always fires. Use `maxLineLength`
-          // to ensure enclosing groups are large enough to force preceding breaks to fire.
+          // Forced break (`.soft` or `.hard`). `size` is never used in this case, because the
+          // break always fires. Advance `total` by `maxLineLength` so that ordinary
+          // preceding breaks and enclosing `.open` groups see a length large enough to force
+          // them to wrap. `suffixTotal` is advanced by `size` only. Last-resort elective
+          // breaks preceding this one will not be forced to fire by this injection.
           total += maxLineLength
+          suffixTotal += size
         }
 
       // Space tokens have a length equal to its size.
       case .space(let size, _):
         lengths.append(size)
         total += size
+        suffixTotal += size
 
       // Syntax tokens have a length equal to the number of columns needed to print its contents.
       case .syntax(let text):
         lengths.append(text.count)
         total += text.count
+        suffixTotal += text.count
 
       case .comment(let comment, let wasEndOfLine):
         lengths.append(comment.length)
-        total += wasEndOfLine ? 0 : comment.length
+        let contribution = wasEndOfLine ? 0 : comment.length
+        total += contribution
+        suffixTotal += contribution
 
       case .verbatim(let verbatim):
         let length = verbatim.prettyPrintingLength(maximum: maxLineLength)
         lengths.append(length)
         total += length
+        suffixTotal += length
 
       case .printerControl:
         // Control tokens have no length. They aren't printed.
@@ -710,6 +762,7 @@ public class PrettyPrinter {
         if shouldHandleCommaDelimitedRegion(isCollection: isCollection) == true {
           let length = isSingleElement ? 0 : 1
           total += length
+          suffixTotal += length
           lengths.append(length)
         } else {
           lengths.append(0)
@@ -721,13 +774,13 @@ public class PrettyPrinter {
       }
     }
 
-    // There may be an extra break token that needs to have its length calculated.
+    // There may be an extra (non-suffix-elective) break token that needs to have its length calculated.
     assert(delimIndexStack.count < 2, "Too many unresolved delimiter token lengths.")
     if let index = delimIndexStack.popLast() {
       if case .open = tokens[index] {
         assert(false, "Open tokens must be closed.")
       }
-      lengths[index] += total
+      lengths[index] += closingCounter(for: index)
     }
 
     // Print out the token stream, wrapping according to line-length limitations.

--- a/Sources/SwiftFormat/PrettyPrint/Token.swift
+++ b/Sources/SwiftFormat/PrettyPrint/Token.swift
@@ -133,7 +133,19 @@ enum BreakKind: Equatable {
 /// allowed.
 enum NewlineBehavior {
   /// Breaking onto a newline is allowed if necessary, but is not required. `ignoresDiscretionary`
-  /// specifies whether a user-entered discretionary newline should be respected.
+  /// specifies whether the break is treated as a "last resort" break.
+  ///
+  /// When `false` (the default), a user-entered discretionary newline at this position is respected
+  /// (the trivia handler may upgrade the break to a soft break), and the break fires whenever the
+  /// content following it, up to the next break or the end of its enclosing group, does not fit on
+  /// the current line, including additional length contributed by any forced breaks within that content.
+  ///
+  /// When `true`, the break is a last-resort break: a user-entered discretionary newline is not respected,
+  /// and the break fires only when the literal content following it cannot fit on the current line.
+  /// Forced breaks (e.g. `.soft` or `.hard`) appearing later in the same span do not on their own cause
+  /// this break to fire, even though they cause earlier non-last-resort breaks to fire. The break is
+  /// therefore suitable for positions where a newline should be inserted only when the content immediately
+  /// following the break is itself too long, regardless of how that content is laid out internally.
   case elective(ignoresDiscretionary: Bool)
 
   /// Breaking onto a newline `count` times is required, unless it would create more blank lines

--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -770,14 +770,20 @@ private final class TokenStreamCreator: SyntaxVisitor {
         before(expression.firstToken(viewMode: .sourceAccurate), tokens: .break(.open))
         after(expression.lastToken(viewMode: .sourceAccurate), tokens: .break(.close(mustBreak: false)))
       } else {
-        before(expression.firstToken(viewMode: .sourceAccurate), tokens: .break)
+        before(
+          expression.firstToken(viewMode: .sourceAccurate),
+          tokens: .break(.continue, newlines: electiveNewlineForKeywordPrefix(before: expression))
+        )
       }
     }
     return .visitChildren
   }
 
   override func visit(_ node: ThrowStmtSyntax) -> SyntaxVisitorContinueKind {
-    before(node.expression.firstToken(viewMode: .sourceAccurate), tokens: .break)
+    before(
+      node.expression.firstToken(viewMode: .sourceAccurate),
+      tokens: .break(.continue, newlines: electiveNewlineForKeywordPrefix(before: node.expression))
+    )
     return .visitChildren
   }
 
@@ -2510,12 +2516,18 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: PackExpansionExprSyntax) -> SyntaxVisitorContinueKind {
-    after(node.repeatKeyword, tokens: .break)
+    after(
+      node.repeatKeyword,
+      tokens: .break(.continue, newlines: .elective(ignoresDiscretionary: true))
+    )
     return .visitChildren
   }
 
   override func visit(_ node: PackExpansionTypeSyntax) -> SyntaxVisitorContinueKind {
-    after(node.repeatKeyword, tokens: .break)
+    after(
+      node.repeatKeyword,
+      tokens: .break(.continue, newlines: .elective(ignoresDiscretionary: true))
+    )
     return .visitChildren
   }
 
@@ -3903,6 +3915,61 @@ private final class TokenStreamCreator: SyntaxVisitor {
       before(expr.firstToken(viewMode: .sourceAccurate), tokens: .open)
       after(expr.lastToken(viewMode: .sourceAccurate), tokens: .close)
     }
+  }
+
+  /// Returns the elective newline behavior to use for a break between a leading
+  /// keyword (e.g. `return`, `throw`) and its expression.
+  ///
+  /// Returns `.elective(ignoresDiscretionary: true)` only when both of the
+  /// following conditions are true:
+  ///
+  /// - The expression begins with a member-access chain (a `MemberAccessExpr`,
+  /// or a `FunctionCallExpr` whose callee is a `MemberAccessExpr`). In this
+  /// case, honoring a user's discretionary newline between the keyword and
+  /// the expression would strand the keyword at the top of a wrapped chain.
+  ///
+  /// - The first token of the expression has no preceding line or doc-line
+  /// comment. A comment on the discretionary line break is a strong signal
+  /// of user intent that should be preserved.
+  ///
+  /// In all other cases, returns plain `.elective` so that discretionary
+  /// newlines (e.g. `return\n200`) are respected.
+  private func electiveNewlineForKeywordPrefix(before expr: ExprSyntax) -> NewlineBehavior {
+    guard expressionBeginsWithMemberAccess(expr) else {
+      return .elective
+    }
+    guard let firstToken = expr.firstToken(viewMode: .sourceAccurate) else {
+      return .elective
+    }
+    for piece in firstToken.leadingTrivia {
+      switch piece {
+      case .lineComment, .docLineComment:
+        return .elective
+      default:
+        continue
+      }
+    }
+    return .elective(ignoresDiscretionary: true)
+  }
+
+  /// Returns `true` if the given expression begins with a member-access chain.
+  ///
+  /// An expression begins with a member-access chain when it is either:
+  /// - a `MemberAccessExprSyntax` (regardless of its base), or
+  /// - a `FunctionCallExprSyntax` or `SubscriptCallExprSyntax` whose called
+  /// expression itself begins with a member-access chain.
+  ///
+  /// For example, `foo.bar`, `foo.bar.baz`, `foo.bar(x)`, `foo.bar(x).baz`,
+  /// `foo().bar`, and `foo[0].bar` all begin with a member-access chain.
+  /// `foo`, `foo(x)`, and `foo[0]` do not.
+  private func expressionBeginsWithMemberAccess(_ expr: ExprSyntax) -> Bool {
+    if expr.is(MemberAccessExprSyntax.self) {
+      return true
+    }
+    if let callingExpr = expr.asProtocol(CallingExprSyntaxProtocol.self) {
+      return expressionBeginsWithMemberAccess(callingExpr.calledExpression)
+    }
+    return false
   }
 
   /// Returns whether the given expression consists of multiple subexpressions. Certain expressions

--- a/Tests/SwiftFormatTests/PrettyPrint/PackExpansionTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/PackExpansionTests.swift
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftFormat
+
+final class PackExpansionTests: PrettyPrintTestCase {
+  func testExprIgnoresDiscretionaryNewlineAfterRepeat() {
+    let input =
+      """
+      func f<each T>(_ values: repeat each T) -> (repeat each T) {
+        return (repeat
+          each values)
+      }
+      """
+
+    let expected =
+      """
+      func f<each T>(_ values: repeat each T) -> (repeat each T) {
+        return (repeat each values)
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 80)
+  }
+
+  func testTypeIgnoresDiscretionaryNewlineAfterRepeat() {
+    let input =
+      """
+      func f<each T>(_ values: repeat
+        each T) {}
+      """
+
+    let expected =
+      """
+      func f<each T>(_ values: repeat each T) {}
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 80)
+  }
+}

--- a/Tests/SwiftFormatTests/PrettyPrint/ReturnStmtTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/ReturnStmtTests.swift
@@ -1,0 +1,108 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftFormat
+
+final class ReturnStmtTests: PrettyPrintTestCase {
+  func testIgnoresDiscretionaryNewlineBeforeExpression() {
+    let input =
+      """
+      func f() -> SomeResult {
+        return
+          SomeResult
+          .memberA
+          .memberB
+      }
+      """
+
+    let expected =
+      """
+      func f() -> SomeResult {
+        return SomeResult
+          .memberA
+          .memberB
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 80)
+  }
+
+  func testWrapsLongExpression() {
+    let input =
+      """
+      func f() -> Value {
+        return SomeType.someStaticFactoryMethod(withArgument: someValue)
+      }
+      """
+
+    let expected =
+      """
+      func f() -> Value {
+        return
+          SomeType
+          .someStaticFactoryMethod(
+            withArgument: someValue)
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 30)
+  }
+
+  func testPreservesDiscretionaryNewlineForBareIdentifierExpression() {
+    let input =
+      """
+      func f() -> Int {
+        return
+          someValue
+      }
+      """
+
+    assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 80)
+  }
+
+  func testPreservesDiscretionaryNewlineWhenChainIsPrecededByLineComment() {
+    let input =
+      """
+      func f() -> SomeResult {
+        return
+          // explanation of why we return this specific value
+          SomeResult
+          .memberA
+          .memberB
+      }
+      """
+
+    assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 80)
+  }
+
+  func testCollapsesDiscretionaryNewlineForImplicitMemberAccess() {
+    let input =
+      """
+      func f() -> Result {
+        return
+          .success(value)
+      }
+      """
+
+    let expected =
+      """
+      func f() -> Result {
+        return .success(value)
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 80)
+  }
+}

--- a/Tests/SwiftFormatTests/PrettyPrint/ThrowStmtTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/ThrowStmtTests.swift
@@ -1,0 +1,165 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftFormat
+
+final class ThrowStmtTests: PrettyPrintTestCase {
+  func testIgnoresDiscretionaryNewlineBeforeExpression() {
+    let input =
+      """
+      func f() throws {
+        throw
+          SomeError
+          .memberA(.optionA)
+          .memberB
+      }
+      """
+
+    let expected =
+      """
+      func f() throws {
+        throw SomeError
+          .memberA(.optionA)
+          .memberB
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 80)
+  }
+
+  func testWrapsLongExpression() {
+    let input =
+      """
+      func f() throws {
+        throw SomeError.aReallyLongCaseName(withAnArgument: someValue)
+      }
+      """
+
+    let expected =
+      """
+      func f() throws {
+        throw
+          SomeError
+          .aReallyLongCaseName(
+            withAnArgument:
+              someValue)
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 30)
+  }
+
+  func testPreservesDiscretionaryNewlineForBareIdentifierExpression() {
+    let input =
+      """
+      func f() throws {
+        throw
+          someErrorValue
+      }
+      """
+
+    assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 80)
+  }
+
+  func testCollapsesDiscretionaryNewlineForShortMemberAccessExpression() {
+    let input =
+      """
+      func f() throws {
+        throw
+          SomeError.singleCase
+      }
+      """
+
+    let expected =
+      """
+      func f() throws {
+        throw SomeError.singleCase
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 80)
+  }
+
+  func testCollapsesDiscretionaryNewlineForCallWithMemberAccessCallee() {
+    let input =
+      """
+      func f() throws {
+        throw
+          SomeError
+          .someCase(argument: someValue)
+      }
+      """
+
+    let expected =
+      """
+      func f() throws {
+        throw SomeError
+          .someCase(argument: someValue)
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 80)
+  }
+
+  func testPreservesDiscretionaryNewlineWhenChainIsPrecededByLineComment() {
+    let input =
+      """
+      func f() throws {
+        throw
+          // explain why this particular error
+          SomeError
+          .memberA
+          .memberB
+      }
+      """
+
+    assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 80)
+  }
+
+  func testPreservesLineCommentAfterKeyword() {
+    let input =
+      """
+      func f() throws {
+        throw  // some note
+          SomeError
+          .memberA
+          .memberB
+      }
+      """
+
+    assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 80)
+  }
+
+  func testCollapsesDiscretionaryNewlineForImplicitMemberAccess() {
+    let input =
+      """
+      func f() throws {
+        throw
+          .failure(someError)
+      }
+      """
+
+    let expected =
+      """
+      func f() throws {
+        throw .failure(someError)
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 80)
+  }
+}


### PR DESCRIPTION
When formatting code such as:

```swift
throw SomeError
    .memberA
    .memberB
```

at a narrow line length, the formatter strands the keyword on its own line:

```swift
throw 
    SomeError
    .memberA
    .memberB
```

The same happens for `return` before a wrapped chain expression and for `repeat` before its `each` operand in a pack expansion. These shapes are unusual and rarely the user's intent.

This PR addresses three sites where a keyword introducer was being stranded ahead of its operand: `ReturnStmtSyntax`, `ThrowStmtSyntax`, and `PackExpansionExprSyntax`/`PackExpansionTypeSyntax`. The exact gating differs by site:

- For `return` and `throw`, the break ignores discretionary newlines only when the expression begins with a member-access chain. In all other cases the break remains a plain elective, so user-entered newlines before bare identifiers, literals, or other non-chain expressions continue to be respected. A discretionary newline immediately followed by a line comment or doc-line comment is also preserved on chain expressions, since the comment is a strong signal of intent that the formatter should not discard.

- For `repeat` in pack expansion expressions and types, the change is unconditional. The operand is constrained to be `each <reference>`, so preserving a user's newline there is never the right behavior.

These changes bring the affected sites in line with the existing treatment of `try`, `await`, and similar keyword-modified expressions.

### `PrettyPrinter` change

The behavior described above requires a small change in the pretty printer's scan pass. An `.elective(ignoresDiscretionary: true)` break is documented as a "last resort" break, and it fires only when its content cannot fit on the current line. In practice, the scan pass computed its length against the same running counter as ordinary breaks, which is inflated by `maxLineLength` per forced break (`.soft` or `.hard`) within its span. This meant any forced break later in the span, such as one from a wrapped function call inside a chain, would force the elective to fire even when its own content fit, contradicting its stated semantics.

`prettyPrint()` now maintains a second counter, `suffixTotal`, that counts only the literal content emitted by tokens. Forced breaks advance it by `size`, not `maxLineLength`. The two counters diverge only inside the span of a forced break. `.elective(ignoresDiscretionary: true)` breaks close their length against `suffixTotal`. All other breaks and `.open` groups continue to close against `total`. The span over which a break is measured is unchanged.

This change applies to every use of `.elective(ignoresDiscretionary: true)` in the formatter, not only the new ones for `return` and `throw`. The old behavior (being preempted by forced breaks elsewhere in the span) was inconsistent with the "last resort" framing documented on `NewlineBehavior.elective`.

### Testing

Added `ReturnStmtTests`, `ThrowStmtTests`, and `PackExpansionTests` to verify the new visitor logic.

All tests pass when run locally on macOS. No existing tests needed modifications.

### Future directions

Labeled `break` and `continue` have a similar symptom but a different cause. The Swift parser requires the label to appear on the same source line as the keyword, and any newline between them causes the parser to commit to the labelless form and treat the identifier on the next line as a fresh statement. By the time the formatter sees the tree, the construct has already been split into two unrelated `CodeBlockItemSyntax` nodes, and the user's intent is no longer recoverable at the token-stream layer. Fixing this would probably require either a post-parse `SyntaxRewriter` or parser-level error recovery in swift-syntax. I can file a separate issue if there's interest.