### PR TITLE
Fix OneCasePerLine stranding the case keyword on its own line

### DIFF
--- a/Sources/SwiftFormat/Core/Trivia+Convenience.swift
+++ b/Sources/SwiftFormat/Core/Trivia+Convenience.swift
@@ -37,6 +37,21 @@ extension Trivia {
     return Trivia(pieces: self.pieces.drop(while: \.isSpaceOrTab))
   }
 
+  /// Returns this trivia with any leading newlines and horizontal whitespace removed, stopping at
+  /// the first comment so that comments and anything following them are preserved.
+  func withoutLeadingVerticalWhitespace() -> Trivia {
+    return Trivia(
+      pieces: self.pieces.drop {
+        switch $0 {
+        case .newlines, .carriageReturns, .carriageReturnLineFeeds, .formfeeds, .spaces, .tabs:
+          return true
+        default:
+          return false
+        }
+      }
+    )
+  }
+
   func withoutTrailingSpaces() -> Trivia {
     guard let lastNonSpaceIndex = self.pieces.lastIndex(where: \.isSpaceOrTab) else {
       return self

--- a/Sources/SwiftFormat/Core/Trivia+Convenience.swift
+++ b/Sources/SwiftFormat/Core/Trivia+Convenience.swift
@@ -37,19 +37,35 @@ extension Trivia {
     return Trivia(pieces: self.pieces.drop(while: \.isSpaceOrTab))
   }
 
-  /// Returns this trivia with any leading newlines and horizontal whitespace removed, stopping at
-  /// the first comment so that comments and anything following them are preserved.
-  func withoutLeadingVerticalWhitespace() -> Trivia {
-    return Trivia(
-      pieces: self.pieces.drop {
-        switch $0 {
-        case .newlines, .carriageReturns, .carriageReturnLineFeeds, .formfeeds, .spaces, .tabs:
-          return true
-        default:
-          return false
-        }
-      }
-    )
+  /// Returns whether the given trivia piece is vertical or horizontal whitespace (a newline, form
+  /// feed, space, or tab).
+  private static func isWhitespace(_ piece: TriviaPiece) -> Bool {
+    switch piece {
+    case .newlines, .carriageReturns, .carriageReturnLineFeeds, .formfeeds, .spaces, .tabs:
+      return true
+    default:
+      return false
+    }
+  }
+
+  /// Splits this trivia into the leading comments that should be hoisted ahead of a token and the
+  /// remaining trivia that should stay with the token itself.
+  ///
+  /// All leading whitespace is discarded. If a comment is present, the returned `hoisted` trivia
+  /// contains every comment up to and including the last one (along with any whitespace between
+  /// them), with surrounding whitespace trimmed. The `remainder` is whatever followed the last
+  /// comment, with its own leading whitespace removed. If there is no comment, `hoisted` is empty
+  /// and `remainder` is the trivia with leading whitespace removed.
+  func splittingLeadingComments() -> (hoisted: Trivia, remainder: Trivia) {
+    let pieces = Array(self.pieces)
+    guard let lastCommentIndex = pieces.lastIndex(where: { $0.isComment }) else {
+      return (Trivia(pieces: []), Trivia(pieces: pieces.drop(while: Trivia.isWhitespace)))
+    }
+
+    let throughLastComment = pieces[...lastCommentIndex]
+    let hoisted = throughLastComment.drop(while: Trivia.isWhitespace)
+    let remainder = pieces[(lastCommentIndex + 1)...].drop(while: Trivia.isWhitespace)
+    return (Trivia(pieces: Array(hoisted)), Trivia(pieces: Array(remainder)))
   }
 
   func withoutTrailingSpaces() -> Trivia {

--- a/Sources/SwiftFormat/Rules/OneCasePerLine.swift
+++ b/Sources/SwiftFormat/Rules/OneCasePerLine.swift
@@ -50,6 +50,17 @@ public final class OneCasePerLine: SyntaxFormatRule {
       elements.append(element)
     }
 
+    /// Removes the trailing comma from the given element, keeping any end-of-line comment that was
+    /// attached to that comma (like `case a = 1,  // comment`) on the element so it stays on the
+    /// element's own line instead of being discarded along with the comma.
+    static func removeTrailingComma(from element: inout EnumCaseElementSyntax) {
+      let commaTrailingTrivia = element.trailingComma?.trailingTrivia ?? []
+      element.trailingComma = nil
+      if commaTrailingTrivia.hasAnyComments {
+        element.trailingTrivia = element.trailingTrivia + commaTrailingTrivia
+      }
+    }
+
     /// Creates a new case declaration with the elements collected so far, then resets the internal
     /// state to start a new empty declaration again.
     ///
@@ -58,8 +69,9 @@ public final class OneCasePerLine: SyntaxFormatRule {
     mutating func makeCaseDeclAndReset() -> EnumCaseDeclSyntax? {
       guard !elements.isEmpty else { return nil }
 
-      // Remove the trailing comma on the final element, if there was one.
-      elements[elements.count - 1].trailingComma = nil
+      // Remove the trailing comma on the final element, if there was one, keeping any end-of-line
+      // comment that the comma carried on the element's line.
+      CaseElementCollector.removeTrailingComma(from: &elements[elements.count - 1])
 
       defer { elements.removeAll() }
       return makeCaseDeclFromBasis(elements: elements)
@@ -70,13 +82,22 @@ public final class OneCasePerLine: SyntaxFormatRule {
     mutating func makeCaseDeclFromBasis(elements: [EnumCaseElementSyntax]) -> EnumCaseDeclSyntax {
       var caseDecl = basis
 
-      // The first element follows the `case` keyword, so any leading newline it inherited from the
-      // original (where it was on a continuation line, like `case a,\n  b`) would force it onto its
-      // own line. Drop that whitespace so the element stays on the same line as `case`, but preserve
-      // any comments that were attached to it.
+      // The first element follows the `case` keyword. When the original wrote it on a continuation
+      // line (like `case a,\n  b`), it inherited leading whitespace, and any comment documenting it
+      // (like `case a,\n  // about b\n  b`) ended up in that leading trivia too. Drop the whitespace
+      // so the element sits on the same line as `case`, and hoist any documentation comment so that
+      // it precedes the newly inserted `case` keyword instead of being stranded after it.
       var elements = elements
       if let first = elements.first {
-        elements[0].leadingTrivia = first.leadingTrivia.withoutLeadingVerticalWhitespace()
+        let (hoistedComments, remainder) = first.leadingTrivia.splittingLeadingComments()
+        elements[0].leadingTrivia = remainder
+        if !hoistedComments.isEmpty {
+          // Place the hoisted comments between the existing leading trivia (which ends the previous
+          // line) and the `case` keyword, with a trailing newline so `case` starts its own line. The
+          // pretty printer fixes up indentation.
+          caseDecl.leadingTrivia =
+            caseDecl.leadingTrivia + hoistedComments + Trivia.newlines(1)
+        }
       }
       caseDecl.elements = EnumCaseElementListSyntax(elements)
 
@@ -120,7 +141,7 @@ public final class OneCasePerLine: SyntaxFormatRule {
           }
 
           var basisElement = element
-          basisElement.trailingComma = nil
+          CaseElementCollector.removeTrailingComma(from: &basisElement)
           let separatedCaseDecl = collector.makeCaseDeclFromBasis(elements: [basisElement])
 
           var newMember = member

--- a/Sources/SwiftFormat/Rules/OneCasePerLine.swift
+++ b/Sources/SwiftFormat/Rules/OneCasePerLine.swift
@@ -69,6 +69,15 @@ public final class OneCasePerLine: SyntaxFormatRule {
     /// basis declaration, and updates the comment preserving state if needed.
     mutating func makeCaseDeclFromBasis(elements: [EnumCaseElementSyntax]) -> EnumCaseDeclSyntax {
       var caseDecl = basis
+
+      // The first element follows the `case` keyword, so any leading newline it inherited from the
+      // original (where it was on a continuation line, like `case a,\n  b`) would force it onto its
+      // own line. Drop that whitespace so the element stays on the same line as `case`, but preserve
+      // any comments that were attached to it.
+      var elements = elements
+      if let first = elements.first {
+        elements[0].leadingTrivia = first.leadingTrivia.withoutLeadingVerticalWhitespace()
+      }
       caseDecl.elements = EnumCaseElementListSyntax(elements)
 
       if shouldKeepLeadingTrivia {

--- a/Tests/SwiftFormatTests/Rules/OneCasePerLineTests.swift
+++ b/Tests/SwiftFormatTests/Rules/OneCasePerLineTests.swift
@@ -137,7 +137,7 @@ final class OneCasePerLineTests: LintOrFormatRuleTestCase {
     )
   }
 
-  func testCommentBetweenElementsOnContinuationLinesIsPreserved() {
+  func testCommentBeforeElementOnContinuationLineMovesAheadOfCaseKeyword() {
     assertFormatting(
       OneCasePerLine.self,
       input: """
@@ -150,8 +150,54 @@ final class OneCasePerLineTests: LintOrFormatRuleTestCase {
       expected: """
         enum Foo: Int {
           case a = 1
-        case // This should stay with `b`.
-            b = 2
+        // This should stay with `b`.
+        case b = 2
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "move 'a' to its own 'case' declaration"),
+        FindingSpec("2️⃣", message: "move 'b' to its own 'case' declaration"),
+      ]
+    )
+  }
+
+  func testEndOfLineCommentStaysWithItsElement() {
+    assertFormatting(
+      OneCasePerLine.self,
+      input: """
+        enum Foo: Int {
+          case 1️⃣a = 1,  // a comment about 'a'
+            2️⃣b = 2
+        }
+        """,
+      expected: """
+        enum Foo: Int {
+          case a = 1  // a comment about 'a'
+        case b = 2
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "move 'a' to its own 'case' declaration"),
+        FindingSpec("2️⃣", message: "move 'b' to its own 'case' declaration"),
+      ]
+    )
+  }
+
+  func testEndOfLineAndLeadingCommentsBothStayWithTheirElements() {
+    assertFormatting(
+      OneCasePerLine.self,
+      input: """
+        enum Foo: Int {
+          case 1️⃣a = 1,  // an end-of-line comment about 'a'
+            // This should stay with `b`.
+            2️⃣b = 2
+        }
+        """,
+      expected: """
+        enum Foo: Int {
+          case a = 1  // an end-of-line comment about 'a'
+        // This should stay with `b`.
+        case b = 2
         }
         """,
       findings: [

--- a/Tests/SwiftFormatTests/Rules/OneCasePerLineTests.swift
+++ b/Tests/SwiftFormatTests/Rules/OneCasePerLineTests.swift
@@ -112,6 +112,55 @@ final class OneCasePerLineTests: LintOrFormatRuleTestCase {
     )
   }
 
+  func testElementsOnContinuationLinesAreMovedOntoCaseKeyword() {
+    assertFormatting(
+      OneCasePerLine.self,
+      input: """
+        public enum TestEnum: Int {
+          case 1️⃣a = 0,
+            2️⃣b = 1,
+            3️⃣c = 2
+        }
+        """,
+      expected: """
+        public enum TestEnum: Int {
+          case a = 0
+        case b = 1
+        case c = 2
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "move 'a' to its own 'case' declaration"),
+        FindingSpec("2️⃣", message: "move 'b' to its own 'case' declaration"),
+        FindingSpec("3️⃣", message: "move 'c' to its own 'case' declaration"),
+      ]
+    )
+  }
+
+  func testCommentBetweenElementsOnContinuationLinesIsPreserved() {
+    assertFormatting(
+      OneCasePerLine.self,
+      input: """
+        enum Foo: Int {
+          case 1️⃣a = 1,
+            // This should stay with `b`.
+            2️⃣b = 2
+        }
+        """,
+      expected: """
+        enum Foo: Int {
+          case a = 1
+        case // This should stay with `b`.
+            b = 2
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "move 'a' to its own 'case' declaration"),
+        FindingSpec("2️⃣", message: "move 'b' to its own 'case' declaration"),
+      ]
+    )
+  }
+
   func testAttributesArePropagated() {
     assertFormatting(
       OneCasePerLine.self,


### PR DESCRIPTION
Fixes #1009.

When a multi-element `case` declaration has its elements spread across continuation lines, `OneCasePerLine` left the leading newline trivia on each element's name when splitting them into separate declarations. With `respectsExistingLineBreaks` enabled (the default), the pretty printer honored that newline, so the `case` keyword ended up alone on its own line:

```swift
public enum TestEnum: Int {
  case a = 0,
    b = 1,
    c = 2
}
```

was reformatted to

```swift
public enum TestEnum: Int {
  case a = 0
  case
    b = 1
  case
    c = 2
}
```

### Fix

When building each generated case declaration, drop the leading vertical whitespace (newlines and surrounding indentation) from its first element so the element stays on the same line as the `case` keyword. Comments attached to the element are preserved rather than dropped, so something like

```swift
case a = 1,
  // keep with b
  b = 2
```

still keeps the comment with `b`.

### Testing

Added `testElementsOnContinuationLinesAreMovedOntoCaseKeyword` covering the reported case and `testCommentBetweenElementsOnContinuationLinesIsPreserved` for the comment edge case. `swift test` passes (915 tests, the one pre-existing skip unchanged).