### PR TITLE
Clarify AlwaysUseLowerCamelCase docs on the test-code carve-out

### DIFF
--- a/Documentation/RuleDocumentation.md
+++ b/Documentation/RuleDocumentation.md
@@ -81,9 +81,9 @@ Underscores (except at the beginning of an identifier) are disallowed.
 Underscores are allowed in the names of test functions, where they are commonly used to
 separate phrases in long, descriptive names. The lower camel-case requirement still applies
 otherwise, so a test function name that begins with a capital letter is still diagnosed. Test
-code is defined as code which:
-  * Contains the line `import XCTest`
-  * Has a function marked with the `@Test` attribute
+functions are functions that either:
+  * start with `test` in a file containing `import XCTest`, or
+  * are marked with the `@Test` attribute.
 
 Lint: If an identifier contains underscores or begins with a capital letter, a lint error is
       raised.

--- a/Documentation/RuleDocumentation.md
+++ b/Documentation/RuleDocumentation.md
@@ -78,9 +78,12 @@ Format: All invalid use sites would be related with empty literal (with or witho
 All values should be written in lower camel-case (`lowerCamelCase`).
 Underscores (except at the beginning of an identifier) are disallowed.
 
-This rule does not apply to test code, defined as code which:
+Underscores are allowed in the names of test functions, where they are commonly used to
+separate phrases in long, descriptive names. The lower camel-case requirement still applies
+otherwise, so a test function name that begins with a capital letter is still diagnosed. Test
+code is defined as code which:
   * Contains the line `import XCTest`
-  * The function is marked with `@Test` attribute
+  * Has a function marked with the `@Test` attribute
 
 Lint: If an identifier contains underscores or begins with a capital letter, a lint error is
       raised.

--- a/Sources/SwiftFormat/Rules/AlwaysUseLowerCamelCase.swift
+++ b/Sources/SwiftFormat/Rules/AlwaysUseLowerCamelCase.swift
@@ -18,9 +18,9 @@ import SwiftSyntax
 /// Underscores are allowed in the names of test functions, where they are commonly used to
 /// separate phrases in long, descriptive names. The lower camel-case requirement still applies
 /// otherwise, so a test function name that begins with a capital letter is still diagnosed. Test
-/// code is defined as code which:
-///   * Contains the line `import XCTest`
-///   * Has a function marked with the `@Test` attribute
+/// functions are functions that either:
+///   * start with `test` in a file containing `import XCTest`, or
+///   * are marked with the `@Test` attribute.
 ///
 /// Lint: If an identifier contains underscores or begins with a capital letter, a lint error is
 ///       raised.

--- a/Sources/SwiftFormat/Rules/AlwaysUseLowerCamelCase.swift
+++ b/Sources/SwiftFormat/Rules/AlwaysUseLowerCamelCase.swift
@@ -15,9 +15,12 @@ import SwiftSyntax
 /// All values should be written in lower camel-case (`lowerCamelCase`).
 /// Underscores (except at the beginning of an identifier) are disallowed.
 ///
-/// This rule does not apply to test code, defined as code which:
+/// Underscores are allowed in the names of test functions, where they are commonly used to
+/// separate phrases in long, descriptive names. The lower camel-case requirement still applies
+/// otherwise, so a test function name that begins with a capital letter is still diagnosed. Test
+/// code is defined as code which:
 ///   * Contains the line `import XCTest`
-///   * The function is marked with `@Test` attribute
+///   * Has a function marked with the `@Test` attribute
 ///
 /// Lint: If an identifier contains underscores or begins with a capital letter, a lint error is
 ///       raised.


### PR DESCRIPTION
## Problem

The `AlwaysUseLowerCamelCase` rule documentation says the rule "does not apply to test code" (code that imports XCTest or has a function marked with `@Test`). That is not what the rule does. The test-code carve-out only relaxes the restriction on underscores; the lower camel-case requirement still applies, so a test function whose name begins with a capital letter is still diagnosed.

For example, this still produces a warning even though the function is marked `@Test`:

```swift
import Testing

struct MyTests {
  @Test func MyTestCase() {}  // warning: [AlwaysUseLowerCamelCase] rename the function 'MyTestCase' using lowerCamelCase
}
```

This matches the behavior described by the maintainer in #1129: underscores are permitted in test names by convention, but UpperCamelCase is not allowed just because something is a test.

## Fix

Reword the rule's doc comment to describe the actual behavior: underscores are allowed in test function names, while the lower camel-case requirement otherwise still applies. `RuleDocumentation.md` is regenerated from that comment via `swift run generate-swift-format`.

This is a documentation-only change; the rule's behavior is unchanged.

## Testing

`swift build` and `swift test --filter AlwaysUseLowerCamelCaseTests` pass. The existing tests already cover both halves of the clarified wording: underscores are accepted in test names (`testIgnoresUnderscoresInTestNames`, `testIgnoresFunctionsWithTestAttributes`) while invalid casing is still flagged (`testInvalidFunctionCasing`).

Fixes #1129.