### PR TITLE
fix: handle CRLF trivia in ordered imports

### DIFF
--- a/Sources/SwiftFormat/Rules/OrderedImports.swift
+++ b/Sources/SwiftFormat/Rules/OrderedImports.swift
@@ -420,7 +420,7 @@ private func generateLines(
     for piece in block.leadingTrivia {
       switch piece {
       // Create new Line objects when we encounter newlines.
-      case .newlines(let N):
+      case .newlines(let N), .carriageReturns(let N), .carriageReturnLineFeeds(let N):
         for _ in 0..<N {
           appendNewLine()
         }

--- a/Tests/SwiftFormatTests/Rules/OrderedImportsTests.swift
+++ b/Tests/SwiftFormatTests/Rules/OrderedImportsTests.swift
@@ -541,6 +541,17 @@ final class OrderedImportsTests: LintOrFormatRuleTestCase {
     )
   }
 
+  func testImportsContainingCarriageReturnLineFeeds() {
+    assertFormatting(
+      OrderedImports.self,
+      input: "import Zeta\r\n1️⃣import Alpha\r\n\r\nfoo()",
+      expected: "import Alpha\nimport Zeta\n\nfoo()",
+      findings: [
+        FindingSpec("1️⃣", message: "sort import statements lexicographically")
+      ]
+    )
+  }
+
   func testRemovesDuplicateImports() {
     assertFormatting(
       OrderedImports.self,


### PR DESCRIPTION
Fixes #1250

`OrderedImports` only recognized `.newlines` trivia when reconstructing lines. SwiftSyntax represents Windows line endings as `.carriageReturnLineFeeds`, so CRLF separators were kept as trivia and could produce extra blank lines when imports were reordered.

This change treats LF, CR, and CRLF trivia as line boundaries and adds a regression test using CRLF input.

Tests:
- `swift test --parallel`
- `swift-format lint --strict Sources/SwiftFormat/Rules/OrderedImports.swift Tests/SwiftFormatTests/Rules/OrderedImportsTests.swift`