### PR TITLE
Fix rule-based formatting for non-zero offset selections

### DIFF
--- a/Sources/SwiftFormat/Core/Context.swift
+++ b/Sources/SwiftFormat/Core/Context.swift
@@ -90,11 +90,45 @@ public final class Context {
     self.ruleNameCache = ruleNameCache
   }
 
+  /// Returns whether the selection touches any part of the given node.
+  func selectionOverlaps(_ node: Syntax) -> Bool {
+    return selection.overlapsOrTouches(node.position..<node.endPosition)
+  }
+
   /// Given a rule's name and the node it is examining, determine if the rule is disabled at this
   /// location or not. Also makes sure the entire node is contained inside any selection.
   func shouldFormat<R: Rule>(_ rule: R.Type, node: Syntax) -> Bool {
-    let start = node.positionAfterSkippingLeadingTrivia
-    guard selection.contains(start) else { return false }
+    let isSelected: Bool
+    switch R.targetScope {
+    case .content:
+      // Content rules require the selection to intersect the actual code tokens.
+      let contentRange = node.positionAfterSkippingLeadingTrivia..<node.endPositionBeforeTrailingTrivia
+      isSelected = selection.overlapsOrTouches(contentRange)
+
+    case .leadingTrivia:
+      // Trivia rules should run if the selection intersects any part of the leading trivia range.
+      let leadingTriviaRange = node.position..<node.positionAfterSkippingLeadingTrivia
+      isSelected = selection.overlapsOrTouches(leadingTriviaRange)
+
+    case .trailingTrivia:
+      // Trivia rules should run if the selection intersects any part of the trailing trivia range.
+      let trailingTriviaRange = node.endPositionBeforeTrailingTrivia..<node.endPosition
+      isSelected = selection.overlapsOrTouches(trailingTriviaRange)
+
+    case .trivia:
+      let leadingTriviaRange = node.position..<node.positionAfterSkippingLeadingTrivia
+      let trailingTriviaRange = node.endPositionBeforeTrailingTrivia..<node.endPosition
+      isSelected =
+        selection.overlapsOrTouches(leadingTriviaRange)
+        || selection.overlapsOrTouches(trailingTriviaRange)
+
+    case .all:
+      // Broad rules run if the selection touches any part of the node at all.
+      let totalRange = node.position..<node.endPosition
+      isSelected = selection.overlapsOrTouches(totalRange)
+    }
+
+    guard isSelected else { return false }
 
     let loc = node.startLocation(converter: self.sourceLocationConverter)
 

--- a/Sources/SwiftFormat/Core/Context.swift
+++ b/Sources/SwiftFormat/Core/Context.swift
@@ -99,7 +99,7 @@ public final class Context {
   /// location or not. Also makes sure the entire node is contained inside any selection.
   func shouldFormat<R: Rule>(_ rule: R.Type, node: Syntax) -> Bool {
     let isSelected: Bool
-    switch R.targetScope {
+    switch R.affectedContent {
     case .content:
       // Content rules require the selection to intersect the actual code tokens.
       let contentRange = node.positionAfterSkippingLeadingTrivia..<node.endPositionBeforeTrailingTrivia

--- a/Sources/SwiftFormat/Core/Context.swift
+++ b/Sources/SwiftFormat/Core/Context.swift
@@ -93,7 +93,8 @@ public final class Context {
   /// Given a rule's name and the node it is examining, determine if the rule is disabled at this
   /// location or not. Also makes sure the entire node is contained inside any selection.
   func shouldFormat<R: Rule>(_ rule: R.Type, node: Syntax) -> Bool {
-    guard node.isInsideSelection(selection) else { return false }
+    let start = node.positionAfterSkippingLeadingTrivia
+    guard selection.contains(start) else { return false }
 
     let loc = node.startLocation(converter: self.sourceLocationConverter)
 

--- a/Sources/SwiftFormat/Core/Rule.swift
+++ b/Sources/SwiftFormat/Core/Rule.swift
@@ -25,6 +25,9 @@ public protocol Rule {
   /// Whether this rule is opt-in, meaning it is disabled by default.
   static var isOptIn: Bool { get }
 
+  /// The scope of the syntax node that this rule operates on.
+  static var targetScope: RuleTargetScope { get }
+
   /// Creates a new Rule in a given context.
   init(context: Context)
 }
@@ -45,9 +48,31 @@ public enum FindingAnchor {
   case trailingTrivia(Trivia.Index)
 }
 
+/// Describes the portion of a syntax node that a rule targets.
+@_spi(Rules)
+public enum RuleTargetScope {
+  /// The rule operates on the non-trivia content of the node.
+  case content
+
+  /// The rule operates on the leading trivia of the node.
+  case leadingTrivia
+
+  /// The rule operates on the trailing trivia of the node (such as end-of-line comments).
+  case trailingTrivia
+
+  /// The rule operates on either leading or trailing trivia of the node.
+  case trivia
+
+  /// The rule operates on the entire node, including all trivia and content.
+  case all
+}
+
 extension Rule {
   /// By default, the `ruleName` is just the name of the implementing rule class.
   public static var ruleName: String { String("\(self)".split(separator: ".").last!) }
+
+  /// By default, rules target the non-trivia content of a syntax node.
+  public static var targetScope: RuleTargetScope { .content }
 
   /// Emits the given finding.
   ///

--- a/Sources/SwiftFormat/Core/Rule.swift
+++ b/Sources/SwiftFormat/Core/Rule.swift
@@ -26,8 +26,7 @@ public protocol Rule {
   static var isOptIn: Bool { get }
 
   /// The scope of the syntax node that this rule operates on.
-  static var targetScope: RuleTargetScope { get }
-
+  static var affectedContent: AffectedContent { get }
   /// Creates a new Rule in a given context.
   init(context: Context)
 }
@@ -50,7 +49,7 @@ public enum FindingAnchor {
 
 /// Describes the portion of a syntax node that a rule targets.
 @_spi(Rules)
-public enum RuleTargetScope {
+public enum AffectedContent {
   /// The rule operates on the non-trivia content of the node.
   case content
 
@@ -72,7 +71,7 @@ extension Rule {
   public static var ruleName: String { String("\(self)".split(separator: ".").last!) }
 
   /// By default, rules target the non-trivia content of a syntax node.
-  public static var targetScope: RuleTargetScope { .content }
+  public static var affectedContent: AffectedContent { .content }
 
   /// Emits the given finding.
   ///

--- a/Sources/SwiftFormat/Core/SyntaxFormatRule.swift
+++ b/Sources/SwiftFormat/Core/SyntaxFormatRule.swift
@@ -21,6 +21,11 @@ public class SyntaxFormatRule: SyntaxRewriter, Rule {
     return false
   }
 
+  /// The scope of the syntax node that this rule operates on.
+  public class var targetScope: RuleTargetScope {
+    return .content
+  }
+
   /// The context in which the rule is executed.
   public let context: Context
 
@@ -32,7 +37,12 @@ public class SyntaxFormatRule: SyntaxRewriter, Rule {
   public override func visitAny(_ node: Syntax) -> Syntax? {
     // If the rule is not enabled, then return the node unmodified; otherwise, returning nil tells
     // SwiftSyntax to continue with the standard dispatch.
-    guard context.shouldFormat(type(of: self), node: node) else { return node }
+    guard context.shouldFormat(type(of: self), node: node) else {
+      if type(of: self).targetScope != .content && context.selectionOverlaps(node) {
+        return nil
+      }
+      return node
+    }
     return nil
   }
 }

--- a/Sources/SwiftFormat/Core/SyntaxFormatRule.swift
+++ b/Sources/SwiftFormat/Core/SyntaxFormatRule.swift
@@ -22,7 +22,7 @@ public class SyntaxFormatRule: SyntaxRewriter, Rule {
   }
 
   /// The scope of the syntax node that this rule operates on.
-  public class var targetScope: RuleTargetScope {
+  public class var affectedContent: AffectedContent {
     return .content
   }
 
@@ -38,7 +38,7 @@ public class SyntaxFormatRule: SyntaxRewriter, Rule {
     // If the rule is not enabled, then return the node unmodified; otherwise, returning nil tells
     // SwiftSyntax to continue with the standard dispatch.
     guard context.shouldFormat(type(of: self), node: node) else {
-      if type(of: self).targetScope != .content && context.selectionOverlaps(node) {
+      if type(of: self).affectedContent != .content && context.selectionOverlaps(node) {
         return nil
       }
       return node

--- a/Sources/SwiftFormat/Core/SyntaxLintRule.swift
+++ b/Sources/SwiftFormat/Core/SyntaxLintRule.swift
@@ -23,7 +23,7 @@ public class SyntaxLintRule: SyntaxVisitor, Rule {
   }
 
   /// The scope of the syntax node that this rule operates on.
-  public class var targetScope: RuleTargetScope {
+  public class var affectedContent: AffectedContent {
     return .content
   }
 

--- a/Sources/SwiftFormat/Core/SyntaxLintRule.swift
+++ b/Sources/SwiftFormat/Core/SyntaxLintRule.swift
@@ -22,6 +22,11 @@ public class SyntaxLintRule: SyntaxVisitor, Rule {
     return false
   }
 
+  /// The scope of the syntax node that this rule operates on.
+  public class var targetScope: RuleTargetScope {
+    return .content
+  }
+
   /// The context in which the rule is executed.
   public let context: Context
 

--- a/Sources/SwiftFormat/Rules/NoBlockComments.swift
+++ b/Sources/SwiftFormat/Rules/NoBlockComments.swift
@@ -17,6 +17,8 @@ import SwiftSyntax
 /// Lint: If a block comment appears, a lint error is raised.
 @_spi(Rules)
 public final class NoBlockComments: SyntaxLintRule {
+  public override class var targetScope: RuleTargetScope { .trivia }
+
   public override func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
     for triviaIndex in token.leadingTrivia.indices {
       let piece = token.leadingTrivia[triviaIndex]

--- a/Sources/SwiftFormat/Rules/NoBlockComments.swift
+++ b/Sources/SwiftFormat/Rules/NoBlockComments.swift
@@ -17,7 +17,7 @@ import SwiftSyntax
 /// Lint: If a block comment appears, a lint error is raised.
 @_spi(Rules)
 public final class NoBlockComments: SyntaxLintRule {
-  public override class var targetScope: RuleTargetScope { .trivia }
+  public override class var affectedContent: AffectedContent { .trivia }
 
   public override func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
     for triviaIndex in token.leadingTrivia.indices {

--- a/Sources/SwiftFormat/Rules/UseTripleSlashForDocumentationComments.swift
+++ b/Sources/SwiftFormat/Rules/UseTripleSlashForDocumentationComments.swift
@@ -24,7 +24,7 @@ import SwiftSyntax
 ///         multiple doc line comments.
 @_spi(Rules)
 public final class UseTripleSlashForDocumentationComments: SyntaxFormatRule {
-  public override class var targetScope: RuleTargetScope { .leadingTrivia }
+  public override class var affectedContent: AffectedContent { .leadingTrivia }
 
   public override func visit(_ node: FunctionDeclSyntax) -> DeclSyntax {
     return convertDocBlockCommentToDocLineComment(DeclSyntax(node))

--- a/Sources/SwiftFormat/Rules/UseTripleSlashForDocumentationComments.swift
+++ b/Sources/SwiftFormat/Rules/UseTripleSlashForDocumentationComments.swift
@@ -24,6 +24,8 @@ import SwiftSyntax
 ///         multiple doc line comments.
 @_spi(Rules)
 public final class UseTripleSlashForDocumentationComments: SyntaxFormatRule {
+  public override class var targetScope: RuleTargetScope { .leadingTrivia }
+
   public override func visit(_ node: FunctionDeclSyntax) -> DeclSyntax {
     return convertDocBlockCommentToDocLineComment(DeclSyntax(node))
   }
@@ -73,6 +75,9 @@ public final class UseTripleSlashForDocumentationComments: SyntaxFormatRule {
   ///
   /// If the declaration had no comment or had only line comments, it is returned unchanged.
   private func convertDocBlockCommentToDocLineComment(_ decl: DeclSyntax) -> DeclSyntax {
+    guard context.shouldFormat(Self.self, node: Syntax(decl)) else {
+      return decl
+    }
     guard
       let commentInfo = DocumentationCommentText(extractedFrom: decl.leadingTrivia),
       commentInfo.introducer != .line

--- a/Tests/SwiftFormatTests/API/SwiftFormatterSelectionTests.swift
+++ b/Tests/SwiftFormatTests/API/SwiftFormatterSelectionTests.swift
@@ -232,6 +232,31 @@ final class SwiftFormatterSelectionTests: XCTestCase {
     try assertFormatting(source, expected: expected, selection: Selection(lineRanges: [0...0]))
   }
 
+  func testRuleFormattingWithNonZeroOffsetRange() throws {
+    let source = "/// Some String....\n if (a = 0) {             NSLog(\"print: \\(a)\");}"
+    let expected = "/// Some String....\nif a = 0 { NSLog(\"print: \\(a)\") }\n"
+
+    var configuration = Configuration.forTesting
+    configuration.rules["NoParensAroundConditions"] = true
+    configuration.rules["DoNotUseSemicolons"] = true
+
+    let formatter = SwiftFormatter(configuration: configuration)
+    var output = ""
+    let tree = Parser.parse(source: source)
+    let foldedTree = try OperatorTable.standardOperators.foldAll(tree).as(SourceFileSyntax.self)!
+
+    try formatter.format(
+      syntax: foldedTree,
+      source: source,
+      operatorTable: .standardOperators,
+      assumingFileURL: nil,
+      selection: Selection(offsetRanges: [1..<source.utf8.count]),
+      to: &output
+    )
+
+    XCTAssertEqual(output, expected)
+  }
+
   private func assertFormatting(
     _ source: String,
     expected: String,

--- a/Tests/SwiftFormatTests/API/SwiftFormatterSelectionTests.swift
+++ b/Tests/SwiftFormatTests/API/SwiftFormatterSelectionTests.swift
@@ -234,8 +234,17 @@ final class SwiftFormatterSelectionTests: XCTestCase {
   }
 
   func testRuleFormattingWithNonZeroOffsetRange() throws {
-    let source = "/// Some String....\n if (a = 0) {             NSLog(\"print: \\(a)\");}"
-    let expected = "/// Some String....\nif a = 0 { NSLog(\"print: \\(a)\") }\n"
+    let source = """
+      /// Some String....
+       if (a = 0) {             NSLog("print: \\(a)");}
+
+      """
+
+    let expected = """
+      /// Some String....
+      if a = 0 { NSLog("print: \\(a)") }
+
+      """
 
     var configuration = Configuration.forTesting
     configuration.rules["NoParensAroundConditions"] = true
@@ -312,13 +321,13 @@ final class SwiftFormatterSelectionTests: XCTestCase {
 
   func testContentSelectionIgnoresTrivia() throws {
     let source = """
-      /// documentation
+      /* documentation */
           func foo() {}
 
       """
 
     let expected = """
-      /// documentation
+      /* documentation */
       func foo() {}
 
       """

--- a/Tests/SwiftFormatTests/API/SwiftFormatterSelectionTests.swift
+++ b/Tests/SwiftFormatTests/API/SwiftFormatterSelectionTests.swift
@@ -10,12 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftFormat
 import SwiftOperators
 import SwiftParser
 import SwiftSyntax
 import XCTest
 import _SwiftFormatTestSupport
+
+@_spi(Rules) @testable import SwiftFormat
 
 final class SwiftFormatterSelectionTests: XCTestCase {
   func testSingleLineFormatting() throws {
@@ -257,6 +258,74 @@ final class SwiftFormatterSelectionTests: XCTestCase {
     XCTAssertEqual(output, expected)
   }
 
+  func testTriviaSelectionScopesWithRealRules() throws {
+    let source = """
+      /// leading comment
+      func foo() {} // trailing comment
+      """
+    let tree = Parser.parse(source: source)
+    let funcNode = Syntax(tree.statements.first!.item)
+
+    var config = Configuration.forTesting
+    config.rules["UseTripleSlashForDocumentationComments"] = true
+    config.rules["NoBlockComments"] = true
+
+    let ruleNameCache = [
+      ObjectIdentifier(UseTripleSlashForDocumentationComments.self): "UseTripleSlashForDocumentationComments",
+      ObjectIdentifier(NoBlockComments.self): "NoBlockComments",
+    ]
+
+    let leadingContext = Context(
+      configuration: config,
+      operatorTable: .standardOperators,
+      findingConsumer: nil,
+      fileURL: URL(fileURLWithPath: "/test.swift"),
+      selection: Selection(lineRanges: [1...1]),
+      sourceFileSyntax: tree,
+      ruleNameCache: ruleNameCache
+    )
+
+    XCTAssertTrue(leadingContext.shouldFormat(UseTripleSlashForDocumentationComments.self, node: funcNode))
+    XCTAssertTrue(leadingContext.shouldFormat(NoBlockComments.self, node: funcNode))
+
+    guard let commentRange = source.range(of: "// trailing comment") else {
+      XCTFail("Could not find comment in source")
+      return
+    }
+
+    let startOffset = source.distance(from: source.startIndex, to: commentRange.lowerBound)
+    let endOffset = source.distance(from: source.startIndex, to: commentRange.upperBound)
+
+    let trailingContext = Context(
+      configuration: config,
+      operatorTable: .standardOperators,
+      findingConsumer: nil,
+      fileURL: URL(fileURLWithPath: "/test.swift"),
+      selection: Selection(offsetRanges: [startOffset..<endOffset]),
+      sourceFileSyntax: tree,
+      ruleNameCache: ruleNameCache
+    )
+
+    XCTAssertTrue(trailingContext.shouldFormat(NoBlockComments.self, node: funcNode))
+    XCTAssertFalse(trailingContext.shouldFormat(UseTripleSlashForDocumentationComments.self, node: funcNode))
+  }
+
+  func testContentSelectionIgnoresTrivia() throws {
+    let source = """
+      /// documentation
+          func foo() {}
+
+      """
+
+    let expected = """
+      /// documentation
+      func foo() {}
+
+      """
+
+    try assertFormatting(source, expected: expected, selection: Selection(lineRanges: [2...2]))
+  }
+
   private func assertFormatting(
     _ source: String,
     expected: String,
@@ -270,7 +339,7 @@ final class SwiftFormatterSelectionTests: XCTestCase {
     let formatter = SwiftFormatter(configuration: configuration)
     var output = ""
     let tree = Parser.parse(source: source)
-    let foldedTree = try! OperatorTable.standardOperators.foldAll(tree).as(SourceFileSyntax.self)!
+    let foldedTree = try OperatorTable.standardOperators.foldAll(tree).as(SourceFileSyntax.self)!
     try formatter.format(
       syntax: foldedTree,
       source: source,


### PR DESCRIPTION
Fixes #1114 

Rule-based formatting was skipped when a selection started inside a node's leading trivia. Use positionAfterSkippingLeadingTrivia when checking whether a rule should be applied. Adds a regression test covering formatting with a non-zero offset range.