### PR TITLE
Recognize CJK full stops in the non-linguistic sentence fallback

### DIFF
--- a/Sources/SwiftFormat/Rules/BeginDocumentationCommentWithOneLineSummary.swift
+++ b/Sources/SwiftFormat/Rules/BeginDocumentationCommentWithOneLineSummary.swift
@@ -184,7 +184,12 @@ public final class BeginDocumentationCommentWithOneLineSummary: SyntaxLintRule {
   /// halfwidth forms, which are the ordinary full stops in CJK text. The linguistic APIs on Apple
   /// platforms already report all of these as sentence terminators, so recognizing them here keeps
   /// the two implementations in agreement.
-  private static let fullStops: Set<Character> = ["\u{002E}", "\u{3002}", "\u{FF0E}", "\u{FF61}"]
+  private static let fullStops: Set<Character> = [
+    "\u{002E}",  // FULL STOP
+    "\u{3002}",  // IDEOGRAPHIC FULL STOP
+    "\u{FF0E}",  // FULLWIDTH FULL STOP
+    "\u{FF61}",  // HALFWIDTH IDEOGRAPHIC FULL STOP
+  ]
 
   /// Returns the best approximation of sentences in the given text using string splitting around
   /// full stops.

--- a/Sources/SwiftFormat/Rules/BeginDocumentationCommentWithOneLineSummary.swift
+++ b/Sources/SwiftFormat/Rules/BeginDocumentationCommentWithOneLineSummary.swift
@@ -178,8 +178,16 @@ public final class BeginDocumentationCommentWithOneLineSummary: SyntaxLintRule {
     #endif
   }
 
+  /// The characters that the fallback implementation treats as full stops.
+  ///
+  /// Besides the ASCII period, this contains the ideographic full stop and its fullwidth and
+  /// halfwidth forms, which are the ordinary full stops in CJK text. The linguistic APIs on Apple
+  /// platforms already report all of these as sentence terminators, so recognizing them here keeps
+  /// the two implementations in agreement.
+  private static let fullStops: Set<Character> = ["\u{002E}", "\u{3002}", "\u{FF0E}", "\u{FF61}"]
+
   /// Returns the best approximation of sentences in the given text using string splitting around
-  /// periods that are followed by spaces.
+  /// full stops.
   ///
   /// This method is a fallback for platforms (like Linux, currently) that does not
   /// support `NaturalLanguage` and its related APIs. It will fail to catch certain kinds of
@@ -190,38 +198,30 @@ public final class BeginDocumentationCommentWithOneLineSummary: SyntaxLintRule {
   ) -> (
     sentences: [String], trailingText: Substring
   ) {
-    // If we find a period followed by a space, then there is definitely one (approximate) sentence;
-    // there may be more.
-    let possiblyHasMultipleSentences = text.range(of: ". ") != nil
+    var sentences = [String]()
+    var sentenceStart = text.startIndex
+    var index = text.startIndex
 
-    // If the string does not end in a period, then the text preceding it (up until the last
-    // sentence terminator, or the beginning of the string, whichever comes first), is trailing
-    // text.
-    let hasTrailingText = !text.hasSuffix(".")
+    while index < text.endIndex {
+      let next = text.index(after: index)
+      defer { index = next }
 
-    if !possiblyHasMultipleSentences {
-      // If we didn't find a ". " sequence, then we either have trailing text (if there is no period
-      // at the end of the string) or we have a single sentence (if there is a final period).
-      if hasTrailingText {
-        return (sentences: [], trailingText: text[...])
-      } else {
-        return (sentences: [text], trailingText: "")
+      guard Self.fullStops.contains(text[index]) else { continue }
+
+      // An ASCII period only ends a sentence when it is followed by a space or by the end of the
+      // text, so that decimal points and abbreviations stay inside the sentence they belong to.
+      // The CJK full stops are not written with a following space, so they always end a sentence.
+      if text[index] == "." && next != text.endIndex && text[next] != " " {
+        continue
       }
+
+      sentences.append(String(text[sentenceStart..<next]).trimmingCharacters(in: .whitespaces))
+      sentenceStart = next
     }
 
-    // Otherwise, split the string around ". " sequences. All of these but the last one are
-    // definitely (approximate) sentences. The last one is either trailing text or another sentence,
-    // depending on whether the entire string ended with a period.
-    let splitText = text.components(separatedBy: ". ")
-    let definiteApproximateSentences = splitText.dropLast().map { "\($0)." }
-    let trailingText = splitText.last ?? ""
-    if hasTrailingText {
-      return (sentences: Array(definiteApproximateSentences), trailingText: trailingText[...])
-    } else {
-      var sentences = Array(definiteApproximateSentences)
-      sentences.append(trailingText)
-      return (sentences: sentences, trailingText: "")
-    }
+    // Anything after the last full stop was not terminated, so it is trailing text.
+    let trailingText = text[sentenceStart...].drop { $0 == " " }
+    return (sentences: sentences, trailingText: trailingText)
   }
 }
 

--- a/Tests/SwiftFormatTests/Rules/BeginDocumentationCommentWithOneLineSummaryTests.swift
+++ b/Tests/SwiftFormatTests/Rules/BeginDocumentationCommentWithOneLineSummaryTests.swift
@@ -180,6 +180,60 @@ final class BeginDocumentationCommentWithOneLineSummaryTests: LintOrFormatRuleTe
     #endif
   }
 
+  func testCJKFullStopsTerminateSentences() {
+    assertLint(
+      BeginDocumentationCommentWithOneLineSummary.self,
+      """
+      /// 何かする関数。
+      func doSomething() {}
+
+      /// 何かする関数．
+      func doSomething2() {}
+
+      /// 何かする関数｡
+      func doSomething3() {}
+
+      /// 一つ目の文。二つ目の文。
+      1️⃣func doSomething4() {}
+
+      /// 何かする関数
+      2️⃣func doSomething5() {}
+      """,
+      findings: [
+        FindingSpec("1️⃣", message: #"add a blank comment line after this sentence: "一つ目の文。""#),
+        FindingSpec("2️⃣", message: #"terminate this sentence with a period: "何かする関数""#),
+      ]
+    )
+  }
+
+  func testCJKFullStopsTerminateSentencesInFallbackMode() {
+    BeginDocumentationCommentWithOneLineSummary._forcesFallbackModeForTesting = true
+
+    assertLint(
+      BeginDocumentationCommentWithOneLineSummary.self,
+      """
+      /// 何かする関数。
+      func doSomething() {}
+
+      /// 何かする関数．
+      func doSomething2() {}
+
+      /// 何かする関数｡
+      func doSomething3() {}
+
+      /// 一つ目の文。二つ目の文。
+      1️⃣func doSomething4() {}
+
+      /// 何かする関数
+      2️⃣func doSomething5() {}
+      """,
+      findings: [
+        FindingSpec("1️⃣", message: #"add a blank comment line after this sentence: "一つ目の文。""#),
+        FindingSpec("2️⃣", message: #"terminate this sentence with a period: "何かする関数""#),
+      ]
+    )
+  }
+
   func testSentenceTerminationInsideQuotes() {
     assertLint(
       BeginDocumentationCommentWithOneLineSummary.self,


### PR DESCRIPTION
`BeginDocumentationCommentWithOneLineSummary` uses NaturalLanguage on Darwin and a period-splitting fallback everywhere else, and the fallback only understood the ASCII period. A doc summary such as `/// 何かする関数。` therefore linted clean on macOS but produced "terminate this sentence with a period" on Linux. The fallback now scans for any full stop, adding U+3002, U+FF0E, and U+FF61, which NLTagger already reports as sentence terminators, and ends a sentence at each one. An ASCII period still only ends a sentence when a space or the end of the text follows it, so decimal points and abbreviations behave exactly as before, and the CJK stops end a sentence directly because they are not written with a following space. Verified with two new tests, one per implementation, covering a single sentence, two sentences on one line, and an unterminated summary. The fallback test fails on main and passes here, and the full `BeginDocumentationCommentWithOneLineSummaryTests` suite passes.

Note that this deliberately covers only full stops. NLTagger also treats `!` and `?` as sentence terminators, but accepting those in the fallback would change what the rule asks for rather than just aligning the platforms, so I left that out.

Fixes #1237