### PR TITLE
Add ReflowComments rule

### DIFF
--- a/Documentation/RuleDocumentation.md
+++ b/Documentation/RuleDocumentation.md
@@ -41,6 +41,7 @@ Here's the list of available rules:
 - [OneVariableDeclarationPerLine](#OneVariableDeclarationPerLine)
 - [OnlyOneTrailingClosureArgument](#OnlyOneTrailingClosureArgument)
 - [OrderedImports](#OrderedImports)
+- [ReflowComments](#ReflowComments)
 - [ReplaceForEachWithForLoop](#ReplaceForEachWithForLoop)
 - [ReturnVoidInsteadOfEmptyTuple](#ReturnVoidInsteadOfEmptyTuple)
 - [SwiftTestingNamingConventions](#SwiftTestingNamingConventions)
@@ -428,6 +429,29 @@ Lint: If an import appears anywhere other than the beginning of the file it resi
 Format: Imports will be reordered and (optionally) grouped at the top of the file.
 
 `OrderedImports` rule can format your code automatically.
+
+### ReflowComments
+
+Joins comments that were hard-wrapped across multiple lines back into one line when the combined
+text still fits within the configured line length.
+
+The rule reflows only line comments (`//`) and documentation line comments (`///`); it leaves
+block comments (`/* ... */` and `/** ... */`) untouched. It parses the body of each comment as
+Markdown and joins only lines that belong to the same paragraph. The Markdown parser recognizes
+lists, headings, indented and fenced code blocks, block quotes, and thematic breaks, and the
+rule leaves all of them untouched, along with blank lines between paragraphs. The rule also
+never merges "divider" lines that contain no words (for example `//===----===//`) or lines
+matching `reflowComments.preservedLinePrefixes`. If a comment block contains a `//===...===//`
+file header, the rule leaves the whole block alone. `reflowComments.reflowedCommentKinds`
+controls which kinds of comments the rule reflows.
+
+Lint: If two adjacent comment lines in the same paragraph can be joined without exceeding
+      `lineLength`, a lint error is raised.
+
+Format: Adjacent comment lines in the same paragraph that can be joined without exceeding
+        `lineLength` are merged.
+
+`ReflowComments` rule can format your code automatically.
 
 ### ReplaceForEachWithForLoop
 

--- a/Sources/SwiftFormat/API/Configuration+Default.swift
+++ b/Sources/SwiftFormat/API/Configuration+Default.swift
@@ -45,5 +45,6 @@ extension Configuration {
     self.indentBlankLines = false
     self.orderedImports = OrderedImportsConfiguration()
     self.swiftTestingNamingConventions = SwiftTestingNamingConventionsConfiguration()
+    self.reflowComments = ReflowCommentsConfiguration()
   }
 }

--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -50,6 +50,7 @@ public struct Configuration: Codable, Equatable {
     case indentBlankLines
     case orderedImports
     case swiftTestingNamingConventions
+    case reflowComments
   }
 
   /// A dictionary containing the default enabled/disabled states of rules, keyed by the rules'
@@ -311,6 +312,9 @@ public struct Configuration: Codable, Equatable {
   /// Configuration for the `SwiftTestingNamingConventions` rule.
   public var swiftTestingNamingConventions: SwiftTestingNamingConventionsConfiguration
 
+  /// Configuration for the `ReflowComments` rule.
+  public var reflowComments: ReflowCommentsConfiguration
+
   /// Creates a new `Configuration` by loading it from a configuration file.
   public init(contentsOf url: URL) throws {
     let data = try Data(contentsOf: url)
@@ -467,6 +471,13 @@ public struct Configuration: Codable, Equatable {
       )
       ?? defaults.swiftTestingNamingConventions
 
+    self.reflowComments =
+    try container.decodeIfPresent(
+      ReflowCommentsConfiguration.self,
+      forKey: .reflowComments
+    )
+    ?? defaults.reflowComments
+
     // If the `rules` key is not present at all, default it to the built-in set
     // so that the behavior is the same as if the configuration had been
     // default-initialized. To get an empty rules dictionary, one can explicitly
@@ -509,6 +520,7 @@ public struct Configuration: Codable, Equatable {
     try container.encode(indentBlankLines, forKey: .indentBlankLines)
     try container.encode(orderedImports, forKey: .orderedImports)
     try container.encode(swiftTestingNamingConventions, forKey: .swiftTestingNamingConventions)
+    try container.encode(reflowComments, forKey: .reflowComments)
     try container.encode(rules, forKey: .rules)
   }
 
@@ -573,6 +585,57 @@ public struct NoAssignmentInExpressionsConfiguration: Codable, Equatable {
   ]
 
   public init() {}
+}
+
+/// Configuration for the `ReflowComments` rule.
+public struct ReflowCommentsConfiguration: Codable, Equatable {
+  /// The kinds of comments that the rule is allowed to reflow.
+  public enum CommentKind: String, Codable, CaseIterable, Sendable {
+    /// Regular line comments introduced by `//`.
+    case line
+    /// Documentation line comments introduced by `///`.
+    case docLine
+  }
+
+  /// The kinds of comments that should be reflowed.
+  ///
+  /// Defaults to every kind. Remove a kind to leave those comments untouched; for example, drop
+  /// `.docLine` to reflow only regular `//` line comments.
+  public var reflowedCommentKinds: Set<CommentKind> = Set(CommentKind.allCases)
+
+  /// Line content prefixes that are never merged with an adjacent comment line.
+  ///
+  /// Defaults cover common license header terms and Xcode source annotations.
+  public var preservedLinePrefixes: [String] = [
+    "MARK:", "TODO:", "FIXME:",
+    "Copyright", "Licensed",
+  ]
+
+  private enum CodingKeys: String, CodingKey {
+    case reflowedCommentKinds
+    case preservedLinePrefixes
+  }
+
+  public init() {}
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let defaults = ReflowCommentsConfiguration()
+    self.reflowedCommentKinds =
+      try container.decodeIfPresent(Set<CommentKind>.self, forKey: .reflowedCommentKinds)
+      ?? defaults.reflowedCommentKinds
+    self.preservedLinePrefixes =
+      try container.decodeIfPresent([String].self, forKey: .preservedLinePrefixes)
+      ?? defaults.preservedLinePrefixes
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    // Encode the set in a stable declaration order so that dumped configurations are deterministic.
+    let orderedKinds = CommentKind.allCases.filter(reflowedCommentKinds.contains)
+    try container.encode(orderedKinds, forKey: .reflowedCommentKinds)
+    try container.encode(preservedLinePrefixes, forKey: .preservedLinePrefixes)
+  }
 }
 
 /// Configuration for the `OrderedImports` rule.

--- a/Sources/SwiftFormat/Core/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Core/Pipelines+Generated.swift
@@ -574,10 +574,12 @@ class LintPipeline: SyntaxVisitor {
 
   override func visit(_ node: TokenSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(NoBlockComments.visit, for: node)
+    visitIfEnabled(ReflowComments.visit, for: node)
     return .visitChildren
   }
   override func visitPost(_ node: TokenSyntax) {
     onVisitPost(rule: NoBlockComments.self, for: node)
+    onVisitPost(rule: ReflowComments.self, for: node)
   }
 
   override func visit(_ node: TryExprSyntax) -> SyntaxVisitorContinueKind {
@@ -656,6 +658,7 @@ extension FormatPipeline {
     node = OneCasePerLine(context: context).rewrite(node)
     node = OneVariableDeclarationPerLine(context: context).rewrite(node)
     node = OrderedImports(context: context).rewrite(node)
+    node = ReflowComments(context: context).rewrite(node)
     node = ReturnVoidInsteadOfEmptyTuple(context: context).rewrite(node)
     node = UseEarlyExits(context: context).rewrite(node)
     node = UseExplicitNilCheckInConditions(context: context).rewrite(node)

--- a/Sources/SwiftFormat/Core/RuleNameCache+Generated.swift
+++ b/Sources/SwiftFormat/Core/RuleNameCache+Generated.swift
@@ -46,6 +46,7 @@ public let ruleNameCache: [ObjectIdentifier: String] = [
   ObjectIdentifier(OneVariableDeclarationPerLine.self): "OneVariableDeclarationPerLine",
   ObjectIdentifier(OnlyOneTrailingClosureArgument.self): "OnlyOneTrailingClosureArgument",
   ObjectIdentifier(OrderedImports.self): "OrderedImports",
+  ObjectIdentifier(ReflowComments.self): "ReflowComments",
   ObjectIdentifier(ReplaceForEachWithForLoop.self): "ReplaceForEachWithForLoop",
   ObjectIdentifier(ReturnVoidInsteadOfEmptyTuple.self): "ReturnVoidInsteadOfEmptyTuple",
   ObjectIdentifier(SwiftTestingNamingConventions.self): "SwiftTestingNamingConventions",

--- a/Sources/SwiftFormat/Core/RuleRegistry+Generated.swift
+++ b/Sources/SwiftFormat/Core/RuleRegistry+Generated.swift
@@ -45,6 +45,7 @@
     "OneVariableDeclarationPerLine": true,
     "OnlyOneTrailingClosureArgument": true,
     "OrderedImports": true,
+    "ReflowComments": false,
     "ReplaceForEachWithForLoop": true,
     "ReturnVoidInsteadOfEmptyTuple": true,
     "SwiftTestingNamingConventions": true,

--- a/Sources/SwiftFormat/Core/Trivia+Convenience.swift
+++ b/Sources/SwiftFormat/Core/Trivia+Convenience.swift
@@ -176,4 +176,27 @@ extension Trivia {
 
     return (Trivia(pieces: pieces), trimmmed)
   }
+
+  /// Returns the indentation width, in columns, of the run of space and tab trivia that immediately
+  /// precedes the element at `index`.
+  ///
+  /// Each tab counts as `tabWidth` columns. The run ends at the first non-whitespace piece or at the
+  /// start of the collection.
+  func indentWidth(before index: Int, tabWidth: Int) -> Int {
+    var width = 0
+    var j = index - 1
+    while j >= startIndex {
+      switch self[j] {
+      case .spaces(let n):
+        width += n
+        j -= 1
+      case .tabs(let n):
+        width += n * tabWidth
+        j -= 1
+      default:
+        return width
+      }
+    }
+    return width
+  }
 }

--- a/Sources/SwiftFormat/Rules/ReflowComments.swift
+++ b/Sources/SwiftFormat/Rules/ReflowComments.swift
@@ -1,0 +1,324 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Markdown
+import SwiftSyntax
+
+/// Joins comments that were hard-wrapped across multiple lines back into one line when the combined
+/// text still fits within the configured line length.
+///
+/// The rule reflows only line comments (`//`) and documentation line comments (`///`); it leaves
+/// block comments (`/* ... */` and `/** ... */`) untouched. It parses the body of each comment as
+/// Markdown and joins only lines that belong to the same paragraph. The Markdown parser recognizes
+/// lists, headings, indented and fenced code blocks, block quotes, and thematic breaks, and the
+/// rule leaves all of them untouched, along with blank lines between paragraphs. The rule also
+/// never merges "divider" lines that contain no words (for example `//===----===//`) or lines
+/// matching `reflowComments.preservedLinePrefixes`. If a comment block contains a `//===...===//`
+/// file header, the rule leaves the whole block alone. `reflowComments.reflowedCommentKinds`
+/// controls which kinds of comments the rule reflows.
+///
+/// Lint: If two adjacent comment lines in the same paragraph can be joined without exceeding
+///       `lineLength`, a lint error is raised.
+///
+/// Format: Adjacent comment lines in the same paragraph that can be joined without exceeding
+///         `lineLength` are merged.
+@_spi(Rules)
+public final class ReflowComments: SyntaxFormatRule {
+  public override class var isOptIn: Bool { return true }
+
+  private var kindsToReflow: Set<ReflowCommentsConfiguration.CommentKind> {
+    context.configuration.reflowComments.reflowedCommentKinds
+  }
+
+  private var tabWidth: Int { context.configuration.tabWidth }
+
+  private var lineLength: Int { context.configuration.lineLength }
+
+  public override func visit(_ token: TokenSyntax) -> TokenSyntax {
+    let trivia = token.leadingTrivia
+    guard trivia.contains(where: \.isComment) else { return token }
+    guard !containsFileHeaderSeparator(trivia) else { return token }
+
+    let joinableLineIndices = joinableCommentIndices(in: trivia)
+    guard !joinableLineIndices.isEmpty else { return token }
+
+    var output: [TriviaPiece] = []
+    var changed = false
+    var index = 0
+    while index < trivia.count {
+      guard let kind = trivia[index].commentKind, let configKind = kind.configKind, kindsToReflow.contains(configKind)
+      else {
+        output.append(trivia[index])
+        index += 1
+        continue
+      }
+
+      let indent = trivia.indentWidth(before: index, tabWidth: tabWidth)
+      var content = lineContent(trivia[index], kind: kind)
+      var lastMerged = index
+      while let next = nextLineCommentIndex(in: trivia, after: lastMerged, kind: kind),
+        joinableLineIndices.contains(next)
+      {
+        let body = continuationContent(trivia[next], kind: kind)
+        guard fits(content, body, renderedPrefixWidth: indent + kind.prefixLength + 1) else { break }
+        diagnose(.hardWrappedComment, on: token, anchor: .leadingTrivia(next))
+        content += " " + body
+        lastMerged = next
+        changed = true
+      }
+
+      // Leave an unmerged comment exactly as written; only rebuild when something merged.
+      output.append(lastMerged == index ? trivia[index] : TriviaPiece(commentKind: kind, content: content))
+      index = lastMerged + 1
+    }
+
+    guard changed else { return token }
+    var result = token
+    result.leadingTrivia = Trivia(pieces: output)
+    return result
+  }
+
+  // MARK: - Line comment merging
+
+  /// The index of the next same-kind line comment following `index`, if it is separated from it by
+  /// exactly one newline. Returns nil at a blank line (two or more newlines), any non-comment /
+  /// non-whitespace piece, a comment of a different kind, or the end of the trivia.
+  private func nextLineCommentIndex(in trivia: Trivia, after index: Int, kind: Comment.Kind) -> Int? {
+    var newlineCount = 0
+    var j = index + 1
+    while j < trivia.count {
+      switch trivia[j] {
+      case .newlines(let n), .carriageReturns(let n), .carriageReturnLineFeeds(let n):
+        newlineCount += n
+        j += 1
+      case .spaces, .tabs:
+        j += 1
+      case .lineComment, .docLineComment:
+        guard newlineCount == 1, trivia[j].commentKind == kind else { return nil }
+        return j
+      default:
+        return nil
+      }
+    }
+    return nil
+  }
+
+  /// One line of a run of consecutive same-kind line comments.
+  private struct CommentLine {
+    var triviaIndex: Int
+    /// Only reflowable prose lines are eligible for a paragraph id.
+    var isReflowable: Bool
+    /// The joinable paragraph this line belongs to, or nil if it can never be joined with a neighbor.
+    var paragraphID: Int?
+  }
+
+  /// Walks a parsed comment run to tag each reflowable line with the ID of the paragraph that
+  /// contains it.
+  private struct ParagraphTagger: MarkupWalker {
+    /// The run being tagged; `paragraphID` is filled in as paragraphs are visited.
+    var run: [CommentLine]
+    private var nextParagraphID = 0
+
+    // Skip block quotes entirely; their lines are never joined.
+    mutating func visitBlockQuote(_ blockQuote: BlockQuote) {}
+
+    mutating func visitParagraph(_ paragraph: Paragraph) {
+      defer { nextParagraphID += 1 }
+      guard let range = paragraph.range else { return }
+      let lowerLine = range.lowerBound.line - 1
+      let upperLine = range.upperBound.line - 1
+      guard lowerLine <= upperLine else { return }
+      for line in lowerLine...upperLine where line >= 0 && line < run.count && run[line].isReflowable {
+        run[line].paragraphID = nextParagraphID
+      }
+    }
+  }
+
+  /// Returns the trivia indices of every line comment that may be joined with the line comment
+  /// immediately before it.
+  private func joinableCommentIndices(in trivia: Trivia) -> Set<Int> {
+    var result = Set<Int>()
+    var runStart = 0
+    while runStart < trivia.count {
+      guard let kind = trivia[runStart].commentKind, kind.isLine else {
+        runStart += 1
+        continue
+      }
+
+      let run = commentRun(in: trivia, from: runStart, kind: kind)
+      for k in 1..<run.count where canJoin(run, at: k) {
+        result.insert(run[k].triviaIndex)
+      }
+      runStart = run.last!.triviaIndex + 1
+    }
+    return result
+  }
+
+  /// Gathers a maximal run of same-kind line comments separated by single newlines, starting at
+  /// `start`, and tags each line with the joinable paragraph it belongs to.
+  private func commentRun(in trivia: Trivia, from start: Int, kind: Comment.Kind) -> [CommentLine] {
+    var run: [CommentLine] = []
+    var body = ""
+    var index: Int? = start
+    while let i = index {
+      let content = lineContent(trivia[i], kind: kind)
+      if !run.isEmpty { body += "\n" }
+      body += content
+      run.append(CommentLine(triviaIndex: i, isReflowable: isReflowableProse(content), paragraphID: nil))
+      index = nextLineCommentIndex(in: trivia, after: i, kind: kind)
+    }
+
+    // A join needs two adjacent reflowable-prose lines; without such a pair (including any
+    // single-line run) nothing can merge, so skip the Markdown parse and leave every line unpaired.
+    guard (1..<run.count).contains(where: { run[$0].isReflowable && run[$0 - 1].isReflowable }) else {
+      return run
+    }
+
+    let document = Document(parsing: body, options: [.disableSmartOpts])
+    var tagger = ParagraphTagger(run: run)
+    tagger.visit(document)
+    return tagger.run
+  }
+
+  /// Returns the text of a line comment after removing its delimiter and one following space.
+  private func lineContent(_ piece: TriviaPiece, kind: Comment.Kind) -> String {
+    var content = String(piece.commentText.dropFirst(kind.prefixLength))
+    // Strip only one space for now. Extra leading spaces can be meaningful formatting, for example
+    // an indented code block:
+    //
+    //     foo()
+    //     bar()
+    if content.hasPrefix(" ") { content.removeFirst() }
+    return content
+  }
+
+  /// Like `lineContent`, but also drops any remaining leading whitespace. Use this for a
+  /// continuation line that merges into the preceding line, for example the wrapped remainder of a
+  /// DocC parameter description.
+  private func continuationContent(_ piece: TriviaPiece, kind: Comment.Kind) -> String {
+    return String(lineContent(piece, kind: kind).drop(while: \.isSpaceOrTab))
+  }
+
+  // MARK: - Shared predicates
+
+  /// Whether line `k` of a run may be joined with line `k - 1`: both belong to the same joinable
+  /// paragraph. A nil `paragraphID` marks a line that can never join.
+  private func canJoin(_ run: [CommentLine], at k: Int) -> Bool {
+    guard let id = run[k].paragraphID else { return false }
+    return run[k - 1].paragraphID == id
+  }
+
+  /// Whether a line's content is ordinary prose that may be reflowed, as opposed to a divider or a
+  /// line protected by the configured prefix rules.
+  private func isReflowableProse(_ content: String) -> Bool {
+    guard !content.isEmpty, !isBanner(content), !isDivider(content) else { return false }
+    let preservedPrefixes = context.configuration.reflowComments.preservedLinePrefixes
+    return !preservedPrefixes.contains(where: { content.hasPrefix($0) })
+  }
+
+  /// Whether a line is a divider or a decorated banner that must never be joined.
+  ///
+  /// Covers word-free rules (for example `------`, `=-=-=-`) and titled banners that begin with a
+  /// run of rule characters (for example `===--- Section ---===//`, `=== Notes ===`). 
+  private func isBanner(_ content: String) -> Bool {
+    let ruleChars: Set<Character> = ["=", "-", "*", "_", "#", "~"]
+    let trimmed = content.drop(while: \.isSpaceOrTab)
+    if let first = trimmed.first, ruleChars.contains(first),
+      trimmed.prefix(while: { $0 == first }).count >= 3
+    {
+      return true
+    }
+    return false
+  }
+
+  /// A "divider" line contains no letters or digits, for example `------` or `===----===//`.
+  private func isDivider<S: StringProtocol>(_ content: S) -> Bool {
+    return !content.contains { $0.isLetter || $0.isNumber }
+  }
+
+  /// Whether any comment among the given trivia pieces is a `//===...===//` file-header sentinel.
+  private func containsFileHeaderSeparator(_ pieces: Trivia) -> Bool {
+    for piece in pieces {
+      guard let kind = piece.commentKind, kind.isLine else { continue }
+      // Inspect the raw text so no stripped copy is allocated.
+      var body = piece.commentText.dropFirst(kind.prefixLength)
+      if body.first == " " { body = body.dropFirst() }
+      if body.hasPrefix("===") && isDivider(body) { return true }
+    }
+    return false
+  }
+
+  private func fits(_ content: String, _ addition: String, renderedPrefixWidth: Int) -> Bool {
+    return renderedPrefixWidth + content.count + 1 + addition.count <= lineLength
+  }
+}
+
+extension Comment.Kind {
+  /// The configuration kind that gates this comment kind, or nil for block comments, which this
+  /// rule does not reflow.
+  fileprivate var configKind: ReflowCommentsConfiguration.CommentKind? {
+    switch self {
+    case .line: return .line
+    case .docLine: return .docLine
+    case .block, .docBlock: return nil
+    }
+  }
+
+  fileprivate var isLine: Bool { self == .line || self == .docLine }
+}
+
+extension TriviaPiece {
+  /// The comment kind corresponding to this trivia piece, or nil if it is not a comment.
+  fileprivate var commentKind: Comment.Kind? {
+    switch self {
+    case .lineComment: return .line
+    case .docLineComment: return .docLine
+    case .blockComment: return .block
+    case .docBlockComment: return .docBlock
+    default: return nil
+    }
+  }
+
+  fileprivate init(commentKind kind: Comment.Kind, content: String) {
+    let text = kind.prefix + " " + content
+    switch kind {
+    case .docLine:
+      self = .docLineComment(text)
+    case .line:
+      self = .lineComment(text)
+    case .block:
+      self = .blockComment(text)
+    case .docBlock:
+      self = .docBlockComment(text)
+    }
+  }
+
+  /// The source text of a comment trivia piece, or the empty string for non-comment pieces.
+  fileprivate var commentText: String {
+    switch self {
+    case .lineComment(let text), .docLineComment(let text),
+      .blockComment(let text), .docBlockComment(let text):
+      return text
+    default:
+      return ""
+    }
+  }
+}
+
+extension Character {
+  fileprivate var isSpaceOrTab: Bool { self == " " || self == "\t" }
+}
+
+extension Finding.Message {
+  fileprivate static let hardWrappedComment: Finding.Message =
+    "join this comment with the preceding line"
+}

--- a/Tests/SwiftFormatTests/Rules/ReflowCommentsTests.swift
+++ b/Tests/SwiftFormatTests/Rules/ReflowCommentsTests.swift
@@ -1,0 +1,594 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(Rules) import SwiftFormat
+import _SwiftFormatTestSupport
+
+final class ReflowCommentsTests: LintOrFormatRuleTestCase {
+  func testMergesTwoLineComment() {
+    assertFormatting(
+      ReflowComments.self,
+      input: """
+        // This comment was
+        1️⃣// unnecessarily wrapped.
+        let x = 1
+        """,
+      expected: """
+        // This comment was unnecessarily wrapped.
+        let x = 1
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "join this comment with the preceding line")
+      ]
+    )
+  }
+
+  func testMergesIndentedLineComments() {
+    assertFormatting(
+      ReflowComments.self,
+      input: """
+        func foo() {
+          // This comment was
+          1️⃣// unnecessarily wrapped.
+          let x = 1
+        }
+        """,
+      expected: """
+        func foo() {
+          // This comment was unnecessarily wrapped.
+          let x = 1
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "join this comment with the preceding line")
+      ]
+    )
+  }
+
+  func testDoesNotMergeIndentedLineCommentsThatOverflowAtTheirColumn() {
+    // The merged line fits at column 0 (32 columns) but not at the comment's indented column
+    // (34 columns). Don't merge.
+    assertFormatting(
+      ReflowComments.self,
+      input: """
+        func foo() {
+          // aaaa bbbb cccc dddd
+          // eeee ffff
+          let x = 1
+        }
+        """,
+      expected: """
+        func foo() {
+          // aaaa bbbb cccc dddd
+          // eeee ffff
+          let x = 1
+        }
+        """,
+      findings: [],
+      configuration: {
+        var config = Configuration.forTesting(enabledRule: ReflowComments.ruleName)
+        config.lineLength = 33
+        return config
+      }()
+    )
+  }
+
+  func testMergesThreeLineComment() {
+    assertFormatting(
+      ReflowComments.self,
+      input: """
+        // This comment was split
+        1️⃣// across three
+        2️⃣// separate lines.
+        let x = 1
+        """,
+      expected: """
+        // This comment was split across three separate lines.
+        let x = 1
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "join this comment with the preceding line"),
+        FindingSpec("2️⃣", message: "join this comment with the preceding line"),
+      ]
+    )
+  }
+
+  func testMergesDocComment() {
+    assertFormatting(
+      ReflowComments.self,
+      input: """
+        /// This doc comment was
+        1️⃣/// unnecessarily wrapped.
+        func foo() {}
+        """,
+      expected: """
+        /// This doc comment was unnecessarily wrapped.
+        func foo() {}
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "join this comment with the preceding line")
+      ]
+    )
+  }
+
+  func testDoesNotMergeAcrossBlankCommentLine() {
+    assertFormatting(
+      ReflowComments.self,
+      input: """
+        // First paragraph.
+        //
+        // Second paragraph.
+        let x = 1
+        """,
+      expected: """
+        // First paragraph.
+        //
+        // Second paragraph.
+        let x = 1
+        """,
+      findings: []
+    )
+  }
+
+  func testDoesNotMergeAcrossBlankLine() {
+    assertFormatting(
+      ReflowComments.self,
+      input: """
+        // First comment.
+
+        // Second comment.
+        let x = 1
+        """,
+      expected: """
+        // First comment.
+
+        // Second comment.
+        let x = 1
+        """,
+      findings: []
+    )
+  }
+
+  func testDoesNotMergeWhenResultExceedsLineLength() {
+    assertFormatting(
+      ReflowComments.self,
+      input: """
+        // This comment line is already quite long and cannot be
+        // merged with this continuation without exceeding the limit.
+        let x = 1
+        """,
+      expected: """
+        // This comment line is already quite long and cannot be
+        // merged with this continuation without exceeding the limit.
+        let x = 1
+        """,
+      findings: [],
+      // Set a short line length so the merge would overflow.
+      configuration: {
+        var config = Configuration.forTesting
+        config.lineLength = 60
+        return config
+      }()
+    )
+  }
+
+  func testDoesNotMergeListItems() {
+    assertFormatting(
+      ReflowComments.self,
+      input: """
+        // Items:
+        // - first
+        // - second
+        let x = 1
+        """,
+      expected: """
+        // Items:
+        // - first
+        // - second
+        let x = 1
+        """,
+      findings: []
+    )
+  }
+
+  func testDoesNotMergeNumberedListItems() {
+    assertFormatting(
+      ReflowComments.self,
+      input: """
+        // Steps:
+        // 1. first
+        // 2. second
+        let x = 1
+        """,
+      expected: """
+        // Steps:
+        // 1. first
+        // 2. second
+        let x = 1
+        """,
+      findings: []
+    )
+  }
+
+  func testDoesNotMergeIndentedCodeBlock() {
+    assertFormatting(
+      ReflowComments.self,
+      input: """
+        /// Example:
+        ///
+        ///     foo()
+        ///     bar()
+        func baz() {}
+        """,
+      expected: """
+        /// Example:
+        ///
+        ///     foo()
+        ///     bar()
+        func baz() {}
+        """,
+      findings: []
+    )
+  }
+
+  func testDoesNotMergeMarkdownHeading() {
+    assertFormatting(
+      ReflowComments.self,
+      input: """
+        // # Section
+        // body text
+        let x = 1
+        """,
+      expected: """
+        // # Section
+        // body text
+        let x = 1
+        """,
+      findings: []
+    )
+  }
+
+  func testDoesNotMixRegularAndDocComments() {
+    assertFormatting(
+      ReflowComments.self,
+      input: """
+        // regular comment
+        /// doc comment
+        func foo() {}
+        """,
+      expected: """
+        // regular comment
+        /// doc comment
+        func foo() {}
+        """,
+      findings: []
+    )
+  }
+
+  func testDoesNotMergeXcodeAnnotations() {
+    assertFormatting(
+      ReflowComments.self,
+      input: """
+        // MARK: - Section
+        // TODO: fix this
+        // FIXME: broken
+        let x = 1
+        """,
+      expected: """
+        // MARK: - Section
+        // TODO: fix this
+        // FIXME: broken
+        let x = 1
+        """,
+      findings: []
+    )
+  }
+
+  func testMergesLinesContainingURL() {
+    // URLs are ordinary prose: a line containing a URL merges with its neighbor when the result
+    // fits.
+    assertFormatting(
+      ReflowComments.self,
+      input: """
+        // Visit https://example.com today
+        1️⃣// for the full guide.
+        let x = 1
+        """,
+      expected: """
+        // Visit https://example.com today for the full guide.
+        let x = 1
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "join this comment with the preceding line")
+      ]
+    )
+  }
+
+  func testCustomPreservedLinePrefix() {
+    // A user-supplied prefix wins: the rule leaves the `NOTE:` line alone, while ordinary prose in
+    // the same block still merges.
+    assertFormatting(
+      ReflowComments.self,
+      input: """
+        // This ordinary comment was
+        1️⃣// wrapped and should join.
+        //
+        // NOTE: keep this on
+        // its own line.
+        let x = 1
+        """,
+      expected: """
+        // This ordinary comment was wrapped and should join.
+        //
+        // NOTE: keep this on
+        // its own line.
+        let x = 1
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "join this comment with the preceding line")
+      ],
+      configuration: {
+        var config = Configuration.forTesting(enabledRule: ReflowComments.ruleName)
+        config.reflowComments.preservedLinePrefixes = ["NOTE:"]
+        return config
+      }()
+    )
+  }
+
+  func testDoesNotReflowLicenseHeader() {
+    // The standard Swift.org file header must survive untouched, even when the line length is
+    // generous enough that adjacent lines would otherwise merge.
+    let header = """
+      //===----------------------------------------------------------------------===//
+      //
+      // This source file is part of the Swift.org open source project
+      //
+      // Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+      // Licensed under Apache License v2.0 with Runtime Library Exception
+      //
+      // See https://swift.org/LICENSE.txt for license information
+      // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+      //
+      //===----------------------------------------------------------------------===//
+      let x = 1
+      """
+    assertFormatting(
+      ReflowComments.self,
+      input: header,
+      expected: header,
+      findings: [],
+      configuration: {
+        var config = Configuration.forTesting(enabledRule: ReflowComments.ruleName)
+        config.lineLength = 200
+        config.reflowComments.preservedLinePrefixes = []
+        return config
+      }()
+    )
+  }
+
+  func testDoesNotMergeSectionDividerWithText() {
+    assertFormatting(
+      ReflowComments.self,
+      input: """
+        //===--- Section Header ---===//
+        // this describes the section
+        let x = 1
+        """,
+      expected: """
+        //===--- Section Header ---===//
+        // this describes the section
+        let x = 1
+        """,
+      findings: []
+    )
+  }
+
+  func testMergesThreeDocLineComment() {
+    assertFormatting(
+      ReflowComments.self,
+      input: """
+        /// This doc comment was split
+        1️⃣/// across three
+        2️⃣/// separate lines.
+        func foo() {}
+        """,
+      expected: """
+        /// This doc comment was split across three separate lines.
+        func foo() {}
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "join this comment with the preceding line"),
+        FindingSpec("2️⃣", message: "join this comment with the preceding line"),
+      ]
+    )
+  }
+
+  func testMergesLineCommentsOnlyWithinParagraph() {
+    assertFormatting(
+      ReflowComments.self,
+      input: """
+        // First paragraph was
+        1️⃣// wrapped here.
+        //
+        // Second paragraph was
+        2️⃣// also wrapped.
+        let x = 1
+        """,
+      expected: """
+        // First paragraph was wrapped here.
+        //
+        // Second paragraph was also wrapped.
+        let x = 1
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "join this comment with the preceding line"),
+        FindingSpec("2️⃣", message: "join this comment with the preceding line"),
+      ]
+    )
+  }
+
+  func testReflowsDocCommentSummaryButPreservesParameterList() {
+    // The summary paragraph is reflowed, but the DocC `- Parameter`/`- Returns` list items are
+    // recognized as Markdown list items and left untouched.
+    assertFormatting(
+      ReflowComments.self,
+      input: """
+        /// Combines the two given values into a single result using the
+        1️⃣/// documented algorithm.
+        ///
+        /// - Parameter first: The first value.
+        /// - Parameter second: The second value.
+        /// - Returns: The combined result.
+        func combine(first: Int, second: Int) -> Int { 0 }
+        """,
+      expected: """
+        /// Combines the two given values into a single result using the documented algorithm.
+        ///
+        /// - Parameter first: The first value.
+        /// - Parameter second: The second value.
+        /// - Returns: The combined result.
+        func combine(first: Int, second: Int) -> Int { 0 }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "join this comment with the preceding line")
+      ]
+    )
+  }
+
+  func testMergesWrappedParameterDescription() {
+    // The summary reflows, and a wrapped description inside a `- Parameters:` outline item is
+    // joined too, while separate items stay separate.
+    assertFormatting(
+      ReflowComments.self,
+      input: """
+        /// Processes the input using the configured strategy and returns
+        1️⃣/// the transformed output.
+        ///
+        /// - Parameters:
+        ///   - value: The value to process that is
+        2️⃣///     described across two lines.
+        ///   - count: The number of iterations.
+        func process(value: Int, count: Int) {}
+        """,
+      expected: """
+        /// Processes the input using the configured strategy and returns the transformed output.
+        ///
+        /// - Parameters:
+        ///   - value: The value to process that is described across two lines.
+        ///   - count: The number of iterations.
+        func process(value: Int, count: Int) {}
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "join this comment with the preceding line"),
+        FindingSpec("2️⃣", message: "join this comment with the preceding line"),
+      ]
+    )
+  }
+
+  func testReflowsOnlyLineCommentsWhenDocLineDisabled() {
+    assertFormatting(
+      ReflowComments.self,
+      input: """
+        // This regular comment was
+        1️⃣// wrapped here.
+        /// This doc comment was
+        /// wrapped here.
+        func foo() {}
+        """,
+      expected: """
+        // This regular comment was wrapped here.
+        /// This doc comment was
+        /// wrapped here.
+        func foo() {}
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "join this comment with the preceding line")
+      ],
+      // Only reflow `//` line comments; leave `///` doc comments untouched.
+      configuration: {
+        var config = Configuration.forTesting(enabledRule: ReflowComments.ruleName)
+        config.reflowComments.reflowedCommentKinds = [.line]
+        return config
+      }()
+    )
+  }
+
+  func testReflowsOnlyDocLineCommentsWhenLineDisabled() {
+    assertFormatting(
+      ReflowComments.self,
+      input: """
+        // This regular comment was
+        // wrapped here.
+        /// This doc comment was
+        1️⃣/// wrapped here.
+        func foo() {}
+        """,
+      expected: """
+        // This regular comment was
+        // wrapped here.
+        /// This doc comment was wrapped here.
+        func foo() {}
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "join this comment with the preceding line")
+      ],
+      // Only reflow `///` doc comments; leave `//` line comments untouched.
+      configuration: {
+        var config = Configuration.forTesting(enabledRule: ReflowComments.ruleName)
+        config.reflowComments.reflowedCommentKinds = [.docLine]
+        return config
+      }()
+    )
+  }
+
+  func testDoesNotMergeBlockquoteLines() {
+    assertFormatting(
+      ReflowComments.self,
+      input: """
+        // > quoted line one
+        // > quoted line two
+        let x = 1
+        """,
+      expected: """
+        // > quoted line one
+        // > quoted line two
+        let x = 1
+        """,
+      findings: []
+    )
+  }
+
+  func testDoesNotMergeDecoratedBanners() {
+    assertFormatting(
+      ReflowComments.self,
+      input: """
+        // ----- Section -----
+        // some description
+        // === Notes ===
+        // detail line
+        //===--- Foo ---===//
+        // trailing text
+        let x = 1
+        """,
+      expected: """
+        // ----- Section -----
+        // some description
+        // === Notes ===
+        // detail line
+        //===--- Foo ---===//
+        // trailing text
+        let x = 1
+        """,
+      findings: []
+    )
+  }
+}


### PR DESCRIPTION
This opt-in rule joins comments that were hard-wrapped across multiple
lines back into a single line when the combined text still fits within
the configured line length.

It reflows only line comments (`//`) and documentation line comments
(`///`), and only joins lines that belong to the same Markdown paragraph.
Lists, headings, code blocks, block quotes, thematic breaks, blank lines
between paragraphs, divider lines such as `//===----===//`, and file
headers are left untouched. The `reflowComments.reflowedCommentKinds` and
`reflowComments.preservedLinePrefixes` options control which comments the
rule reflows.
