### PR TITLE
Fix crash when a switch case's last statement is formatter-ignored

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -845,7 +845,15 @@ private final class TokenStreamCreator: SyntaxVisitor {
     // same effect. If instead the opening and closing tokens were omitted completely in the absence
     // of statements, comments within the empty case would be incorrectly indented to the same level
     // as the case label.
-    if node.label.lastToken(viewMode: .sourceAccurate) != node.lastToken(viewMode: .sourceAccurate) {
+    //
+    // When the last statement is formatter-ignored, its tokens are emitted verbatim and `node`'s
+    // last token is never visited, so an `after` token on it would be dropped and leave the `.open`
+    // above unclosed. Attach the closing tokens before the next token in that case as well.
+    let lastStatementIsIgnored =
+      node.statements.last.map { shouldFormatterIgnore(node: Syntax($0)) } ?? false
+    if node.label.lastToken(viewMode: .sourceAccurate) != node.lastToken(viewMode: .sourceAccurate)
+      && !lastStatementIsIgnored
+    {
       after(node.lastToken(viewMode: .sourceAccurate), tokens: afterLastTokenTokens)
     } else {
       before(node.nextToken(viewMode: .sourceAccurate), tokens: afterLastTokenTokens)

--- a/Tests/SwiftFormatTests/PrettyPrint/IgnoreNodeTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/IgnoreNodeTests.swift
@@ -111,6 +111,58 @@ final class IgnoreNodeTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
   }
 
+  func testIgnoreStatementInSwitchCase() {
+    let input =
+      """
+      switch foo {
+      case .bar:
+        // swift-format-ignore
+        baz()
+      case .quux:
+        baz()
+      }
+      """
+
+    let expected =
+      """
+      switch foo {
+      case .bar:
+        // swift-format-ignore
+        baz()
+      case .quux:
+        baz()
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+  }
+
+  func testIgnoreLastStatementInSwitchCase() {
+    let input =
+      """
+      switch foo {
+      case .bar:
+        baz()
+        // swift-format-ignore
+        quux()
+      }
+      """
+
+    let expected =
+      """
+      switch foo {
+      case .bar:
+        baz()
+        // swift-format-ignore
+        quux()
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+  }
+
   func testIgnoreMemberDeclListItems() {
     let input =
       """


### PR DESCRIPTION
## Summary

Fixes #309.

Linting or formatting a file with `// swift-format-ignore` on the last statement of a `switch` case crashes:

```swift
switch val {
case .foo:
  // swift-format-ignore
  print("Foo")
case .bar:
  print("Bar")
}
```

```
SwiftFormat/PrettyPrint.swift: Assertion failed: Too many unresolved delimiter token lengths.
```

## Root cause

`visit(SwitchCaseSyntax)` emits an `.open` group after the case label and attaches the matching `.close` as an `after` token on the case's **last token**. When the last statement is formatter-ignored it is emitted verbatim and its tokens are never visited (the node is skipped), so the `after` close tokens are dropped and the group is never closed.

This is the same hazard that `visit(CodeBlockItemListSyntax)` already documents and avoids ("the tokens after `item.lastToken` would be ignored and leave unclosed open tokens").

## Fix

When the case's last statement is formatter-ignored, attach the closing tokens before the next token (the next case or the closing brace) instead of after the case's last token — mirroring the existing handling for empty cases.

## Tests

Added `testIgnoreStatementInSwitchCase` and `testIgnoreLastStatementInSwitchCase` to `IgnoreNodeTests`. Both crash without the fix and pass with it. Full test suite passes (934 tests, 0 failures).
