### PR TITLE
fix: avoid breaking after discard assignments

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -2200,7 +2200,10 @@ private final class TokenStreamCreator: SyntaxVisitor {
         // When the RHS is a simple expression, even if is requires multiple lines, we don't add a
         // group so that as much of the expression as possible can stay on the same line as the
         // operator token.
-        if isCompoundExpression(rhs) && leftmostMultilineStringLiteral(of: rhs) == nil {
+        if isCompoundExpression(rhs)
+          && leftmostMultilineStringLiteral(of: rhs) == nil
+          && !node.leftOperand.is(DiscardAssignmentExprSyntax.self)
+        {
           beforeTokens.append(.open)
           after(rhs.lastToken(viewMode: .sourceAccurate), tokens: .close)
         }

--- a/Tests/SwiftFormatTests/PrettyPrint/AssignmentExprTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/AssignmentExprTests.swift
@@ -33,6 +33,26 @@ final class AssignmentExprTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 30)
   }
 
+  func testDiscardAssignmentWithMultilineTypeCast() {
+    let input =
+      """
+      func test() {
+        _ = try! ServiceId.parseFrom(
+          serviceIdString: Self.TEST_UUID_STRING) as! Aci
+      }
+      """
+    let expected =
+      """
+      func test() {
+        _ = try! ServiceId.parseFrom(
+          serviceIdString: Self.TEST_UUID_STRING) as! Aci
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 100)
+  }
+
   func testAssignmentExprsWithGroupedOperators() {
     let input =
       """


### PR DESCRIPTION
Fixes #1033.

When a discard assignment has a compound right-hand side, the pretty printer can add an unnecessary break immediately after `_ =`. This change avoids adding that outer grouping for discard assignments while preserving the existing grouping behavior for normal assignments.

Validation:
- `swift test --parallel` (943 tests)
- `swift test --filter AssignmentExprTests`
- strict formatter lint on changed files
- `git diff --check`