### PR TITLE
Fix broken Configuration link in RuleDocumentation

### DIFF
--- a/Documentation/RuleDocumentation.md
+++ b/Documentation/RuleDocumentation.md
@@ -4,7 +4,7 @@
 
 Use the rules below in the `rules` block of your `.swift-format`
 configuration file, as described in
-[Configuration](Documentation/Configuration.md). All of these rules can be
+[Configuration](Configuration.md). All of these rules can be
 applied in the linter, but only some of them can format your source code
 automatically.
 

--- a/Sources/_GenerateSwiftFormat/RuleDocumentationGenerator.swift
+++ b/Sources/_GenerateSwiftFormat/RuleDocumentationGenerator.swift
@@ -33,7 +33,7 @@ import SwiftFormat
 
       Use the rules below in the `rules` block of your `.swift-format`
       configuration file, as described in
-      [Configuration](Documentation/Configuration.md). All of these rules can be
+      [Configuration](Configuration.md). All of these rules can be
       applied in the linter, but only some of them can format your source code
       automatically.
 


### PR DESCRIPTION
`Documentation/RuleDocumentation.md` links `Documentation/Configuration.md` — from inside `Documentation/`, that resolves to `Documentation/Documentation/Configuration.md` and 404s. The file sits in the same directory → `Configuration.md`.

One-line docs fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)