### PR TITLE
Allow intentional line breaks after `case` in `OneCasePerLine`.

### DIFF
--- a/Sources/SwiftFormat/Rules/OneCasePerLine.swift
+++ b/Sources/SwiftFormat/Rules/OneCasePerLine.swift
@@ -98,6 +98,10 @@ public final class OneCasePerLine: SyntaxFormatRule {
           caseDecl.leadingTrivia =
             caseDecl.leadingTrivia + hoistedComments + Trivia.newlines(1)
         }
+        // Ensure there is a space between `case` and the first element.
+        if caseDecl.caseKeyword.trailingTrivia.isEmpty {
+          caseDecl.caseKeyword.trailingTrivia = .spaces(1)
+        }
       }
       caseDecl.elements = EnumCaseElementListSyntax(elements)
 
@@ -120,6 +124,16 @@ public final class OneCasePerLine: SyntaxFormatRule {
       // If it's not a case declaration, or it's a case declaration with only one element, leave it
       // alone.
       guard let caseDecl = member.decl.as(EnumCaseDeclSyntax.self), caseDecl.elements.count > 1 else {
+        newMembers.append(member)
+        continue
+      }
+
+      // If none of the elements of a particular `case` have associated values or raw values, we
+      // don't need to split them (and shouldn't modify their trivia, either).
+      let hasAssociatedOrRawValue = caseDecl.elements.contains {
+        $0.parameterClause != nil || $0.rawValue != nil
+      }
+      guard hasAssociatedOrRawValue else {
         newMembers.append(member)
         continue
       }

--- a/Tests/SwiftFormatTests/Rules/OneCasePerLineTests.swift
+++ b/Tests/SwiftFormatTests/Rules/OneCasePerLineTests.swift
@@ -234,4 +234,39 @@ final class OneCasePerLineTests: LintOrFormatRuleTestCase {
       ]
     )
   }
+
+  func testNoAssociatedOrRawValuesAndContinuationLineIsUnchanged() {
+    assertFormatting(
+      OneCasePerLine.self,
+      input: """
+        public enum TestEnum {
+          case
+            // foo
+            1️⃣withPayload(Int),
+            // bar
+            2️⃣withPayload2(String)
+          case
+            a,
+            b,
+            c
+        }
+        """,
+      expected: """
+        public enum TestEnum {
+          // foo
+        case withPayload(Int)
+        // bar
+        case withPayload2(String)
+          case
+            a,
+            b,
+            c
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "move 'withPayload' to its own 'case' declaration"),
+        FindingSpec("2️⃣", message: "move 'withPayload2' to its own 'case' declaration"),
+      ]
+    )
+  }
 }


### PR DESCRIPTION
https://github.com/swiftlang/swift-format/pull/1208 added more graceful handling when comments were moved around on `case` elememnts that were promoted to their own `case` lines, but it inadvertently degraded formatting in cases like the following:

```swift
case
  first,
  second,
  third
```

which would become

```swift
case first,
  second,
  third
```

This change fixes that (it ensures that we don't touch case lines where none of the elements have associated/raw values at all, even the trivia).