### PR TITLE
Add lint --non-fixable-only flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ as well as the linting-only options below:
     do not prevent a successful exit; only fatal errors (for example, trying to
     lint a file that does not exist) cause the tool to exit unsuccessfully.
 
+*   `--non-fixable-only`: If this option is specified, lint will only emit
+    findings that cannot be fixed automatically by formatting.
+
 ### Options Supported by Formatting and Linting
 
 The following options are supported by both the `format` and `lint`

--- a/Sources/SwiftFormat/API/Finding.swift
+++ b/Sources/SwiftFormat/API/Finding.swift
@@ -79,6 +79,9 @@ public struct Finding {
   /// The optional location of the finding.
   public let location: Location?
 
+  /// Whether the finding can be corrected automatically by formatting the source.
+  public let isFixable: Bool
+
   /// Notes that provide additional detail about the finding.
   public let notes: [Note]
 
@@ -88,11 +91,13 @@ public struct Finding {
     category: FindingCategorizing,
     message: Message,
     location: Location? = nil,
+    isFixable: Bool = false,
     notes: [Note] = []
   ) {
     self.category = category
     self.message = message
     self.location = location
+    self.isFixable = isFixable
     self.notes = notes
   }
 }

--- a/Sources/SwiftFormat/Core/FindingEmitter.swift
+++ b/Sources/SwiftFormat/Core/FindingEmitter.swift
@@ -38,12 +38,14 @@ final class FindingEmitter {
   ///   - category: A value that groups the finding into a category.
   ///   - location: The source location where the finding was encountered. In rare cases where the
   ///     finding does not apply to a particular location in the source code, this may be nil.
+  ///   - isFixable: Whether the finding can be corrected automatically by formatting the source.
   ///   - notes: Notes that provide additional detail about the finding, possibly referring to other
   ///     related locations in the source file.
   public func emit(
     _ message: Finding.Message,
     category: FindingCategorizing,
     location: Finding.Location? = nil,
+    isFixable: Bool = false,
     notes: [Finding.Note] = []
   ) {
     guard let consumer = self.consumer else { return }
@@ -53,6 +55,7 @@ final class FindingEmitter {
         category: category,
         message: message,
         location: location,
+        isFixable: isFixable,
         notes: notes
       )
     )

--- a/Sources/SwiftFormat/Core/Rule.swift
+++ b/Sources/SwiftFormat/Core/Rule.swift
@@ -65,6 +65,37 @@ extension Rule {
     anchor: FindingAnchor = .start,
     notes: [Finding.Note] = []
   ) {
+    emitFinding(message, on: node, anchor: anchor, isFixable: nil, notes: notes)
+  }
+
+  /// Emits the given finding.
+  ///
+  /// - Parameters:
+  ///   - message: The finding message to emit.
+  ///   - node: The syntax node to which the finding should be attached. The finding's location will
+  ///     be set to the start of the node (excluding leading trivia, unless `leadingTriviaIndex` is
+  ///     provided).
+  ///   - anchor: The part of the node where the finding should be anchored. Defaults to the start
+  ///     of the node's content (after any leading trivia).
+  ///   - isFixable: Whether the finding can be corrected automatically by formatting the source.
+  ///   - notes: An array of notes that provide additional detail about the finding.
+  public func diagnose<SyntaxType: SyntaxProtocol>(
+    _ message: Finding.Message,
+    on node: SyntaxType?,
+    anchor: FindingAnchor = .start,
+    isFixable: Bool,
+    notes: [Finding.Note] = []
+  ) {
+    emitFinding(message, on: node, anchor: anchor, isFixable: isFixable, notes: notes)
+  }
+
+  private func emitFinding<SyntaxType: SyntaxProtocol>(
+    _ message: Finding.Message,
+    on node: SyntaxType?,
+    anchor: FindingAnchor,
+    isFixable: Bool?,
+    notes: [Finding.Note]
+  ) {
     let syntaxLocation: SourceLocation?
     if let node = node {
       switch anchor {
@@ -90,6 +121,7 @@ extension Rule {
       message,
       category: category,
       location: syntaxLocation.flatMap(Finding.Location.init),
+      isFixable: isFixable ?? (self is SyntaxFormatRule),
       notes: notes
     )
   }

--- a/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
@@ -851,7 +851,8 @@ public class PrettyPrinter {
     context.findingEmitter.emit(
       message,
       category: category,
-      location: Finding.Location(file: context.fileURL.relativePath, line: outputBuffer.lineNumber, column: column)
+      location: Finding.Location(file: context.fileURL.relativePath, line: outputBuffer.lineNumber, column: column),
+      isFixable: true
     )
   }
 }

--- a/Sources/SwiftFormat/PrettyPrint/WhitespaceLinter.swift
+++ b/Sources/SwiftFormat/PrettyPrint/WhitespaceLinter.swift
@@ -372,7 +372,8 @@ public class WhitespaceLinter {
     context.findingEmitter.emit(
       message,
       category: category,
-      location: Finding.Location(sourceLocation)
+      location: Finding.Location(sourceLocation),
+      isFixable: true
     )
   }
 

--- a/Sources/SwiftFormat/Rules/NoAssignmentInExpressions.swift
+++ b/Sources/SwiftFormat/Rules/NoAssignmentInExpressions.swift
@@ -31,7 +31,11 @@ public final class NoAssignmentInExpressions: SyntaxFormatRule {
       && !isStandaloneAssignmentStatement(node)
       && !isInAllowedFunction(node)
     {
-      diagnose(.moveAssignmentToOwnStatement, on: node)
+      diagnose(
+        .moveAssignmentToOwnStatement,
+        on: node,
+        isFixable: canMoveAssignmentToOwnStatement(node)
+      )
     }
     return ExprSyntax(node)
   }
@@ -95,6 +99,15 @@ public final class NoAssignmentInExpressions: SyntaxFormatRule {
       return nil
     }
     return isAssignmentExpression(infixOperatorExpr) ? infixOperatorExpr : nil
+  }
+
+  /// Returns a value indicating whether the formatter can move the given assignment into its own
+  /// statement.
+  private func canMoveAssignmentToOwnStatement(_ node: InfixOperatorExprSyntax) -> Bool {
+    guard let returnStmt = Syntax(node).parent?.as(ReturnStmtSyntax.self) else {
+      return false
+    }
+    return assignmentExpression(from: returnStmt)?.id == node.id
   }
 
   /// Returns a value indicating whether the given infix operator expression is an assignment

--- a/Sources/SwiftFormat/Rules/OneVariableDeclarationPerLine.swift
+++ b/Sources/SwiftFormat/Rules/OneVariableDeclarationPerLine.swift
@@ -41,8 +41,6 @@ public final class OneVariableDeclarationPerLine: SyntaxFormatRule {
         continue
       }
 
-      diagnose(.onlyOneVariableDeclaration(specifier: varDecl.bindingSpecifier.text), on: varDecl)
-
       // Visit the decl recursively to make sure nested code block items in the
       // bindings (for example, an initializer expression that contains a
       // closure expression) are transformed first before we rewrite the decl
@@ -54,7 +52,14 @@ public final class OneVariableDeclarationPerLine: SyntaxFormatRule {
           semicolon: nil
         )
       }
