### PR TITLE
Actions: Add a build verdict job

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -82,3 +82,28 @@ jobs:
         run: |
           cd "$GITHUB_WORKSPACE/sourcekit-lsp"
           /tmp/check-swift-format.sh
+
+  build-verdict:
+    name: Verdicts
+    runs-on: ubuntu-latest
+    needs:
+      - tests
+      - soundness
+      - compatibility_check
+    if: always()  # Runs even if previous jobs fail so it can evaluate them
+    steps:
+      - name: Install required tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends coreutils jq
+      - name: Check upstream job statuses
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          failed=$(printf '%s' "$NEEDS_JSON" | jq -r 'to_entries | map(select(.value.result != "success")) | .[] | "\(.key): \(.value.result)"')
+          if [ -n "$failed" ]; then
+            echo "The following required jobs did not succeed:"
+            printf '%s\n' "$failed"
+            exit 1
+          fi
+          echo "All required jobs passed successfully!"


### PR DESCRIPTION
Add a build verdict job that will fail when any dependent workflow fails.  The workflow also emits, on the console, all required job names that failed.