### PR TITLE
Add `git-swift-format` to the `Scripts` directory.

### DIFF
--- a/.licenseignore
+++ b/.licenseignore
@@ -9,3 +9,4 @@
 **/*.modulemap
 CODEOWNERS
 Package.swift
+Scripts/git-swift-format

--- a/Scripts/git-swift-format
+++ b/Scripts/git-swift-format
@@ -1,0 +1,746 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0 with Runtime Library Exception
+##
+## See https://swift.org/LICENSE.txt for license information
+## See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+##
+##===----------------------------------------------------------------------===##
+
+r"""
+swift-format git integration
+============================
+
+This file provides a swift-format integration for git. Put it somewhere in your
+path and ensure that it is executable. Then, "git swift-format" will invoke
+swift-format on the changes in current files or a specific commit.
+
+For further details, run:
+git swift-format -h
+
+Requires Python version >=3.8
+"""
+
+from __future__ import absolute_import, division, print_function
+import argparse
+import collections
+import contextlib
+import errno
+import os
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+
+usage = "git swift-format [OPTIONS] [<commit>] [<commit>|--staged] [--] [<file>...]"
+
+desc = """
+If zero or one commits are given, run swift-format on all lines that differ
+between the working directory and <commit>, which defaults to HEAD. Changes are
+only applied to the working directory, or in the stage/index.
+
+Examples:
+  To format staged changes, i.e. everything that's been `git add`ed:
+    git swift-format
+
+  To also format everything touched in the most recent commit:
+    git swift-format HEAD~1
+
+  If you're on a branch off main, to format everything touched on your branch:
+    git swift-format main
+
+If two commits are given (requires --diff), run swift-format on all lines in the
+second <commit> that differ from the first <commit>.
+
+The following git-config settings set the default of the corresponding option:
+  swiftFormat.binary
+  swiftFormat.commit
+  swiftFormat.configuration
+  swiftFormat.ignoreUnparsableFiles
+
+When running inside a pre-commit CI environment (i.e., no commits are given
+on the command line and the PRE_COMMIT_FROM_REF and PRE_COMMIT_TO_REF
+environment variables are set), the diff range is taken from those variables
+and --diff is implied.
+"""
+
+# Name of the temporary index file in which to save the output of swift-format.
+# This file is created within the .git directory.
+temp_index_basename = "swift-format-index"
+
+
+Range = collections.namedtuple("Range", "start, count")
+
+
+def main():
+    config = load_git_config()
+
+    # In order to keep '--' yet allow options after positionals, we need to
+    # check for '--' ourselves. (Setting nargs='*' throws away the '--', while
+    # nargs=argparse.REMAINDER disallows options after positionals.)
+    argv = sys.argv[1:]
+    try:
+        idx = argv.index("--")
+    except ValueError:
+        dash_dash = []
+    else:
+        dash_dash = argv[idx:]
+        argv = argv[:idx]
+
+    p = argparse.ArgumentParser(
+        usage=usage,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=desc,
+    )
+    p.add_argument(
+        "--binary",
+        default=config.get("swiftformat.binary", "swift-format"),
+        help="path to swift-format",
+    )
+    p.add_argument(
+        "--commit",
+        default=config.get("swiftformat.commit", "HEAD"),
+        help="default commit to use if none is specified",
+    )
+    p.add_argument(
+        "--configuration",
+        default=config.get("swiftformat.configuration", None),
+        help="path to a JSON configuration file or JSON string passed to swift-format",
+    )
+    p.add_argument(
+        "--diff",
+        action="store_true",
+        help="print a diff instead of applying the changes",
+    )
+    p.add_argument(
+        "--diffstat",
+        action="store_true",
+        help="print a diffstat instead of applying the changes",
+    )
+    p.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="allow changes to unstaged files",
+    )
+    p.add_argument(
+        "--ignore-unparsable-files",
+        action="store_true",
+        default=config.get("swiftformat.ignoreunparsablefiles", "false").lower()
+        in ("true", "1", "yes"),
+        help="ignore unparsable files instead of raising an error",
+    )
+    p.add_argument(
+        "-p", "--patch", action="store_true", help="select hunks interactively"
+    )
+    p.add_argument(
+        "-q",
+        "--quiet",
+        action="count",
+        default=0,
+        help="print less information",
+    )
+    p.add_argument(
+        "--staged",
+        "--cached",
+        action="store_true",
+        help="format lines in the stage instead of the working dir",
+    )
+    p.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="print extra information",
+    )
+    # We gather all the remaining positional arguments into 'args' since we need
+    # to use some heuristics to determine whether or not <commit> was present.
+    p.add_argument(
+        "args",
+        nargs="*",
+        metavar="<commit>",
+        help="revision from which to compute the diff",
+    )
+    opts = p.parse_args(argv)
+
+    # When no commits are given explicitly and the pre-commit CI framework's
+    # environment variables are set, use them to define the diff range.
+    if not opts.args and not dash_dash:
+        from_ref = os.environ.get("PRE_COMMIT_FROM_REF")
+        to_ref = os.environ.get("PRE_COMMIT_TO_REF")
+        if from_ref and to_ref:
+            opts.args = [from_ref, to_ref]
+            if not opts.diff and not opts.diffstat:
+                opts.diff = True
+
+    opts.verbose -= opts.quiet
+    del opts.quiet
+
+    commits, files = interpret_args(opts.args, dash_dash, opts.commit)
+    if len(commits) > 2:
+        die("at most two commits allowed; %d given" % len(commits))
+    if len(commits) == 2:
+        if opts.staged:
+            die("--staged is not allowed when two commits are given")
+        if not opts.diff and not opts.diffstat:
+            die("--diff or --diffstat is required when two commits are given")
+
+    changed_lines = compute_diff_and_extract_lines(commits, files, opts.staged)
+    if opts.verbose >= 1:
+        ignored_files = set(changed_lines)
+    filter_swift_files(changed_lines)
+    # The computed diff outputs absolute paths or repository relative paths,
+    # so we must cd before accessing those files.
+    cd_to_toplevel()
+    filter_symlinks(changed_lines)
+    if opts.verbose >= 1:
+        ignored_files.difference_update(changed_lines)
+        if ignored_files:
+            print(
+                "Ignoring the following files (not a .swift file or symlink):"
+            )
+            for filename in ignored_files:
+                print("    %s" % filename)
+        if changed_lines:
+            print("Running swift-format on the following files:")
+            for filename in changed_lines:
+                print("    %s" % filename)
+
+    if not changed_lines:
+        if opts.verbose >= 0:
+            print("no modified files to format")
+        return 0
+
+    if len(commits) > 1:
+        old_tree = create_tree_from_revision(changed_lines, commits[1])
+        revision = commits[1]
+    elif opts.staged:
+        old_tree = create_tree_from_index(changed_lines)
+        revision = ""
+    else:
+        old_tree = create_tree_from_workdir(changed_lines)
+        revision = None
+
+    new_tree = run_swift_format_and_save_to_tree(
+        changed_lines,
+        revision,
+        binary=opts.binary,
+        configuration=opts.configuration,
+        ignore_unparsable_files=opts.ignore_unparsable_files,
+    )
+    if opts.verbose >= 1:
+        print("old tree: %s" % old_tree)
+        print("new tree: %s" % new_tree)
+
+    if old_tree == new_tree:
+        if opts.verbose >= 0:
+            print("swift-format did not modify any files")
+        return 0
+
+    if opts.diff:
+        return print_diff(old_tree, new_tree)
+    if opts.diffstat:
+        return print_diffstat(old_tree, new_tree)
+
+    changed_files = apply_changes(
+        old_tree, new_tree, force=opts.force, patch_mode=opts.patch
+    )
+    if (opts.verbose >= 0 and not opts.patch) or opts.verbose >= 1:
+        print("changed files:")
+        for filename in changed_files:
+            print("    %s" % filename)
+
+    return 1
+
+
+def load_git_config(non_string_options=None):
+    """Return the git configuration as a dictionary."""
+    if non_string_options is None:
+        non_string_options = {}
+    out = {}
+    for entry in run("git", "config", "--list", "--null").split("\0"):
+        if entry:
+            if "\n" in entry:
+                name, value = entry.split("\n", 1)
+            else:
+                name = entry
+                value = "true"
+            if name in non_string_options:
+                value = run("git", "config", non_string_options[name], name)
+            out[name.lower()] = value
+    return out
+
+
+def interpret_args(args, dash_dash, default_commit):
+    """Interpret `args` as "[commits] [--] [files]" and return (commits, files)."""
+    if dash_dash:
+        if len(args) == 0:
+            commits = [default_commit]
+        else:
+            commits = args
+        for commit in commits:
+            object_type = get_object_type(commit)
+            if object_type not in ("commit", "tag"):
+                if object_type is None:
+                    die("'%s' is not a commit" % commit)
+                else:
+                    die(
+                        "'%s' is a %s, but a commit was expected"
+                        % (commit, object_type)
+                    )
+        files = dash_dash[1:]
+    elif args:
+        commits = []
+        while args:
+            if not disambiguate_revision(args[0]):
+                break
+            commits.append(args.pop(0))
+        if not commits:
+            commits = [default_commit]
+        files = args
+    else:
+        commits = [default_commit]
+        files = []
+    return commits, files
+
+
+def disambiguate_revision(value):
+    """Returns True if `value` is a revision, False if it is a file, or dies."""
+    run("git", "rev-parse", value, verbose=False)
+    object_type = get_object_type(value)
+    if object_type is None:
+        return False
+    if object_type in ("commit", "tag"):
+        return True
+    die("`%s` is a %s, but a commit or filename was expected" % (value, object_type))
+
+
+def get_object_type(value):
+    """Returns a string description of an object's type, or None if it is not
+    a valid git object."""
+    cmd = ["git", "cat-file", "-t", value]
+    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, _ = p.communicate()
+    if p.returncode != 0:
+        return None
+    return convert_string(stdout.strip())
+
+
+def compute_diff_and_extract_lines(commits, files, staged):
+    """Calls compute_diff() followed by extract_lines()."""
+    diff_process = compute_diff(commits, files, staged)
+    changed_lines = extract_lines(diff_process.stdout)
+    diff_process.stdout.close()
+    diff_process.wait()
+    if diff_process.returncode != 0:
+        sys.exit(2)
+    return changed_lines
+
+
+def compute_diff(commits, files, staged):
+    """Return a subprocess object producing the diff from `commits`."""
+    git_tool = "diff-index"
+    extra_args = []
+    if len(commits) == 2:
+        git_tool = "diff-tree"
+    elif staged:
+        extra_args += ["--cached"]
+
+    cmd = ["git", git_tool, "-p", "-U0"] + extra_args + commits + ["--"]
+    cmd.extend(files)
+    p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    p.stdin.close()
+    return p
+
+
+def extract_lines(patch_file):
+    """Extract the changed lines in `patch_file`."""
+    matches = {}
+    for line in patch_file:
+        line = convert_string(line)
+        match = re.search(r"^\+\+\+\ [^/]+/(.*)", line)
+        if match:
+            filename = match.group(1).rstrip("\r\n\t")
+        match = re.search(r"^@@ -[0-9,]+ \+(\d+)(,(\d+))?", line)
+        if match:
+            start_line = int(match.group(1))
+            line_count = 1
+            if match.group(3):
+                line_count = int(match.group(3))
+            if line_count == 0:
+                line_count = 1
+            if start_line == 0:
+                continue
+            matches.setdefault(filename, []).append(Range(start_line, line_count))
+    return matches
+
+
+def filter_swift_files(dictionary):
+    """Delete every key in `dictionary` that does not have a .swift extension."""
+    for filename in list(dictionary.keys()):
+        if not filename.lower().endswith(".swift"):
+            del dictionary[filename]
+
+
+def filter_symlinks(dictionary):
+    """Delete every key in `dictionary` that is a symlink."""
+    for filename in list(dictionary.keys()):
+        if os.path.islink(filename):
+            del dictionary[filename]
+
+
+def cd_to_toplevel():
+    """Change to the top level of the git repository."""
+    toplevel = run("git", "rev-parse", "--show-toplevel")
+    os.chdir(toplevel)
+
+
+def create_tree_from_revision(filenames, revision):
+    """Create a new git tree with the given files from a specific revision."""
+    env = os.environ.copy()
+
+    def index_contents_generator():
+        for filename in filenames:
+            git_ls_tree_cmd = [
+                "git",
+                "ls-tree",
+                f"{revision}:{os.path.dirname(filename)}",
+                os.path.basename(filename),
+            ]
+            git_ls_tree = subprocess.Popen(
+                git_ls_tree_cmd,
+                env=env,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+            )
+            stdout = git_ls_tree.communicate()[0]
+            if git_ls_tree.returncode == 0 and stdout:
+                parts = convert_string(stdout.strip()).split()
+                if len(parts) >= 3:
+                    mode = parts[0]
+                    blob_id = parts[2]
+                    yield f"{mode} {blob_id}\t{filename}"
+
+    return create_tree(index_contents_generator(), "--index-info")
+
+
+def create_tree_from_workdir(filenames):
+    """Create a new git tree with the given files from the working directory."""
+    return create_tree(filenames, "--stdin")
+
+
+def create_tree_from_index(filenames):
+    env = os.environ.copy()
+
+    def index_contents_generator():
+        for filename in filenames:
+            git_ls_files_cmd = [
+                "git",
+                "ls-files",
+                "--stage",
+                "-z",
+                "--",
+                filename,
+            ]
+            git_ls_files = subprocess.Popen(
+                git_ls_files_cmd,
+                env=env,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+            )
+            stdout = git_ls_files.communicate()[0]
+            yield convert_string(stdout.split(b"\0")[0])
+
+    return create_tree(index_contents_generator(), "--index-info")
+
+
+def run_swift_format_and_save_to_tree(
+    changed_lines,
+    revision=None,
+    binary="swift-format",
+    configuration=None,
+    ignore_unparsable_files=False,
+):
+    """Run swift-format on each file and save the result to a git tree."""
+    env = os.environ.copy() if revision == "" else None
+
+    def iteritems(container):
+        try:
+            return container.iteritems()
+        except AttributeError:
+            return container.items()
+
+    def index_info_generator():
+        for filename, line_ranges in iteritems(changed_lines):
+            if revision is not None:
+                if len(revision) > 0:
+                    git_metadata_cmd = [
+                        "git",
+                        "ls-tree",
+                        "%s:%s" % (revision, os.path.dirname(filename)),
+                        os.path.basename(filename),
+                    ]
+                else:
+                    git_metadata_cmd = [
+                        "git",
+                        "ls-files",
+                        "--stage",
+                        "--",
+                        filename,
+                    ]
+                git_metadata = subprocess.Popen(
+                    git_metadata_cmd,
+                    env=env,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                )
+                stdout = git_metadata.communicate()[0]
+                mode = oct(int(stdout.split()[0], 8))
+            else:
+                mode = oct(os.stat(filename).st_mode)
+            if mode.startswith("0o"):
+                mode = "0" + mode[2:]
+            blob_id = swift_format_to_blob(
+                filename,
+                line_ranges,
+                revision=revision,
+                binary=binary,
+                configuration=configuration,
+                ignore_unparsable_files=ignore_unparsable_files,
+                env=env,
+            )
+            yield "%s %s\t%s" % (mode, blob_id, filename)
+
+    return create_tree(index_info_generator(), "--index-info")
+
+
+def create_tree(input_lines, mode):
+    """Create a tree object from the given input."""
+    assert mode in ("--stdin", "--index-info")
+    cmd = ["git", "update-index", "--add", "-z", mode]
+    with temporary_index_file():
+        p = subprocess.Popen(cmd, stdin=subprocess.PIPE)
+        for line in input_lines:
+            p.stdin.write(to_bytes("%s\0" % line))
+        p.stdin.close()
+        if p.wait() != 0:
+            die("`%s` failed" % " ".join(cmd))
+        tree_id = run("git", "write-tree")
+        return tree_id
+
+
+def swift_format_to_blob(
+    filename,
+    line_ranges,
+    revision=None,
+    binary="swift-format",
+    configuration=None,
+    ignore_unparsable_files=False,
+    env=None,
+):
+    """Run swift-format on the given file and save the result to a git blob."""
+    swift_format_cmd = shlex.split(binary) + ["format"]
+    if configuration:
+        swift_format_cmd.extend(["--configuration", configuration])
+    if ignore_unparsable_files:
+        swift_format_cmd.append("--ignore-unparsable-files")
+    for start_line, line_count in line_ranges:
+        end_line = start_line + line_count - 1
+        swift_format_cmd.extend(["--lines", f"{start_line}:{end_line}"])
+
+    if revision is not None:
+        swift_format_cmd.extend(["--assume-filename", filename, "-"])
+        git_show_cmd = [
+            "git",
+            "cat-file",
+            "blob",
+            f"{revision}:{filename}",
+        ]
+        git_show = subprocess.Popen(
+            git_show_cmd, env=env, stdin=subprocess.PIPE, stdout=subprocess.PIPE
+        )
+        git_show.stdin.close()
+        swift_format_stdin = git_show.stdout
+    else:
+        swift_format_cmd.append(filename)
+        git_show = None
+        swift_format_stdin = subprocess.PIPE
+
+    try:
+        swift_format = subprocess.Popen(
+            swift_format_cmd, stdin=swift_format_stdin, stdout=subprocess.PIPE
+        )
+        if swift_format_stdin == subprocess.PIPE:
+            swift_format.stdin.close()
+    except OSError as e:
+        if e.errno == errno.ENOENT:
+            die('cannot find executable "%s"' % binary)
+        else:
+            raise
+
+    hash_object_cmd = [
+        "git",
+        "hash-object",
+        "-w",
+        f"--path={filename}",
+        "--stdin",
+    ]
+    hash_object = subprocess.Popen(
+        hash_object_cmd, stdin=swift_format.stdout, stdout=subprocess.PIPE
+    )
+    swift_format.stdout.close()
+    stdout = hash_object.communicate()[0]
+    if hash_object.returncode != 0:
+        die("`%s` failed" % " ".join(hash_object_cmd))
+    if swift_format.wait() != 0:
+        die("`%s` failed" % " ".join(swift_format_cmd))
+    if git_show and git_show.wait() != 0:
+        die("`%s` failed" % " ".join(git_show_cmd))
+    return convert_string(stdout).rstrip("\r\n")
+
+
+@contextlib.contextmanager
+def temporary_index_file(tree=None):
+    """Context manager for setting GIT_INDEX_FILE to a temporary file and
+    deleting the file afterward."""
+    index_path = create_temporary_index(tree)
+    old_index_path = os.environ.get("GIT_INDEX_FILE")
+    os.environ["GIT_INDEX_FILE"] = index_path
+    try:
+        yield
+    finally:
+        if old_index_path is None:
+            del os.environ["GIT_INDEX_FILE"]
+        else:
+            os.environ["GIT_INDEX_FILE"] = old_index_path
+        if os.path.exists(index_path):
+            os.remove(index_path)
+
+
+def create_temporary_index(tree=None):
+    """Create a temporary index file and return the created file's path."""
+    gitdir = run("git", "rev-parse", "--git-dir")
+    fd, path = tempfile.mkstemp(prefix=temp_index_basename + "-", dir=gitdir)
+    os.close(fd)
+    if tree is None:
+        tree = "--empty"
+    run("git", "read-tree", "--index-output=" + path, tree)
+    return path
+
+
+def print_diff(old_tree, new_tree):
+    """Print the diff between the two trees to stdout."""
+    return subprocess.run(
+        ["git", "diff", "--diff-filter=M", "--exit-code", old_tree, new_tree]
+    ).returncode
+
+
+def print_diffstat(old_tree, new_tree):
+    """Print the diffstat between the two trees to stdout."""
+    return subprocess.run(
+        [
+            "git",
+            "diff",
+            "--diff-filter=M",
+            "--exit-code",
+            "--stat",
+            old_tree,
+            new_tree,
+        ]
+    ).returncode
+
+
+def apply_changes(old_tree, new_tree, force=False, patch_mode=False):
+    """Apply the changes in `new_tree` to the working directory."""
+    changed_files = (
+        run(
+            "git",
+            "diff-tree",
+            "--diff-filter=M",
+            "-r",
+            "-z",
+            "--name-only",
+            old_tree,
+            new_tree,
+        )
+        .rstrip("\0")
+        .split("\0")
+    )
+    if not force:
+        unstaged_files = run("git", "diff-files", "--name-status", *changed_files)
+        if unstaged_files:
+            print(
+                "The following files would be modified but have unstaged changes:",
+                file=sys.stderr,
+            )
+            print(unstaged_files, file=sys.stderr)
+            print("Please commit, stage, or stash them first.", file=sys.stderr)
+            sys.exit(2)
+    if patch_mode:
+        with temporary_index_file(old_tree):
+            subprocess.run(["git", "checkout", "--patch", new_tree], check=True)
+    else:
+        with temporary_index_file(new_tree):
+            run("git", "checkout-index", "-f", "--", *changed_files)
+    return changed_files
+
+
+def run(*args, **kwargs):
+    stdin = kwargs.pop("stdin", "")
+    verbose = kwargs.pop("verbose", True)
+    strip = kwargs.pop("strip", True)
+    for name in kwargs:
+        raise TypeError("run() got an unexpected keyword argument '%s'" % name)
+    p = subprocess.Popen(
+        args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdin=subprocess.PIPE,
+    )
+    stdout, stderr = p.communicate(input=to_bytes(stdin))
+
+    stdout = convert_string(stdout)
+    stderr = convert_string(stderr)
+
+    if p.returncode == 0:
+        if stderr:
+            if verbose:
+                print("`%s` printed to stderr:" % " ".join(args), file=sys.stderr)
+            print(stderr.rstrip(), file=sys.stderr)
+        if strip:
+            stdout = stdout.rstrip("\r\n")
+        return stdout
+    if verbose:
+        print("`%s` returned %s" % (" ".join(args), p.returncode), file=sys.stderr)
+    if stderr:
+        print(stderr.rstrip(), file=sys.stderr)
+    sys.exit(2)
+
+
+def die(message):
+    print("error:", message, file=sys.stderr)
+    sys.exit(2)
+
+
+def to_bytes(str_input):
+    if isinstance(str_input, bytes):
+        return str_input
+    return str_input.encode("utf-8")
+
+
+def convert_string(bytes_input):
+    if isinstance(bytes_input, str):
+        return bytes_input
+    try:
+        return bytes_input.decode("utf-8")
+    except (AttributeError, UnicodeError):
+        return str(bytes_input)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
*Consider this experimental for now.*

This is a shamelessly AI-guided adaption of `git-clang-format`, but for swift-format. Logic has been simplified a slight bit:

* There is no way to specify file extensions; it assumes `.swift`.
* Instead of a "style", you can pass a configuration that corresponds to the `--configuration` flag in swift-format. If omitted, swift-format's standard configuration resolution is used (finding the `.swift-format` file relative to the sources being formatted).

Other than that, it's basically the same script as `git-clang-format`. To use it, copy it somewhere into your `PATH` and then run `git swift-format` in a directory that has staged changes (or use one of the flags to specify what should be formatted).