### PR TITLE
Ignore backticks when sorting imports.

### DIFF
--- a/Sources/SwiftFormat/Rules/OrderedImports.swift
+++ b/Sources/SwiftFormat/Rules/OrderedImports.swift
@@ -332,7 +332,9 @@ public final class OrderedImports: SyntaxFormatRule {
           // them. Leave this duplicate import.
         }
         if let previousImport = previousImport,
-          line.importName.lexicographicallyPrecedes(previousImport.importName) && !diagnosed
+          let currentName = line.parsedImportPath,
+          let previousName = previousImport.parsedImportPath,
+          currentName < previousName && !diagnosed
             // Only warn to sort imports that shouldn't be removed.
             && visitedImports[fullyQualifiedImport] == nil
         {
@@ -351,7 +353,10 @@ public final class OrderedImports: SyntaxFormatRule {
       }
     }
 
-    linesWithLeadingComments.sort { $0.0.importName.lexicographicallyPrecedes($1.0.importName) }
+    linesWithLeadingComments.sort {
+      guard let lhs = $0.0.parsedImportPath, let rhs = $1.0.parsedImportPath else { return false }
+      return lhs < rhs
+    }
 
     // Unpack the tuples back into a list of Lines.
     var output: [Line] = []
@@ -629,14 +634,14 @@ private class Line {
   }
 
   /// Returns the path that is imported by this line's import statement if it's an import statement.
-  /// When this line isn't an import statement, returns an empty string.
-  var importName: String {
+  /// When this line isn't an import statement, returns nil.
+  var parsedImportPath: ParsedImportPath? {
     guard let syntaxNode = syntaxNode, case .importCodeBlock(let importCodeBlock, _) = syntaxNode,
       let importDecl = importCodeBlock.item.as(ImportDeclSyntax.self)
     else {
-      return ""
+      return nil
     }
-    return importDecl.path.description.trimmingCharacters(in: .whitespacesAndNewlines)
+    return ParsedImportPath(importDecl.path)
   }
 
   /// Returns the first `TokenSyntax` in the code block(s) from this Line, or nil when this Line
@@ -699,7 +704,9 @@ extension Line: CustomStringConvertible {
       case .nonImportCodeBlocks(let codeBlocks):
         description += "\(codeBlocks.count) code blocks "
       case .importCodeBlock(_, let sortable):
-        description += "\(sortable ? "sorted" : "unsorted") import \(importName) "
+        if let parsedImportPath {
+          description += "\(sortable ? "sorted" : "unsorted") import \(parsedImportPath) "
+        }
       case .ifConfigCodeBlock:
         description += "if config code block "
       }
@@ -713,6 +720,39 @@ extension Line: CustomStringConvertible {
     }
 
     return description.trimmingCharacters(in: .whitespaces)
+  }
+}
+
+/// A parsed representation of an import path that allows for sorting.
+///
+/// This type preserves the original spelling of the import but normalizes the
+/// components by removing backticks. This ensures that we don't treat
+/// `import Foo` differently from `` import `Foo` `` with regard to sort order.
+private struct ParsedImportPath: Comparable, CustomStringConvertible {
+  let originalText: String
+  let components: [Substring]
+
+  init(_ path: ImportPathComponentListSyntax) {
+    self.originalText = path.description.trimmingCharacters(in: .whitespacesAndNewlines)
+    self.components = path.map { component in
+      var text = component.name.text[...]
+      if text.hasPrefix("`") && text.hasSuffix("`") && text.count > 2 {
+        text = text.dropFirst().dropLast()
+      }
+      return text
+    }
+  }
+
+  static func < (lhs: ParsedImportPath, rhs: ParsedImportPath) -> Bool {
+    return lhs.components.lexicographicallyPrecedes(rhs.components)
+  }
+
+  static func == (lhs: ParsedImportPath, rhs: ParsedImportPath) -> Bool {
+    return lhs.components == rhs.components
+  }
+
+  var description: String {
+    return originalText
   }
 }
 

--- a/Tests/SwiftFormatTests/Rules/OrderedImportsTests.swift
+++ b/Tests/SwiftFormatTests/Rules/OrderedImportsTests.swift
@@ -1202,4 +1202,93 @@ final class OrderedImportsTests: LintOrFormatRuleTestCase {
       configuration: configuration
     )
   }
+
+  func testRawIdentifierSorting() {
+    assertFormatting(
+      OrderedImports.self,
+      input: """
+        import Zebra
+        1️⃣import `Beta`
+        import Alpha
+        """,
+      expected: """
+        import Alpha
+        import `Beta`
+        import Zebra
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "sort import statements lexicographically")
+      ]
+    )
+
+    assertFormatting(
+      OrderedImports.self,
+      input: """
+        import Foo.Baz
+        1️⃣import `Foo`.`Bar`
+        """,
+      expected: """
+        import `Foo`.`Bar`
+        import Foo.Baz
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "sort import statements lexicographically")
+      ]
+    )
+
+    assertFormatting(
+      OrderedImports.self,
+      input: """
+        import Alpha
+        import `Beta`
+        import Gamma
+        """,
+      expected: """
+        import Alpha
+        import `Beta`
+        import Gamma
+        """,
+      findings: []
+    )
+
+    assertFormatting(
+      OrderedImports.self,
+      input: """
+        import class Foundation.Date
+        1️⃣import class `Foundation`.Data
+        2️⃣import Foundation
+        """,
+      expected: """
+        import Foundation
+
+        import class `Foundation`.Data
+        import class Foundation.Date
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "sort import statements lexicographically"),
+        FindingSpec("2️⃣", message: "place regular imports before declaration imports"),
+      ]
+    )
+
+    assertFormatting(
+      OrderedImports.self,
+      input: """
+        import Zebra
+        1️⃣import `Beta`
+        @testable import Zebra
+        2️⃣@testable import `Alpha`
+        """,
+      expected: """
+        import `Beta`
+        import Zebra
+
+        @testable import `Alpha`
+        @testable import Zebra
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "sort import statements lexicographically"),
+        FindingSpec("2️⃣", message: "sort import statements lexicographically"),
+      ]
+    )
+  }
 }


### PR DESCRIPTION
If raw identifiers are used for module names, we ignore the backticks so that the sort order is based on the content of the name and not whether or not it's been escaped. This prevents all raw identifiers from being grouped together simply on the basis that they're raw identifiers.