### PR TITLE
Bump the Swift version to 6.3.3

### DIFF
--- a/Sources/swift-format/PrintVersion.swift
+++ b/Sources/swift-format/PrintVersion.swift
@@ -12,5 +12,5 @@
 
 func printVersionInformation() {
   // TODO: Automate updates to this somehow.
-  print("6.3.2")
+  print("6.3.3")
 }


### PR DESCRIPTION
## Summary
- Bumps the Swift version string from 6.3.2 to 6.3.3 in `PrintVersion.swift`

## Test plan
- [ ] Verify `swift-format --version` outputs `6.3.3`