### PR TITLE
Adopt renamed Parser.LanguageFeatures

### DIFF
--- a/Sources/SwiftFormat/API/SwiftFormatter.swift
+++ b/Sources/SwiftFormat/API/SwiftFormatter.swift
@@ -91,7 +91,7 @@ public final class SwiftFormatter {
   ///   - selection: The ranges to format
   ///   - experimentalFeatures: The set of experimental features that should be enabled in the
   ///     parser. These names must be from the set of parser-recognized experimental language
-  ///     features in `SwiftParser`'s `Parser.ExperimentalFeatures` enum, which match the spelling
+  ///     features in `SwiftParser`'s `Parser.LanguageFeatures` enum, which match the spelling
   ///     defined in the compiler's `Features.def` file.
   ///   - outputStream: A value conforming to `TextOutputStream` to which the formatted output will
   ///     be written.

--- a/Sources/SwiftFormat/API/SwiftLinter.swift
+++ b/Sources/SwiftFormat/API/SwiftLinter.swift
@@ -83,7 +83,7 @@ public final class SwiftLinter {
   ///   - url: A file URL denoting the filename/path that should be assumed for this source code.
   ///   - experimentalFeatures: The set of experimental features that should be enabled in the
   ///     parser. These names must be from the set of parser-recognized experimental language
-  ///     features in `SwiftParser`'s `Parser.ExperimentalFeatures` enum, which match the spelling
+  ///     features in `SwiftParser`'s `Parser.LanguageFeatures` enum, which match the spelling
   ///     defined in the compiler's `Features.def` file.
   ///   - parsingDiagnosticHandler: An optional callback that will be notified if there are any
   ///     errors when parsing the source code.

--- a/Sources/SwiftFormat/Core/Parsing.swift
+++ b/Sources/SwiftFormat/Core/Parsing.swift
@@ -31,7 +31,7 @@ import SwiftSyntax
 ///     dummy value will be used.
 ///   - experimentalFeatures: The set of experimental features that should be enabled in the parser.
 ///     These names must be from the set of parser-recognized experimental language features in
-///     `SwiftParser`'s `Parser.ExperimentalFeatures` enum, which match the spelling defined in the
+///     `SwiftParser`'s `Parser.LanguageFeatures` enum, which match the spelling defined in the
 ///     compiler's `Features.def` file.
 ///   - parsingDiagnosticHandler: An optional callback that will be notified if there are any
 ///     errors when parsing the source code.
@@ -43,16 +43,16 @@ func parseAndEmitDiagnostics(
   experimentalFeatures: Set<String>,
   parsingDiagnosticHandler: ((Diagnostic, SourceLocation) -> Void)? = nil
 ) throws -> SourceFileSyntax {
-  var experimentalFeaturesSet: Parser.ExperimentalFeatures = []
+  var experimentalFeaturesSet: Parser.LanguageFeatures = []
   for featureName in experimentalFeatures {
-    guard let featureValue = Parser.ExperimentalFeatures(name: featureName) else {
+    guard let featureValue = Parser.LanguageFeatures(name: featureName) else {
       throw SwiftFormatError.unrecognizedExperimentalFeature(featureName)
     }
     experimentalFeaturesSet.formUnion(featureValue)
   }
   var source = source
   let sourceFile = source.withUTF8 { sourceBytes in
-    operatorTable.foldAll(Parser.parse(source: sourceBytes, experimentalFeatures: experimentalFeaturesSet)) { _ in }
+    operatorTable.foldAll(Parser.parse(source: sourceBytes, languageFeatures: experimentalFeaturesSet)) { _ in }
       .as(SourceFileSyntax.self)!
   }
   let diagnostics = ParseDiagnosticsGenerator.diagnostics(for: sourceFile)

--- a/Sources/_SwiftFormatTestSupport/Parsing.swift
+++ b/Sources/_SwiftFormatTestSupport/Parsing.swift
@@ -24,7 +24,7 @@ extension Parser {
   @_spi(Testing)
   public static func parse(
     source: String,
-    experimentalFeatures: Parser.ExperimentalFeatures
+    experimentalFeatures: Parser.LanguageFeatures
   ) -> SourceFileSyntax {
     var source = source
     return source.withUTF8 { sourceBytes in

--- a/Tests/SwiftFormatTests/PrettyPrint/PrettyPrintTestCase.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/PrettyPrintTestCase.swift
@@ -43,7 +43,7 @@ class PrettyPrintTestCase: DiagnosingTestCase {
     configuration: Configuration = Configuration.forTesting,
     whitespaceOnly: Bool = false,
     findings: [FindingSpec] = [],
-    experimentalFeatures: Parser.ExperimentalFeatures = [],
+    experimentalFeatures: Parser.LanguageFeatures = [],
     file: StaticString = #file,
     line: UInt = #line
   ) {
@@ -121,13 +121,13 @@ class PrettyPrintTestCase: DiagnosingTestCase {
     configuration: Configuration,
     selection: Selection,
     whitespaceOnly: Bool,
-    experimentalFeatures: Parser.ExperimentalFeatures = [],
+    experimentalFeatures: Parser.LanguageFeatures = [],
     findingConsumer: @escaping (Finding) -> Void
   ) -> (String, Context) {
     // Ignore folding errors for unrecognized operators so that we fallback to a reasonable default.
     let sourceFileSyntax =
       OperatorTable.standardOperators.foldAll(
-        Parser.parse(source: source, experimentalFeatures: experimentalFeatures)
+        Parser.parse(source: source, languageFeatures: experimentalFeatures)
       ) { _ in }
       .as(SourceFileSyntax.self)!
     let context = makeContext(

--- a/Tests/SwiftFormatTests/Rules/LintOrFormatRuleTestCase.swift
+++ b/Tests/SwiftFormatTests/Rules/LintOrFormatRuleTestCase.swift
@@ -37,13 +37,13 @@ class LintOrFormatRuleTestCase: DiagnosingTestCase {
     _ markedSource: String,
     findings: [FindingSpec] = [],
     configuration: Configuration? = nil,
-    experimentalFeatures: Parser.ExperimentalFeatures = [],
+    experimentalFeatures: Parser.LanguageFeatures = [],
     file: StaticString = #file,
     line: UInt = #line
   ) {
     let markedText = MarkedText(textWithMarkers: markedSource)
     let unmarkedSource = markedText.textWithoutMarkers
-    let tree = Parser.parse(source: unmarkedSource, experimentalFeatures: experimentalFeatures)
+    let tree = Parser.parse(source: unmarkedSource, languageFeatures: experimentalFeatures)
     let sourceFileSyntax =
       OperatorTable.standardOperators.foldAll(tree) { _ in }.as(SourceFileSyntax.self)!
 
@@ -103,13 +103,13 @@ class LintOrFormatRuleTestCase: DiagnosingTestCase {
     expected: String,
     findings: [FindingSpec] = [],
     configuration: Configuration? = nil,
-    experimentalFeatures: Parser.ExperimentalFeatures = [],
+    experimentalFeatures: Parser.LanguageFeatures = [],
     file: StaticString = #file,
     line: UInt = #line
   ) {
     let markedInput = MarkedText(textWithMarkers: input)
     let originalSource: String = markedInput.textWithoutMarkers
-    let tree = Parser.parse(source: originalSource, experimentalFeatures: experimentalFeatures)
+    let tree = Parser.parse(source: originalSource, languageFeatures: experimentalFeatures)
     let sourceFileSyntax =
       OperatorTable.standardOperators.foldAll(tree) { _ in }.as(SourceFileSyntax.self)!
 
@@ -150,7 +150,7 @@ class LintOrFormatRuleTestCase: DiagnosingTestCase {
       printTokenStream: false,
       whitespaceOnly: false
     ).prettyPrint()
-    let prettyPrintedTree = Parser.parse(source: prettyPrintedSource, experimentalFeatures: experimentalFeatures)
+    let prettyPrintedTree = Parser.parse(source: prettyPrintedSource, languageFeatures: experimentalFeatures)
     XCTAssertEqual(
       whitespaceInsensitiveText(of: actual),
       whitespaceInsensitiveText(of: prettyPrintedTree),


### PR DESCRIPTION
Update for https://github.com/swiftlang/swift-syntax/pull/3377
Update the SwiftParser usage for the swift-syntax rename of `Parser.ExperimentalFeatures` to `Parser.LanguageFeatures` and the `experimentalFeatures:` argument to `languageFeatures:`. swift-format's own `experimentalFeatures` API (the `Set<String>` of feature names) is unchanged.