### PR TITLE
Preserve trailing comments in OrderedImports rule

### DIFF
--- a/Sources/SwiftFormat/Rules/OrderedImports.swift
+++ b/Sources/SwiftFormat/Rules/OrderedImports.swift
@@ -486,15 +486,7 @@ private func convertToCodeBlockItems(lines: [Line]) -> [CodeBlockItemSyntax] {
   while let last = pendingLeadingTrivia.last, case .newlines = last {
     pendingLeadingTrivia.removeLast()
   }
-  let hasComment = pendingLeadingTrivia.contains { piece in
-    switch piece {
-    case .lineComment, .blockComment, .docLineComment, .docBlockComment:
-      return true
-    default:
-      return false
-    }
-  }
-  if hasComment, !output.isEmpty {
+  if Trivia(pieces: pendingLeadingTrivia).hasAnyComments, !output.isEmpty {
     let lastIndex = output.index(before: output.endIndex)
     var lastItem = output[lastIndex]
     lastItem.trailingTrivia = Trivia(pieces: lastItem.trailingTrivia.pieces + pendingLeadingTrivia)

--- a/Sources/SwiftFormat/Rules/OrderedImports.swift
+++ b/Sources/SwiftFormat/Rules/OrderedImports.swift
@@ -476,6 +476,31 @@ private func convertToCodeBlockItems(lines: [Line]) -> [CodeBlockItemSyntax] {
     }
   }
 
+  // If trivia accumulated past the last syntax node (e.g. a trailing comment
+  // that import reordering left behind), attach it to the last code block
+  // item's trailing trivia so it is preserved in the output instead of being
+  // silently dropped. The loop above accumulates an artificial newline after
+  // every iteration to separate the current line from the next one — those
+  // trailing newlines are meaningless when there is no following line and are
+  // stripped before the attachment.
+  while let last = pendingLeadingTrivia.last, case .newlines = last {
+    pendingLeadingTrivia.removeLast()
+  }
+  let hasComment = pendingLeadingTrivia.contains { piece in
+    switch piece {
+    case .lineComment, .blockComment, .docLineComment, .docBlockComment:
+      return true
+    default:
+      return false
+    }
+  }
+  if hasComment, !output.isEmpty {
+    let lastIndex = output.index(before: output.endIndex)
+    var lastItem = output[lastIndex]
+    lastItem.trailingTrivia = Trivia(pieces: lastItem.trailingTrivia.pieces + pendingLeadingTrivia)
+    output[lastIndex] = lastItem
+  }
+
   return output
 }
 

--- a/Tests/SwiftFormatTests/Rules/OrderedImportsTests.swift
+++ b/Tests/SwiftFormatTests/Rules/OrderedImportsTests.swift
@@ -288,6 +288,30 @@ final class OrderedImportsTests: LintOrFormatRuleTestCase {
     )
   }
 
+  func testCommentBetweenImportGroupsIsPreserved() {
+    // A free-standing comment, separated from the surrounding imports by
+    // blank lines, was previously dropped entirely when the rule ran the
+    // import group through its line/trivia normalisation. See
+    // https://github.com/swiftlang/swift-format/issues/1080.
+    assertFormatting(
+      OrderedImports.self,
+      input: """
+        import A
+
+        // Comment
+
+        import B
+        """,
+      expected: """
+        import A
+        import B
+
+        // Comment
+        """,
+      findings: []
+    )
+  }
+
   func testMultipleCodeBlocksPerLine() {
     assertFormatting(
       OrderedImports.self,


### PR DESCRIPTION
## Problem

`OrderedImports` runs every source file through a `convertToCodeBlockItems` pass that walks the categorised `Line` array and flushes accumulated trivia onto each syntax node via `pendingLeadingTrivia`. When the input ends with trivia *after* the last syntax node — typically a free-standing comment that import reordering pushed past the final import — the accumulator is silently dropped at the end of the loop.

```swift
import A

// Comment

import B
```

becomes

```swift
import A
import B
```

The `// Comment` is silently lost.

## Fix

Append any leftover trivia containing comments to the trailing trivia of the last code block item before `convertToCodeBlockItems` returns. The loop synthesised a trailing run of newlines after every iteration to separate the current line from the next; those are meaningless when no following line exists and are stripped first so the output doesn't gain spurious blank lines.

After the fix:

```swift
import A
import B

// Comment
```

## Tests

Added `testCommentBetweenImportGroupsIsPreserved` to `OrderedImportsTests.swift` covering the reproducer from the issue.

`swift test` locally: 913 tests, 1 skipped, 0 failures.

Resolves #1080.

---

This contribution was developed with the help of Claude Code. The fix, regression test, and the full local test suite were reviewed manually before submitting.