### PR TITLE
Add option to restore pre-603 import grouping in OrderedImports

### DIFF
--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -305,8 +305,9 @@ too long.
 
 - `includeConditionalImports` _(boolean)_: Determines whether imports within conditional compilation blocks (`#if`, `#elseif`, `#else`) should be ordered. When `true`, imports inside conditional blocks will be sorted and organized according to the same rules as top-level imports. When `false`, imports within conditional blocks are left in their original order.
 - `shouldGroupImports` _(boolean)_: Determines whether different import types should be grouped together. When `true`, imports are grouped into the following order, with a blank line between each section: 1) regular imports, 2) declaration imports, 3) @\_implementationOnly imports, and 4) @testable imports. When `false`, imports are lexicographically ordered by name, regardless of type.
+- `onlyGroupTestableImports` _(boolean)_: Determines whether `@testable` imports are the only imports assigned to a group based on their attributes. When `false`, any import with a `@testable` attribute is placed in the `@testable` group and imports with the `@_implementationOnly` attribute are placed in their own group. When `true`, an import is placed in the `@testable` group only if `@testable` is its first attribute, no separate group is created for `@_implementationOnly` imports, and imports with any other attributes are grouped and sorted together with regular imports. This matches the behavior of swift-format 602.0.0 and earlier.
 
-**default:** `{ "includeConditionalImports" : false, "shouldGroupImports": true }`
+**default:** `{ "includeConditionalImports" : false, "shouldGroupImports": true, "onlyGroupTestableImports": false }`
 
 ---
 

--- a/Documentation/RuleDocumentation.md
+++ b/Documentation/RuleDocumentation.md
@@ -421,6 +421,11 @@ configuration option to limit this rule to lexicographic ordering.
 By default, imports within conditional compilation blocks (`#if`, `#elseif`, `#else`) are not ordered.
 This behavior can be controlled via the `orderedImports.includeConditionalImports` configuration option.
 
+The `orderedImports.onlyGroupTestableImports` configuration option restores the grouping behavior of
+swift-format 602.0.0 and earlier: only imports whose first attribute is `@testable` are placed in a
+separate group, and imports with any other attributes are grouped and sorted together with regular
+imports.
+
 Lint: If an import appears anywhere other than the beginning of the file it resides in,
       not lexicographically ordered, or (optionally) not in the appropriate import group, a lint error is
       raised.

--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -577,11 +577,38 @@ public struct NoAssignmentInExpressionsConfiguration: Codable, Equatable {
 
 /// Configuration for the `OrderedImports` rule.
 public struct OrderedImportsConfiguration: Codable, Equatable {
+  private enum CodingKeys: String, CodingKey {
+    case includeConditionalImports
+    case shouldGroupImports
+    case onlyGroupTestableImports
+  }
+
   /// Determines whether imports within conditional compilation blocks should be ordered.
   public var includeConditionalImports = false
   /// Determines whether imports are separated into groups based on their type.
   public var shouldGroupImports = true
+  /// Determines whether `@testable` imports are the only imports assigned to a group based on
+  /// their attributes.
+  ///
+  /// When false (the default), any import with a `@testable` attribute is placed in the
+  /// `@testable` group and imports with the `@_implementationOnly` attribute are placed in their
+  /// own group. When true, an import is placed in the `@testable` group only if `@testable` is its
+  /// first attribute, no separate group is created for `@_implementationOnly` imports, and imports
+  /// with any other attributes are grouped and sorted together with regular imports. This matches
+  /// the behavior of swift-format 602.0.0 and earlier.
+  public var onlyGroupTestableImports = false
+
   public init() {}
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.includeConditionalImports =
+      try container.decodeIfPresent(Bool.self, forKey: .includeConditionalImports) ?? false
+    self.shouldGroupImports =
+      try container.decodeIfPresent(Bool.self, forKey: .shouldGroupImports) ?? true
+    self.onlyGroupTestableImports =
+      try container.decodeIfPresent(Bool.self, forKey: .onlyGroupTestableImports) ?? false
+  }
 }
 
 /// Configuration for the `SwiftTestingNamingConventions` rule.