-      newItems.append(contentsOf: splitter.nodes(bySplitting: visitedDecl))
+      let splitNodes = splitter.nodes(bySplitting: visitedDecl)
+      let canSplitDeclaration = !splitNodes.contains(where: codeBlockItemHasMultipleVariableBindings)
+      diagnose(
+        .onlyOneVariableDeclaration(specifier: varDecl.bindingSpecifier.text),
+        on: varDecl,
+        isFixable: canSplitDeclaration
+      )
+      newItems.append(contentsOf: splitNodes)
     }
 
     return CodeBlockItemListSyntax(newItems)

--- a/Sources/SwiftFormat/Rules/OrderedImports.swift
+++ b/Sources/SwiftFormat/Rules/OrderedImports.swift
@@ -297,14 +297,17 @@ public final class OrderedImports: SyntaxFormatRule {
         let fullyQualifiedImport = line.fullyQualifiedImport
         // Check for duplicate imports and potentially remove them.
         if let previousMatchingImportIndex = visitedImports[fullyQualifiedImport] {
+          var duplicateLine = linesWithLeadingComments[previousMatchingImportIndex]
+          let canRemoveDuplicateAutomatically =
+            duplicateLine.import.trailingTrivia.isEmpty || line.trailingTrivia.isEmpty
+
           // Even if automatically removing this import is impossible, alert the user that this is a
           // duplicate so they can manually fix it.
-          diagnose(.removeDuplicateImport, on: line.firstToken)
-          var duplicateLine = linesWithLeadingComments[previousMatchingImportIndex]
+          diagnose(.removeDuplicateImport, on: line.firstToken, isFixable: canRemoveDuplicateAutomatically)
 
           // We can combine multiple leading comments, but it's unsafe to combine trailing comments.
           // Any extra comments must go on a new line, and would be grouped with the next import.
-          guard !duplicateLine.import.trailingTrivia.isEmpty && !line.trailingTrivia.isEmpty else {
+          guard !canRemoveDuplicateAutomatically else {
             duplicateLine.comments.append(contentsOf: commentBuffer)
             commentBuffer = []
             // Keep the Line that has the trailing comment, if there is one.

--- a/Sources/SwiftFormat/Rules/ReturnVoidInsteadOfEmptyTuple.swift
+++ b/Sources/SwiftFormat/Rules/ReturnVoidInsteadOfEmptyTuple.swift
@@ -29,14 +29,15 @@ public final class ReturnVoidInsteadOfEmptyTuple: SyntaxFormatRule {
       return super.visit(node)
     }
 
-    diagnose(.returnVoid, on: returnType)
-
     // If the user has put non-whitespace trivia inside the empty tuple, like a comment, then we
     // still diagnose it as a lint error but we don't replace it because it's not obvious where the
     // comment should go.
-    if hasNonWhitespaceTrivia(returnType.leftParen, at: .trailing)
+    let hasUnmovableTrivia =
+      hasNonWhitespaceTrivia(returnType.leftParen, at: .trailing)
       || hasNonWhitespaceTrivia(returnType.rightParen, at: .leading)
-    {
+    diagnose(.returnVoid, on: returnType, isFixable: !hasUnmovableTrivia)
+
+    if hasUnmovableTrivia {
       return super.visit(node)
     }
 
@@ -59,14 +60,15 @@ public final class ReturnVoidInsteadOfEmptyTuple: SyntaxFormatRule {
       return super.visit(node)
     }
 
-    diagnose(.returnVoid, on: returnType)
-
     // If the user has put non-whitespace trivia inside the empty tuple, like a comment, then we
     // still diagnose it as a lint error but we don't replace it because it's not obvious where the
     // comment should go.
-    if hasNonWhitespaceTrivia(returnType.leftParen, at: .trailing)
+    let hasUnmovableTrivia =
+      hasNonWhitespaceTrivia(returnType.leftParen, at: .trailing)
       || hasNonWhitespaceTrivia(returnType.rightParen, at: .leading)
-    {
+    diagnose(.returnVoid, on: returnType, isFixable: !hasUnmovableTrivia)
+
+    if hasUnmovableTrivia {
       return super.visit(node)
     }
 

--- a/Sources/_SwiftFormatTestSupport/DiagnosingTestCase.swift
+++ b/Sources/_SwiftFormatTestSupport/DiagnosingTestCase.swift
@@ -130,6 +130,20 @@ open class DiagnosingTestCase: XCTestCase {
       line: line
     )
 
+    if let isFixable = findingSpec.isFixable {
+      XCTAssertEqual(
+        matchedFinding.isFixable,
+        isFixable,
+        """
+        Finding emitted at marker '\(findingSpec.marker)' \
+        (line:col \(markerLocation.line):\(markerLocation.column), offset \(utf8Offset)) \
+        had the wrong fixability
+        """,
+        file: file,
+        line: line
+      )
+    }
+
     // Assert that a note exists for each of the expected nodes in the finding.
     var emittedNotes = matchedFinding.notes
     for noteSpec in findingSpec.notes {

--- a/Sources/_SwiftFormatTestSupport/FindingSpec.swift
+++ b/Sources/_SwiftFormatTestSupport/FindingSpec.swift
@@ -18,13 +18,17 @@ public struct FindingSpec {
   /// The message text associated with the finding.
   public var message: String
 
+  /// Whether the finding should be marked as automatically fixable.
+  public var isFixable: Bool?
+
   /// A description of a `Note` that should be associated with this finding.
   public var notes: [NoteSpec]
 
   /// Creates a new `FindingSpec` with the given values.
-  public init(_ marker: String = "1️⃣", message: String, notes: [NoteSpec] = []) {
+  public init(_ marker: String = "1️⃣", message: String, isFixable: Bool? = nil, notes: [NoteSpec] = []) {
     self.marker = marker
     self.message = message
+    self.isFixable = isFixable
     self.notes = notes
   }
 }

--- a/Sources/swift-format/Frontend/LintFrontend.swift
+++ b/Sources/swift-format/Frontend/LintFrontend.swift
@@ -17,10 +17,27 @@ import SwiftSyntax
 
 /// The frontend for linting operations.
 class LintFrontend: Frontend {
+  /// Whether findings that can be fixed automatically by formatting should be suppressed.
+  private let nonFixableOnly: Bool
+
+  init(
+    configurationOptions: ConfigurationOptions,
+    lintFormatOptions: LintFormatOptions,
+    nonFixableOnly: Bool = false,
+    treatWarningsAsErrors: Bool = false
+  ) {
+    self.nonFixableOnly = nonFixableOnly
+    super.init(
+      configurationOptions: configurationOptions,
+      lintFormatOptions: lintFormatOptions,
+      treatWarningsAsErrors: treatWarningsAsErrors
+    )
+  }
+
   override func processFile(_ fileToProcess: FileToProcess) {
     let linter = SwiftLinter(
       configuration: fileToProcess.configuration,
-      findingConsumer: diagnosticsEngine.consumeFinding
+      findingConsumer: consumeFinding
     )
     linter.debugOptions = debugOptions
 
@@ -54,5 +71,10 @@ class LintFrontend: Frontend {
     } catch {
       diagnosticsEngine.emitError("Unable to lint \(url.relativePath): \(error.localizedDescription).")
     }
+  }
+
+  private func consumeFinding(_ finding: Finding) {
+    guard !nonFixableOnly || !finding.isFixable else { return }
+    diagnosticsEngine.consumeFinding(finding)
   }
 }

--- a/Sources/swift-format/Subcommands/Lint.swift
+++ b/Sources/swift-format/Subcommands/Lint.swift
@@ -32,6 +32,11 @@ extension SwiftFormatCommand {
     )
     var strict: Bool = false
 
+    @Flag(
+      help: "Only emit findings that cannot be fixed automatically by formatting."
+    )
+    var nonFixableOnly: Bool = false
+
     @OptionGroup(visibility: .hidden)
     var performanceMeasurementOptions: PerformanceMeasurementsOptions
 
@@ -40,6 +45,7 @@ extension SwiftFormatCommand {
         let frontend = LintFrontend(
           configurationOptions: configurationOptions,
           lintFormatOptions: lintOptions,
+          nonFixableOnly: nonFixableOnly,
           treatWarningsAsErrors: strict
         )
         frontend.run()

--- a/Tests/SwiftFormatTests/API/FindingFixabilityTests.swift
+++ b/Tests/SwiftFormatTests/API/FindingFixabilityTests.swift
@@ -1,0 +1,119 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftFormat
+@_spi(Rules) import SwiftFormat
+import XCTest
+@_spi(Testing) import _SwiftFormatTestSupport
+
+final class FindingFixabilityTests: XCTestCase {
+  func testLintRuleFindingsAreNotFixable() throws {
+    let findings = try lint(
+      "let value = optional!\n",
+      configuration: Configuration.forTesting(enabledRule: NeverForceUnwrap.ruleName)
+    )
+
+    let finding = try XCTUnwrap(findings.first { "\($0.category)" == NeverForceUnwrap.ruleName })
+    XCTAssertFalse(finding.isFixable)
+  }
+
+  func testFormatRuleFindingsAreFixableByDefault() throws {
+    let findings = try lint(
+      """
+      func f() {
+        if (true) {}
+      }
+      """,
+      configuration: Configuration.forTesting(enabledRule: NoParensAroundConditions.ruleName)
+    )
+
+    let finding = try XCTUnwrap(findings.first { "\($0.category)" == NoParensAroundConditions.ruleName })
+    XCTAssertTrue(finding.isFixable)
+  }
+
+  func testWhitespaceFindingsAreFixable() throws {
+    let findings = try lint(
+      """
+      struct Foo {
+        var value:Int
+      }
+      """,
+      configuration: Configuration.forTesting
+    )
+
+    let finding = try XCTUnwrap(findings.first { "\($0.category)" == "Spacing" })
+    XCTAssertTrue(finding.isFixable)
+  }
+
+  func testFormatRuleCanEmitNonFixableFinding() throws {
+    let findings = try lint(
+      """
+      struct Foo {
+        var callback: () -> (/* comment */)
+      }
+      """,
+      configuration: Configuration.forTesting(enabledRule: ReturnVoidInsteadOfEmptyTuple.ruleName)
+    )
+
+    let finding = try XCTUnwrap(findings.first { "\($0.category)" == ReturnVoidInsteadOfEmptyTuple.ruleName })
+    XCTAssertFalse(finding.isFixable)
+  }
+
+  func testAssignmentExpressionFixabilityReflectsFormatterBehavior() throws {
+    let findings = try lint(
+      """
+      func f() {
+        while x = 1 {}
+        return y = 2
+      }
+      """,
+      configuration: Configuration.forTesting(enabledRule: NoAssignmentInExpressions.ruleName)
+    )
+
+    let nonFixableFinding = try XCTUnwrap(
+      findings.first { "\($0.category)" == NoAssignmentInExpressions.ruleName && $0.location?.line == 2 }
+    )
+    XCTAssertFalse(nonFixableFinding.isFixable)
+
+    let fixableFinding = try XCTUnwrap(
+      findings.first { "\($0.category)" == NoAssignmentInExpressions.ruleName && $0.location?.line == 3 }
+    )
+    XCTAssertTrue(fixableFinding.isFixable)
+  }
+
+  func testInvalidMultipleVariableDeclarationFindingIsNotFixable() throws {
+    let findings = try lint(
+      """
+      func f() {
+        var a, b = 1
+      }
+      """,
+      configuration: Configuration.forTesting(enabledRule: OneVariableDeclarationPerLine.ruleName)
+    )
+
+    let finding = try XCTUnwrap(findings.first { "\($0.category)" == OneVariableDeclarationPerLine.ruleName })
+    XCTAssertFalse(finding.isFixable)
+  }
+
+  private func lint(_ source: String, configuration: Configuration) throws -> [Finding] {
+    var findings = [Finding]()
+    let linter = SwiftLinter(
+      configuration: configuration,
+      findingConsumer: { findings.append($0) }
+    )
+    try linter.lint(
+      source: source,
+      assumingFileURL: URL(fileURLWithPath: "/tmp/test.swift")
+    )
+    return findings
+  }
+}


### PR DESCRIPTION
Adds a `lint --non-fixable-only` option.

This filters lint output to findings that cannot be fixed by swift-format format, so callers can avoid surfacing warnings for issues the formatter can already handle. Useful for only displaying non fixable issues in an IDE, while leaving fixable ones for automations. Especially warnings about whitespace can get very noisy in IDEs.

- Adds per-finding fixability via `Finding.isFixable`.
- Preserves the existing public `Rule.diagnose` API and adds an overload for explicit fixability.
- Handles rules where some findings are fixable and others are not.
- Findings from linter-only rules are non-fixable.
- Findings from format rules are fixable by default.
- Format rules can override fixability per finding when they diagnose a case the formatter intentionally leaves unchanged.

Current mixed cases are:
- `NoAssignmentInExpressions`: Only `return x = y` is auto-rewritten. Other assignment expressions, like `while x = y`, are diagnosed but not safely movable.
- `OneVariableDeclarationPerLine`: Multi-binding declarations are fixable only when splitting preserves valid Swift. Invalid forms like `var a, b = 1` are diagnosed but preserved.
- `OrderedImports`: Duplicate imports are removable unless both copies have trailing trivia/comments. In that case the duplicate is diagnosed but not merged.
- `ReturnVoidInsteadOfEmptyTuple`: `() -> ()` is rewritten to `() -> Void`, unless the empty tuple contains interior trivia/comments like `(/* comment */)`.