### PR TITLE
[6.3][Workflow] Accept warnings in Publish Release

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -121,8 +121,8 @@ jobs:
         # fatal: empty ident name (for <>) not allowed
         cmd /c "type $env:TEMP\patch.diff | git am || (exit /b 1)"
       # We require that releases of swift-format build without warnings
-      linux_build_command: swift test -Xswiftc -warnings-as-errors ${{ matrix.release && '-c release' || '' }}
-      windows_build_command: Invoke-Program swift test -Xswiftc -warnings-as-errors ${{ matrix.release && '-c release' || '' }}
+      linux_build_command: swift test ${{ matrix.release && '-c release' || '' }}
+      windows_build_command: Invoke-Program swift test ${{ matrix.release && '-c release' || '' }}
   create_tag:
     name: Create Tag
     runs-on: ubuntu-latest


### PR DESCRIPTION
Recent SwiftPM (nightly-toolchain) adds `-suppress-warnings` for remote-packages, but that conflict with `-warnings-as-errors`:
```
error: conflicting options '-warnings-as-errors' and '-suppress-warnings'
```
That issue is being fixed in https://github.com/swiftlang/swift-package-manager/pull/10196 but until that, this PR workarounds that.