--- a/Sources/SwiftFormat/Rules/OrderedImports.swift
+++ b/Sources/SwiftFormat/Rules/OrderedImports.swift
@@ -23,6 +23,11 @@ import SwiftSyntax
 /// By default, imports within conditional compilation blocks (`#if`, `#elseif`, `#else`) are not ordered.
 /// This behavior can be controlled via the `orderedImports.includeConditionalImports` configuration option.
 ///
+/// The `orderedImports.onlyGroupTestableImports` configuration option restores the grouping behavior of
+/// swift-format 602.0.0 and earlier: only imports whose first attribute is `@testable` are placed in a
+/// separate group, and imports with any other attributes are grouped and sorted together with regular
+/// imports.
+///
 /// Lint: If an import appears anywhere other than the beginning of the file it resides in,
 ///       not lexicographically ordered, or (optionally) not in the appropriate import group, a lint error is
 ///       raised.
@@ -437,6 +442,8 @@ private func generateLines(
       let sortable = context.shouldFormat(OrderedImports.self, node: Syntax(block))
       var blockWithoutTrailingTrivia = block
       blockWithoutTrailingTrivia.trailingTrivia = []
+      currentLine.onlyGroupTestableImports =
+        context.configuration.orderedImports.onlyGroupTestableImports
       currentLine.syntaxNode = .importCodeBlock(blockWithoutTrailingTrivia, sortable: sortable)
     } else if block.item.is(IfConfigDeclSyntax.self) {
       if currentLine.syntaxNode != nil {
@@ -571,6 +578,11 @@ private class Line {
     case ifConfigCodeBlock(CodeBlockItemSyntax)
   }
 
+  /// Determines whether only imports whose first attribute is `@testable` are treated specially
+  /// when computing this line's import type. Mirrors the value of the
+  /// `orderedImports.onlyGroupTestableImports` configuration option.
+  var onlyGroupTestableImports = false
+
   /// Stores line comments. `syntaxNode` need not be defined, since a comment can exist by itself on
   /// a line.
   var leadingTrivia: [TriviaPiece] = []
@@ -660,6 +672,21 @@ private class Line {
 
   /// Returns a `LineType` the represents the type of import from the given import decl.
   private func importType(of importDecl: ImportDeclSyntax) -> LineType {
+    if onlyGroupTestableImports {
+      // Match the behavior of swift-format 602.0.0 and earlier: only an import whose first
+      // attribute is `@testable` is treated specially, and there is no separate group for
+      // `@_implementationOnly` imports.
+      if let attr = importDecl.attributes.firstToken(viewMode: .sourceAccurate),
+        attr.tokenKind == .atSign,
+        attr.nextToken(viewMode: .sourceAccurate)?.text == "testable"
+      {
+        return .testableImport
+      }
+      if importDecl.importKindSpecifier != nil {
+        return .declImport
+      }
+      return .regularImport
+    }
 
     let importIdentifierTypes = importDecl.attributes.compactMap { $0.as(AttributeSyntax.self)?.attributeName }
     let importAttributeNames = importIdentifierTypes.compactMap { $0.as(IdentifierTypeSyntax.self)?.name.text }

--- a/Tests/SwiftFormatTests/API/ConfigurationTests.swift
+++ b/Tests/SwiftFormatTests/API/ConfigurationTests.swift
@@ -115,6 +115,28 @@ final class ConfigurationTests: XCTestCase {
     }
   }
 
+  func testDecodingPartialOrderedImportsConfiguration() throws {
+    // Configuration files that predate the addition of newer options to `orderedImports` (or that
+    // simply omit some of them) must still decode successfully, with the missing options taking
+    // their default values.
+    let jsonData = """
+      {
+          "orderedImports": {
+              "includeConditionalImports": true
+          }
+      }
+      """.data(using: .utf8)!
+
+    let jsonDecoder = JSONDecoder()
+    #if canImport(Darwin) || compiler(>=6)
+    jsonDecoder.allowsJSON5 = true
+    #endif
+    let config = try jsonDecoder.decode(Configuration.self, from: jsonData)
+    XCTAssertTrue(config.orderedImports.includeConditionalImports)
+    XCTAssertTrue(config.orderedImports.shouldGroupImports)
+    XCTAssertFalse(config.orderedImports.onlyGroupTestableImports)
+  }
+
   func testConfigurationWithComments() throws {
     #if !canImport(Darwin) && compiler(<6)
     try XCTSkipIf(true, "JSONDecoder does not support JSON5")

--- a/Tests/SwiftFormatTests/Rules/OrderedImportsTests.swift
+++ b/Tests/SwiftFormatTests/Rules/OrderedImportsTests.swift
@@ -1291,4 +1291,80 @@ final class OrderedImportsTests: LintOrFormatRuleTestCase {
       ]
     )
   }
+
+  func testOnlyGroupTestableImportsKeepsAttributedImportsWithRegularImports() {
+    var configuration = Configuration.forTesting
+    configuration.orderedImports.onlyGroupTestableImports = true
+
+    let code = """
+      import Foundation
+      import MLX
+      @_spi(Testing) @testable import MLXLMCommon
+      import MLXNN
+      import Testing
+
+      struct Test {}
+      """
+
+    assertFormatting(
+      OrderedImports.self,
+      input: code,
+      expected: code,
+      findings: [],
+      configuration: configuration
+    )
+  }
+
+  func testOnlyGroupTestableImportsSortsAttributedImportsWithRegularImports() {
+    var configuration = Configuration.forTesting
+    configuration.orderedImports.onlyGroupTestableImports = true
+
+    assertFormatting(
+      OrderedImports.self,
+      input: """
+        @_implementationOnly import Zebras
+        1️⃣import Apples
+        @preconcurrency import Bananas
+
+        let a = 3
+        """,
+      expected: """
+        import Apples
+        @preconcurrency import Bananas
+        @_implementationOnly import Zebras
+
+        let a = 3
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "sort import statements lexicographically")
+      ],
+      configuration: configuration
+    )
+  }
+
+  func testOnlyGroupTestableImportsStillGroupsLeadingTestableImports() {
+    var configuration = Configuration.forTesting
+    configuration.orderedImports.onlyGroupTestableImports = true
+
+    assertFormatting(
+      OrderedImports.self,
+      input: """
+        @testable import Zebras
+        1️⃣import Apples
+
+        let a = 3
+        """,
+      expected: """
+        import Apples
+
+        @testable import Zebras
+
+        let a = 3
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "place regular imports before testable imports")
+      ],
+      configuration: configuration
+    )
+  }
 }


