### PR TITLE
[PrettyPrint] Keep ternary formatting idempotent

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
@@ -426,8 +426,8 @@ public class PrettyPrinter {
 
       var overrideBreakingSuppressed = false
       switch newline {
-      case .elective, .escaped: break
-      case .soft(_, let discretionary):
+      case .elective, .electiveIgnoringGroupLength, .escaped: break
+      case .soft(_, let discretionary), .softIgnoringGroupLength(_, let discretionary):
         // A discretionary newline (i.e. from the source) should create a line break even if the
         // rules for breaking are disabled.
         overrideBreakingSuppressed =
@@ -667,7 +667,7 @@ public class PrettyPrinter {
         delimIndexStack.append(i)
 
         switch newline {
-        case .elective, .escaped:
+        case .elective, .electiveIgnoringGroupLength, .softIgnoringGroupLength, .escaped:
           total += size
         default:
           // `size` is never used in this case, because the break always fires. Use `maxLineLength`

--- a/Sources/SwiftFormat/PrettyPrint/PrettyPrintBuffer.swift
+++ b/Sources/SwiftFormat/PrettyPrint/PrettyPrintBuffer.swift
@@ -77,9 +77,9 @@ struct PrettyPrintBuffer {
   mutating func writeNewlines(_ newlines: NewlineBehavior, shouldIndentBlankLines: Bool) {
     let numberToPrint: Int
     switch newlines {
-    case .elective:
+    case .elective, .electiveIgnoringGroupLength:
       numberToPrint = consecutiveNewlineCount == 0 ? 1 : 0
-    case .soft(let count, _):
+    case .soft(let count, _), .softIgnoringGroupLength(let count, _):
       // We add 1 to the max blank lines because it takes 2 newlines to create the first blank line.
       numberToPrint = min(count, maximumBlankLines + 1) - consecutiveNewlineCount
     case .hard(let count):

--- a/Sources/SwiftFormat/PrettyPrint/Token.swift
+++ b/Sources/SwiftFormat/PrettyPrint/Token.swift
@@ -136,11 +136,21 @@ enum NewlineBehavior {
   /// specifies whether a user-entered discretionary newline should be respected.
   case elective(ignoresDiscretionary: Bool)
 
+  /// An elective newline whose discretionary form should fire without forcing any enclosing
+  /// groups to break. This is useful when a user may split a construct at a point that should not
+  /// change the layout decisions made before that point.
+  case electiveIgnoringGroupLength
+
   /// Breaking onto a newline `count` times is required, unless it would create more blank lines
   /// than are allowed by the current configuration. Any blank lines over the configured limit are
   /// discarded. `discretionary` tracks whether these newlines were created based on user-entered
   /// discretionary newlines, from the source, or were inserted by the formatter.
   case soft(count: Int, discretionary: Bool)
+
+  /// A required newline that does not contribute the maximum line length to enclosing groups.
+  /// This is produced when a discretionary newline is preserved for
+  /// ``electiveIgnoringGroupLength``.
+  case softIgnoringGroupLength(count: Int, discretionary: Bool)
 
   /// Breaking onto a newline `count` times is required and any limits on blank lines are
   /// **ignored**. Exactly `count` newlines are always printed, regardless of existing consecutive

--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -2080,18 +2080,12 @@ private final class TokenStreamCreator: SyntaxVisitor {
     // wrapping after that.
     before(node.questionMark, tokens: .break(.open(kind: .continuation)), .open)
     after(node.questionMark, tokens: .space)
-    // Ignore a discretionary newline here so that a break inserted before the colon does not
-    // inflate the preceding question-mark break's length on the next formatting pass. Continue
-    // honoring the newline when the colon's leading trivia contains a comment, so that the comment
-    // does not get attached to the previous token.
-    let colonBreakIgnoresDiscretionaryNewline = !node.colon.leadingTrivia.hasAnyComments
     before(
       node.colon,
       tokens: .break(.close(mustBreak: false), size: 0),
-      .break(
-        .open(kind: .continuation),
-        newlines: .elective(ignoresDiscretionary: colonBreakIgnoresDiscretionaryNewline)
-      ),
+      // A user may place a discretionary newline before the colon, but preserving it should not
+      // force the question-mark break on an otherwise fitting ternary expression.
+      .break(.open(kind: .continuation), newlines: .electiveIgnoringGroupLength),
       .open
     )
     after(node.colon, tokens: .space)
@@ -3656,7 +3650,15 @@ private final class TokenStreamCreator: SyntaxVisitor {
         guard !isStartOfFile else { break }
 
         if requiresNextNewline || (config.respectsExistingLineBreaks && isDiscretionaryNewlineAllowed(before: token)) {
-          appendNewlines(.soft(count: count, discretionary: true))
+          let newlines: NewlineBehavior
+          if !token.leadingTrivia.hasAnyComments,
+            shouldPreserveNewlineWithoutForcingEarlierBreaks(before: token)
+          {
+            newlines = .softIgnoringGroupLength(count: count, discretionary: true)
+          } else {
+            newlines = .soft(count: count, discretionary: true)
+          }
+          appendNewlines(newlines)
         } else {
           // Even if discretionary line breaks are not being respected, we still respect multiple
           // line breaks in order to keep blank separator lines that the user might want.
@@ -3739,6 +3741,17 @@ private final class TokenStreamCreator: SyntaxVisitor {
       return foundBreakFirst
     }
     return isBreakMoreRecentThanNonbreakingContent(tokens) ?? true
+  }
+
+  /// Returns whether a discretionary newline before `token` should be retained without affecting
+  /// the enclosing groups' layout decisions.
+  private func shouldPreserveNewlineWithoutForcingEarlierBreaks(before token: TokenSyntax) -> Bool {
+    return beforeMap[token]?.contains {
+      if case .break(_, _, .electiveIgnoringGroupLength) = $0 {
+        return true
+      }
+      return false
+    } ?? false
   }
 
   /// Appends the newlines to the token stream.
@@ -4654,6 +4667,15 @@ extension NewlineBehavior {
       // `lhs` is either also elective or a required newline, which overwrites elective.
       return lhs
 
+    case (.electiveIgnoringGroupLength, .soft(let count, let discretionary)):
+      return .softIgnoringGroupLength(count: count, discretionary: discretionary)
+    case (.electiveIgnoringGroupLength, .electiveIgnoringGroupLength):
+      return .electiveIgnoringGroupLength
+    case (.electiveIgnoringGroupLength, _):
+      return rhs
+    case (_, .electiveIgnoringGroupLength):
+      return lhs
+
     case (.escaped, _):
       return rhs
     case (_, .escaped):
@@ -4671,8 +4693,27 @@ extension NewlineBehavior {
       }
       return .soft(count: mergedCount, discretionary: lhsDiscretionary || rhsDiscretionary)
 
+    case (.softIgnoringGroupLength(let count, let discretionary), .soft(let rhsCount, let rhsDiscretionary)),
+      (.soft(let rhsCount, let rhsDiscretionary), .softIgnoringGroupLength(let count, let discretionary)):
+      return .softIgnoringGroupLength(
+        count: max(count, rhsCount),
+        discretionary: discretionary || rhsDiscretionary
+      )
+    case (
+      .softIgnoringGroupLength(let lhsCount, let lhsDiscretionary),
+      .softIgnoringGroupLength(let rhsCount, let rhsDiscretionary)
+    ):
+      return .softIgnoringGroupLength(
+        count: max(lhsCount, rhsCount),
+        discretionary: lhsDiscretionary || rhsDiscretionary
+      )
+
     case (.soft(let softCount, _), .hard(let hardCount)),
       (.hard(let hardCount), .soft(let softCount, _)):
+      return .hard(count: max(softCount, hardCount))
+
+    case (.softIgnoringGroupLength(let softCount, _), .hard(let hardCount)),
+      (.hard(let hardCount), .softIgnoringGroupLength(let softCount, _)):
       return .hard(count: max(softCount, hardCount))
 
     case (.hard(let lhsCount), .hard(let rhsCount)):

--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -2080,10 +2080,18 @@ private final class TokenStreamCreator: SyntaxVisitor {
     // wrapping after that.
     before(node.questionMark, tokens: .break(.open(kind: .continuation)), .open)
     after(node.questionMark, tokens: .space)
+    // Ignore a discretionary newline here so that a break inserted before the colon does not
+    // inflate the preceding question-mark break's length on the next formatting pass. Continue
+    // honoring the newline when the colon's leading trivia contains a comment, so that the comment
+    // does not get attached to the previous token.
+    let colonBreakIgnoresDiscretionaryNewline = !node.colon.leadingTrivia.hasAnyComments
     before(
       node.colon,
       tokens: .break(.close(mustBreak: false), size: 0),
-      .break(.open(kind: .continuation)),
+      .break(
+        .open(kind: .continuation),
+        newlines: .elective(ignoresDiscretionary: colonBreakIgnoresDiscretionaryNewline)
+      ),
       .open
     )
     after(node.colon, tokens: .space)

--- a/Tests/SwiftFormatTests/PrettyPrint/TernaryExprTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/TernaryExprTests.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftFormat
+
 final class TernaryExprTests: PrettyPrintTestCase {
   func testTernaryExprs() {
     let input =
@@ -66,6 +68,55 @@ final class TernaryExprTests: PrettyPrintTestCase {
       """
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 80)
+  }
+
+  func testLongTypedVariableDeclarationIsIdempotent() {
+    let input =
+      """
+      struct Outer {
+          func test() {
+              let ffiStructKeepAlive: (FixedByteArrayConverter<FixedByteArrayHelper15>.KeepAlive?, IdentityConverter<Int32>.KeepAlive?, )? = (media_id_keepalive != nil || cdn_keepalive != nil || false) ? (media_id_keepalive, cdn_keepalive,) : nil
+          }
+      }
+      """
+    let expected =
+      """
+      struct Outer {
+          func test() {
+              let ffiStructKeepAlive:
+                  (FixedByteArrayConverter<FixedByteArrayHelper15>.KeepAlive?, IdentityConverter<Int32>.KeepAlive?, )? =
+                      (media_id_keepalive != nil || cdn_keepalive != nil || false) ? (media_id_keepalive, cdn_keepalive,)
+                      : nil
+          }
+      }
+
+      """
+    var configuration = Configuration.forTesting
+    configuration.indentation = .spaces(4)
+    configuration.indentConditionalCompilationBlocks = false
+    configuration.lineBreakBeforeEachArgument = true
+    configuration.lineBreakBetweenDeclarationAttributes = true
+    configuration.prioritizeKeepingFunctionOutputTogether = true
+
+    assertPrettyPrintEqual(
+      input: input,
+      expected: expected,
+      linelength: 120,
+      configuration: configuration
+    )
+  }
+
+  func testCommentBeforeColonStaysOnItsOwnLine() {
+    let input =
+      """
+      let value =
+        condition
+        ? trueValue
+        // Explain the false branch.
+        : falseValue
+      """
+
+    assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 100)
   }
 
   func testTernaryWithWrappingExpressions() {

--- a/Tests/SwiftFormatTests/PrettyPrint/TernaryExprTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/TernaryExprTests.swift
@@ -119,6 +119,17 @@ final class TernaryExprTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 100)
   }
 
+  func testDiscretionaryNewlineBeforeColonDoesNotForceQuestionMarkBreak() {
+    let input =
+      """
+      let result = condition ? trueValue
+        : falseValue
+      """
+    let expected = input + "\n"
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 80)
+  }
+
   func testTernaryWithWrappingExpressions() {
     let input =
       """


### PR DESCRIPTION
## Summary

- prevent a formatter-inserted newline before a ternary colon from changing the preceding `?` break on the next formatting pass
- continue honoring the newline when the colon's leading trivia contains a comment
- add regression coverage for the reported long typed declaration and for comments before the colon

## Testing

- `swift test --filter 'TernaryExprTests|RespectsExistingLineBreaksTests'`
- `swift test --parallel`
- formatted both changed files with the modified formatter and confirmed no diff

Fixes #1248
