### PR TITLE
Update access level

### DIFF
--- a/Sources/SwiftFormat/Core/ImportsAnyTestingLibrary.swift
+++ b/Sources/SwiftFormat/Core/ImportsAnyTestingLibrary.swift
@@ -12,7 +12,8 @@
 
 import SwiftSyntax
 
-package let supportedTestLibraryModuleNames = [
+@_spi(Testing)
+public let supportedTestLibraryModuleNames = [
   "XCTest",
   "Testing",
 ]
@@ -35,7 +36,8 @@ public func setImportsAnyTestLibrary(context: Context, sourceFile: SourceFileSyn
   }
 }
 
-private func statementsImportAnyTestLibrary(_ statements: CodeBlockItemListSyntax) -> Bool {
+@_spi(Testing)
+public func statementsImportAnyTestLibrary(_ statements: CodeBlockItemListSyntax) -> Bool {
   for codeBlockItem in statements {
     switch codeBlockItem.item {
     case .decl(let decl):

--- a/api-breakages.txt
+++ b/api-breakages.txt
@@ -1,6 +1,7 @@
 6.4
 ---
 API breakage: accessor Context.importsXCTest.Set() has been removed
+API breakage: var supportedTestLibraryModuleNames is now with @_spi
 
 6.2
 ---


### PR DESCRIPTION
Uupdate the access level of a function to match the deprecated equivalent.

Closes #1243
Issue: rdar://181871593