### PR DESCRIPTION
Adds an `orderedImports.onlyGroupTestableImports` configuration option that restores the import grouping behavior of swift-format 602.0.0 and earlier, as suggested by @allevato in #1242.

Fixes #1242.

### Motivation

#1013 had an unintended side effect on existing code: any import with a `@testable` attribute — even when it isn't the first attribute, e.g. `@_spi(Testing) @testable import Foo` — is now moved into the `@testable` group, and `@_implementationOnly` imports are moved into a new group of their own. This changed formatting output between 602 and 603 with no configuration escape hatch, which breaks projects that enforce formatting in CI.

### Changes

- **New option** `orderedImports.onlyGroupTestableImports` (default `false`, so the current 603 behavior is unchanged). When `true`, the pre-603 classification is used: only an import whose *first* attribute is `@testable` is placed in the `@testable` group, no separate group is created for `@_implementationOnly` imports, and imports with any other attributes are grouped and sorted together with regular imports. The legacy classification is taken verbatim from the pre-#1013 implementation.
- **Robust decoding of `OrderedImportsConfiguration`.** The struct relied on synthesized `Codable`, which throws on missing keys — so adding any new option would have broken every existing configuration file containing an `orderedImports` object (and a partial object such as `{"includeConditionalImports": true}` already failed to decode today). It now has an explicit `init(from:)` that defaults missing keys, consistent with how the top-level `Configuration` decodes.
- Documentation: rule doc comment (with `RuleDocumentation.md` regenerated via `generate-swift-format`) and `Documentation/Configuration.md`.
- Tests: the exact scenario from #1242 (file is left untouched with the option enabled), sorting of attributed imports within the regular group, leading-`@testable` imports still being grouped, and decoding of partial `orderedImports` configuration objects.

### Verification

On the reproduction from #1242, default behavior is unchanged, and with `{"orderedImports": {"onlyGroupTestableImports": true}}` the output matches 602.0.0 byte-for-byte. Full test suite passes.
