### PR TITLE
Fix assertion failure when swift-format-ignore is used inside #if

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -1523,10 +1523,21 @@ private final class TokenStreamCreator: SyntaxVisitor {
     // Unlike other code blocks, where we may want a single statement to be laid out on the same
     // line as a parent construct, the content of an `#if` block must always be on its own line;
     // the newline token inserted at the end enforces this.
-    if let lastElemTok = node.elements?.lastToken(viewMode: .sourceAccurate) {
+    //
+    // The closing tokens are normally attached after the last token of the body. If that last token
+    // belongs to a formatter-ignored item, however, it is never visited (its node is emitted as a
+    // single verbatim token), so an `after` group on it would be dropped and the `.open` above would
+    // be left unclosed. In that case, attach the closing tokens before the following token (the next
+    // `#elseif`/`#else`/`#endif`) instead, which is always visited.
+    if let lastElemTok = node.elements?.lastToken(viewMode: .sourceAccurate),
+      !isFormatterIgnored(lastElemTok)
+    {
       after(lastElemTok, tokens: .break(breakKindClose, newlines: .soft), .close)
     } else {
-      before(tokenToOpenWith.nextToken(viewMode: .all), tokens: .break(breakKindClose, newlines: .soft), .close)
+      let tokenAfterBody =
+        node.elements?.lastToken(viewMode: .sourceAccurate)?.nextToken(viewMode: .all)
+        ?? tokenToOpenWith.nextToken(viewMode: .all)
+      before(tokenAfterBody, tokens: .break(breakKindClose, newlines: .soft), .close)
     }
 
     if !isNestedInPostfixIfConfig(node: Syntax(node)), let condition = node.condition {
@@ -4585,6 +4596,26 @@ private func shouldFormatterIgnore(node: Syntax) -> Bool {
 /// - Parameter file: The root syntax node for a source file.
 private func shouldFormatterIgnore(file: SourceFileSyntax) -> Bool {
   return isFormatterIgnorePresent(inTrivia: file.allPrecedingTrivia, isWholeFile: true)
+}
+
+/// Returns whether the given token is contained within a formatter-ignored item.
+///
+/// When an item is formatter-ignored, its entire subtree is emitted as a single verbatim token and
+/// none of its tokens are visited individually. Code that wants to attach tokens after such a token
+/// (via `after(_:tokens:)`) must account for the fact that those tokens would be silently dropped.
+///
+/// - Parameter token: The token to test.
+private func isFormatterIgnored(_ token: TokenSyntax) -> Bool {
+  // Only `CodeBlockItem` and `MemberBlockItem` nodes are emitted verbatim via the per-item ignore
+  // path, so those are the only ancestors that can prevent `token` from being visited.
+  var node = Syntax(token).parent
+  while let current = node {
+    if current.is(CodeBlockItemSyntax.self) || current.is(MemberBlockItemSyntax.self) {
+      return shouldFormatterIgnore(node: current)
+    }
+    node = current.parent
+  }
+  return false
 }
 
 extension NewlineBehavior {

--- a/Tests/SwiftFormatTests/PrettyPrint/IgnoreNodeTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/IgnoreNodeTests.swift
@@ -205,6 +205,112 @@ final class IgnoreNodeTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
   }
 
+  func testIgnoreInConditionalCompilationBlock() {
+    let input =
+      """
+      #if FOO
+      // swift-format-ignore
+      let  x  =  1
+      #endif
+      """
+
+    let expected =
+      """
+      #if FOO
+        // swift-format-ignore
+        let  x  =  1
+      #endif
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+  }
+
+  func testIgnoreInEachConditionalCompilationClause() {
+    let input =
+      """
+      #if FOO
+      // swift-format-ignore
+      let  x  =  1
+      #elseif BAR
+      let y = 2
+      // swift-format-ignore
+      let  z  =  3
+      #else
+      // swift-format-ignore
+      let  w  =  4
+      #endif
+      """
+
+    let expected =
+      """
+      #if FOO
+        // swift-format-ignore
+        let  x  =  1
+      #elseif BAR
+        let y = 2
+        // swift-format-ignore
+        let  z  =  3
+      #else
+        // swift-format-ignore
+        let  w  =  4
+      #endif
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+  }
+
+  func testIgnoreInNestedConditionalCompilationBlock() {
+    let input =
+      """
+      #if FOO
+      #if BAR
+      // swift-format-ignore
+      let  a  =  1
+      #endif
+      #endif
+      """
+
+    let expected =
+      """
+      #if FOO
+        #if BAR
+          // swift-format-ignore
+          let  a  =  1
+        #endif
+      #endif
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+  }
+
+  func testIgnoreMemberInConditionalCompilationBlock() {
+    let input =
+      """
+      struct S {
+        #if FOO
+        // swift-format-ignore
+        let  x  =  1
+        #endif
+      }
+      """
+
+    let expected =
+      """
+      struct S {
+        #if FOO
+          // swift-format-ignore
+          let  x  =  1
+        #endif
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+  }
+
   func testInvalidComment() {
     let input =
       """


### PR DESCRIPTION
Fixes #1079.

### Problem

Running swift-format (debug build) on a `// swift-format-ignore` directive applied to the last element of a conditional-compilation clause crashes with:

```
SwiftFormat/PrettyPrint.swift:725: Assertion failed: Too many unresolved delimiter token lengths.
```

Minimal reproducer from the issue:

```swift
#if FOO
// swift-format-ignore
print("Hi")
#endif
```

### Root cause

`visit(_ node: IfConfigClauseSyntax)` attaches the clause body’s closing tokens with `after(node.elements?.lastToken, tokens: ..., .close)`, matching the `.open` it emits right after the condition.

When the last element of the body is formatter-ignored, the whole element is emitted as a single `.verbatim` token by `appendFormatterIgnored` and the visit returns `.skipChildren`, so that element’s tokens are never visited. The `after` group registered on its last token is therefore never flushed, the matching `.close` is dropped, and the `.open` is left unclosed. During length calculation in `prettyPrint()`, `delimIndexStack` ends with two unresolved entries and the assertion fires (in release builds the lengths would be resolved incorrectly).

The same hazard is already handled elsewhere: the `CodeBlockItemListSyntax` and `MemberBlockItemListSyntax` visitors skip emitting per-item `.open`/`.close` for ignored items, and the `SwitchCase` visitor falls back to a `before(nextToken:)` anchor when its body has no trailing token of its own.

### Fix

Detect when the body’s last token belongs to a formatter-ignored item, and in that case attach the closing tokens `before` the following token (the next `#elseif`/`#else`/`#endif`), which is always visited. This mirrors the existing empty-clause branch. Non-ignored `#if` blocks take the unchanged `after(lastElemTok:)` path, so their output is byte-for-byte identical.

### Testing

- Added four cases to `IgnoreNodeTests`: ignore in a single `#if`, ignore in each of `#if`/`#elseif`/`#else`, ignore in a nested `#if`, and an ignored member inside `#if` within a type. Each asserts the ignored region is preserved verbatim while the surrounding directive lines are formatted; the helper’s idempotency check also runs.
- Verified the reproducer (and `#elseif`/`#else`, nested, member-block, postfix `#if`, and `indentConditionalCompilationBlocks = false` variants) no longer crashes and produces correct output.
- Full `swift test` suite is green with no regressions.