### PR TITLE
CI: cmake-smoke-test workflow

### DIFF
--- a/.github/scripts/cmake-smoke-test.ps1
+++ b/.github/scripts/cmake-smoke-test.ps1
@@ -1,0 +1,41 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0 with Runtime Library Exception
+##
+## See https://swift.org/LICENSE.txt for license information
+## See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+##
+##===----------------------------------------------------------------------===##
+
+# Build using CMake for validation purposes.
+#
+# Any arguments passed to this script are forwarded to CMake as extra
+# configuration arguments (e.g. -DCMAKE_Swift_COMPILER=...).
+
+param (
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$ExtraArgs
+)
+
+$ErrorActionPreference = "Stop"
+
+# The package to build. In CI this is the checkout the build command runs in;
+# locally it defaults to the current directory.
+$SourceDir = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+$BuildDir = if ($env:BUILD_DIR) { $env:BUILD_DIR } else { Join-Path $SourceDir ".cmake-smoke-test" }
+
+New-Item -ItemType Directory -Force -Path $BuildDir | Out-Null
+
+cmake -G Ninja `
+    "-DCMAKE_MAKE_PROGRAM=$((Get-Command ninja).Path)" `
+    "-DCMAKE_BUILD_TYPE=Debug" `
+    "-DCMAKE_Swift_FLAGS=-module-cache-path $BuildDir/module-cache" `
+    @ExtraArgs `
+    -S $SourceDir -B $BuildDir
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+cmake --build $BuildDir
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/scripts/cmake-smoke-test.sh
+++ b/.github/scripts/cmake-smoke-test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0 with Runtime Library Exception
+##
+## See https://swift.org/LICENSE.txt for license information
+## See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+##
+##===----------------------------------------------------------------------===##
+
+# Build using CMake for validation purposes.
+#
+# Any arguments passed to this script are forwarded to CMake as extra
+# configuration arguments (e.g. -DCMAKE_Swift_COMPILER=...).
+
+set -euo pipefail
+
+# The package to build. In CI this is the checkout the build command runs in;
+# locally it defaults to the current directory.
+source_dir="${GITHUB_WORKSPACE:-$PWD}"
+build_dir="${BUILD_DIR:-"$source_dir/.cmake-smoke-test"}"
+
+mkdir -p "$build_dir"
+
+cmake -G Ninja \
+    -DCMAKE_MAKE_PROGRAM="$(command -v ninja)" \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DCMAKE_Swift_FLAGS="-module-cache-path $build_dir/module-cache" \
+    "$@" \
+    -S "$source_dir" -B "$build_dir"
+
+cmake --build "$build_dir"

--- a/.github/scripts/prebuild.ps1
+++ b/.github/scripts/prebuild.ps1
@@ -1,0 +1,29 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2025 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0 with Runtime Library Exception
+##
+## See https://swift.org/LICENSE.txt for license information
+## See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+##
+##===----------------------------------------------------------------------===##
+
+param (
+    [switch]$InstallCMake
+)
+
+# winget isn't easily made available in containers, so use chocolatey
+Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+
+if ($InstallCMake) {
+    choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=System' --apply-install-arguments-to-dependencies
+    choco install -y ninja
+
+    Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
+    refreshenv
+
+    # Let swiftc find the path to link.exe in the CMake smoke test
+    $env:Path += ";$(Split-Path -Path "$(& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" "-latest" -products Microsoft.VisualStudio.Product.BuildTools -find VC\Tools\MSVC\*\bin\HostX64\x64\link.exe)" -Parent)"
+}

--- a/.github/scripts/prebuild.sh
+++ b/.github/scripts/prebuild.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2025 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0 with Runtime Library Exception
+##
+## See https://swift.org/LICENSE.txt for license information
+## See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+##
+##===----------------------------------------------------------------------===##
+
+set -e
+
+if [[ $(uname) == Darwin ]] ; then
+    if [[ "$INSTALL_CMAKE" == "1" ]] ; then
+        mkdir -p "$RUNNER_TOOL_CACHE"
+        if ! command -v cmake >/dev/null 2>&1 ; then
+            curl -fsSLO https://github.com/Kitware/CMake/releases/download/v4.1.2/cmake-4.1.2-macos-universal.tar.gz
+            echo '3be85f5b999e327b1ac7d804cbc9acd767059e9f603c42ec2765f6ab68fbd367 cmake-4.1.2-macos-universal.tar.gz' > cmake-4.1.2-macos-universal.tar.gz.sha256
+            sha256sum -c cmake-4.1.2-macos-universal.tar.gz.sha256
+            tar -xf cmake-4.1.2-macos-universal.tar.gz
+            ln -s "$PWD/cmake-4.1.2-macos-universal/CMake.app/Contents/bin/cmake" "$RUNNER_TOOL_CACHE/cmake"
+        fi
+        if ! command -v ninja >/dev/null 2>&1 ; then
+            curl -fsSLO https://github.com/ninja-build/ninja/releases/download/v1.13.1/ninja-mac.zip
+            echo 'da7797794153629aca5570ef7c813342d0be214ba84632af886856e8f0063dd9 ninja-mac.zip' > ninja-mac.zip.sha256
+            sha256sum -c ninja-mac.zip.sha256
+            unzip ninja-mac.zip
+            rm -f ninja-mac.zip
+            mv ninja "$RUNNER_TOOL_CACHE/ninja"
+        fi
+    fi
+elif command -v apt-get >/dev/null 2>&1 ; then # bookworm, noble, jammy
+    export DEBIAN_FRONTEND=noninteractive
+
+    apt-get update -y
+
+    # Debug symbols
+    apt-get install -y libc6-dbg
+
+    if [[ "$INSTALL_CMAKE" == "1" ]] ; then
+        apt-get install -y cmake ninja-build
+    fi
+elif command -v dnf >/dev/null 2>&1 ; then # rhel-ubi9
+    dnf update -y
+
+    # Debug symbols
+    dnf debuginfo-install -y glibc
+elif command -v yum >/dev/null 2>&1 ; then # amazonlinux2
+    yum update -y
+
+    # Debug symbols
+    yum install -y yum-utils
+    debuginfo-install -y glibc
+fi

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,6 +22,21 @@ jobs:
       enable_cross_pr_testing: true
       linux_exclude_swift_versions: "[{\"swift_version\": \"5.9\"}, {\"swift_version\": \"5.10\"}]"
       windows_exclude_swift_versions: "[{\"swift_version\": \"5.9\"}]"
+  cmake-smoke-test:
+    name: cmake-smoke-test
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    with:
+      linux_os_versions: '["noble"]'
+      linux_pre_build_command: INSTALL_CMAKE=1 ./.github/scripts/prebuild.sh
+      linux_build_command: './.github/scripts/cmake-smoke-test.sh -DCMAKE_C_COMPILER=`which clang` -DCMAKE_CXX_COMPILER=`which clang++` -DCMAKE_Swift_COMPILER=`which swiftc`'
+      linux_swift_versions: '["nightly-main"]'
+      enable_macos_checks: true
+      macos_xcode_versions: '["26.4"]'
+      macos_pre_build_command: INSTALL_CMAKE=1 ./.github/scripts/prebuild.sh
+      macos_build_command: 'export PATH=$PATH:$RUNNER_TOOL_CACHE && ./.github/scripts/cmake-smoke-test.sh -DCMAKE_C_COMPILER=`which clang` -DCMAKE_CXX_COMPILER=`which clang++` -DCMAKE_Swift_COMPILER=`which swiftc`'
+      windows_pre_build_command: 'Invoke-Program .\.github\scripts\prebuild.ps1 -InstallCMake'
+      windows_swift_versions: '["nightly-main"]'
+      windows_build_command: 'Invoke-Program .\.github\scripts\cmake-smoke-test.ps1 "-DCMAKE_C_COMPILER=$((Get-Command clang).Path)" "-DCMAKE_CXX_COMPILER=$((Get-Command clang).Path)" "-DCMAKE_Swift_COMPILER=$((Get-Command swiftc).Path)" "-DCMAKE_STATIC_LIBRARY_PREFIX_Swift=lib" "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL"'
   soundness:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.11


### PR DESCRIPTION
Add a cmake-smoke-test job to the pull request workflow, mirroring the setup in swift-tools-protocols. It builds swift-format with CMake on Linux, macOS, and Windows to validate the CMake build.

The supporting scripts under `.github/scripts/` install `cmake/ninja` (`prebuild.{sh,ps1}`) and drive the CMake configure/build (`cmake-smoke-test.{sh,ps1}`).