### PR TITLE
Fix ?. wrapping misread as a ternary

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -4057,6 +4057,12 @@ private final class TokenStreamCreator: SyntaxVisitor {
     {
       parenthesizedExpr = nextExpr
     }
+    while let parent = parenthesizedExpr?.parent,
+      parent.is(OptionalChainingExprSyntax.self) || parent.is(ForceUnwrapExprSyntax.self),
+      parent.firstToken(viewMode: .sourceAccurate) == parenthesizedExpr?.firstToken(viewMode: .sourceAccurate)
+    {
+      parenthesizedExpr = parent
+    }
     return parenthesizedExpr
   }
 

--- a/Tests/SwiftFormatTests/PrettyPrint/MemberAccessExprTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/MemberAccessExprTests.swift
@@ -544,4 +544,23 @@ final class MemberAccessExprTests: PrettyPrintTestCase {
       configuration: configuration
     )
   }
+
+  func testOptionalChainAfterParenthesizedBaseKeepsQuestionMarkAttached() {
+    let input =
+      """
+      if (a ? b : c)?.f {}
+      """
+
+    let expected =
+      """
+      if (a
+        ? b
+        : c)?.f
+      {
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 10)
+  }
 }


### PR DESCRIPTION
Add test for #1226. Fix it.