### PR TITLE
Avoid indenting declarations after standalone modifiers

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -2140,7 +2140,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
     if node.name.tokenKind == .keyword(.async) {
       breakOrSpace = .space
     } else {
-      breakOrSpace = .break
+      breakOrSpace = .break(.same)
     }
     after(node.lastToken(viewMode: .sourceAccurate), tokens: breakOrSpace)
     return .visitChildren

--- a/Tests/SwiftFormatTests/PrettyPrint/StructDeclTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/StructDeclTests.swift
@@ -13,6 +13,27 @@
 import SwiftFormat
 
 final class StructDeclTests: PrettyPrintTestCase {
+  func testModifierOnSeparateLineDoesNotIndentDeclaration() {
+    let input =
+      """
+      nonisolated
+      struct Car {
+        let make: String
+      }
+      """
+
+    let expected =
+      """
+      nonisolated
+      struct Car {
+        let make: String
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 80)
+  }
+
   func testBasicStructDeclarations() {
     let input =
       """


### PR DESCRIPTION
Fixes #1260

## Summary

- Treat a standalone declaration modifier break like a same-level attribute break.
- Keep declarations aligned when nonisolated appears on its own line.
- Add a regression test for a wrapped nonisolated struct declaration.

## Tests

- swift build --product swift-format
- swift test --filter StructDeclTests
- swift test --filter AttributeTests
- swift test --filter FunctionDeclTests

This PR was prepared with AI assistance and the implementation and test results were reviewed locally.