### PR TITLE
Fix access levels on nested protocols

### DIFF
--- a/Documentation/RuleDocumentation.md
+++ b/Documentation/RuleDocumentation.md
@@ -239,6 +239,8 @@ Lint: Specifying an access level for an extension declaration yields a lint erro
 Format: The access level is removed from the extension declaration and is added to each
         declaration in the extension; declarations with redundant access levels (e.g.
         `internal`, as that is the default access level) have the explicit access level removed.
+        For a nested protocol, the access level is added to the protocol declaration itself and
+        not to its requirements, which implicitly have the protocol's access level.
 
 `NoAccessLevelOnExtensionDeclaration` rule can format your code automatically.
 

--- a/Sources/SwiftFormat/Core/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Core/Pipelines+Generated.swift
@@ -461,6 +461,7 @@ class LintPipeline: SyntaxVisitor {
   override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(AllPublicDeclarationsHaveDocumentation.visit, for: node)
     visitIfEnabled(BeginDocumentationCommentWithOneLineSummary.visit, for: node)
+    visitIfEnabled(NoAccessLevelOnExtensionDeclaration.visit, for: node)
     visitIfEnabled(NoLeadingUnderscores.visit, for: node)
     visitIfEnabled(TypeNamesShouldBeCapitalized.visit, for: node)
     visitIfEnabled(UseTripleSlashForDocumentationComments.visit, for: node)
@@ -469,6 +470,7 @@ class LintPipeline: SyntaxVisitor {
   override func visitPost(_ node: ProtocolDeclSyntax) {
     onVisitPost(rule: AllPublicDeclarationsHaveDocumentation.self, for: node)
     onVisitPost(rule: BeginDocumentationCommentWithOneLineSummary.self, for: node)
+    onVisitPost(rule: NoAccessLevelOnExtensionDeclaration.self, for: node)
     onVisitPost(rule: NoLeadingUnderscores.self, for: node)
     onVisitPost(rule: TypeNamesShouldBeCapitalized.self, for: node)
     onVisitPost(rule: UseTripleSlashForDocumentationComments.self, for: node)

--- a/Sources/SwiftFormat/Rules/NoAccessLevelOnExtensionDeclaration.swift
+++ b/Sources/SwiftFormat/Rules/NoAccessLevelOnExtensionDeclaration.swift
@@ -19,6 +19,8 @@ import SwiftSyntax
 /// Format: The access level is removed from the extension declaration and is added to each
 ///         declaration in the extension; declarations with redundant access levels (e.g.
 ///         `internal`, as that is the default access level) have the explicit access level removed.
+///         For a nested protocol, the access level is added to the protocol declaration itself and
+///         not to its requirements, which implicitly have the protocol's access level.
 @_spi(Rules)
 public final class NoAccessLevelOnExtensionDeclaration: SyntaxFormatRule {
   private enum State {
@@ -143,6 +145,15 @@ public final class NoAccessLevelOnExtensionDeclaration: SyntaxFormatRule {
     return applyingAccessModifierIfNone(to: node)
   }
 
+  /// Visits a nested protocol declaration.
+  ///
+  /// This override deliberately does not visit the protocol's children. A protocol's requirements
+  /// implicitly have the protocol's own access level and it is an error to state one explicitly, so
+  /// the access level must land on the protocol itself and never descend into its body.
+  public override func visit(_ node: ProtocolDeclSyntax) -> DeclSyntax {
+    return applyingAccessModifierIfNone(to: node)
+  }
+
   public override func visit(_ node: StructDeclSyntax) -> DeclSyntax {
     return applyingAccessModifierIfNone(to: node)
   }
@@ -196,6 +207,12 @@ public final class NoAccessLevelOnExtensionDeclaration: SyntaxFormatRule {
       withModifier = applyingAccessModifierIfNone(accessKeyword, to: initDecl, declKeywordKeyPath: \.initKeyword)
     case .functionDecl(let funcDecl):
       withModifier = applyingAccessModifierIfNone(accessKeyword, to: funcDecl, declKeywordKeyPath: \.funcKeyword)
+    case .protocolDecl(let protocolDecl):
+      withModifier = applyingAccessModifierIfNone(
+        accessKeyword,
+        to: protocolDecl,
+        declKeywordKeyPath: \.protocolKeyword
+      )
     case .structDecl(let structDecl):
       withModifier = applyingAccessModifierIfNone(accessKeyword, to: structDecl, declKeywordKeyPath: \.structKeyword)
     case .subscriptDecl(let subscriptDecl):

--- a/Tests/SwiftFormatTests/Rules/NoAccessLevelOnExtensionDeclarationTests.swift
+++ b/Tests/SwiftFormatTests/Rules/NoAccessLevelOnExtensionDeclarationTests.swift
@@ -560,4 +560,129 @@ final class NoAccessLevelOnExtensionDeclarationTests: LintOrFormatRuleTestCase {
       ]
     )
   }
+
+  func testNestedProtocolTakesAccessLevelInsteadOfItsRequirements() {
+    // A protocol's requirements implicitly have the protocol's access level and it is an error to
+    // state one explicitly, so the keyword has to land on the protocol itself.
+    assertFormatting(
+      NoAccessLevelOnExtensionDeclaration.self,
+      input: """
+        1️⃣public extension Namespace {
+          2️⃣protocol Boundary: Sendable {
+            associatedtype Value
+            var name: String { get }
+            func work()
+          }
+        }
+        """,
+      expected: """
+        extension Namespace {
+          public protocol Boundary: Sendable {
+            associatedtype Value
+            var name: String { get }
+            func work()
+          }
+        }
+        """,
+      findings: [
+        FindingSpec(
+          "1️⃣",
+          message: "move this 'public' access modifier to precede each member inside this extension",
+          notes: [
+            NoteSpec("2️⃣", message: "add 'public' access modifier to this declaration")
+          ]
+        )
+      ]
+    )
+  }
+
+  func testNestedProtocolWithExplicitAccessLevelIsLeftAlone() {
+    assertFormatting(
+      NoAccessLevelOnExtensionDeclaration.self,
+      input: """
+        1️⃣public extension Foo {
+          private protocol P {
+            func f()
+          }
+          2️⃣func g() {}
+        }
+        """,
+      expected: """
+        extension Foo {
+          private protocol P {
+            func f()
+          }
+          public func g() {}
+        }
+        """,
+      findings: [
+        FindingSpec(
+          "1️⃣",
+          message: "move this 'public' access modifier to precede each member inside this extension",
+          notes: [
+            NoteSpec("2️⃣", message: "add 'public' access modifier to this declaration")
+          ]
+        )
+      ]
+    )
+  }
+
+  func testNestedProtocolInPrivateExtensionBecomesFileprivate() {
+    assertFormatting(
+      NoAccessLevelOnExtensionDeclaration.self,
+      input: """
+        1️⃣private extension Foo {
+          2️⃣protocol P {
+            func f()
+          }
+        }
+        """,
+      expected: """
+        extension Foo {
+          fileprivate protocol P {
+            func f()
+          }
+        }
+        """,
+      findings: [
+        FindingSpec(
+          "1️⃣",
+          message:
+            "remove this 'private' access modifier and declare each member inside this extension as 'fileprivate'",
+          notes: [
+            NoteSpec("2️⃣", message: "add 'fileprivate' access modifier to this declaration")
+          ]
+        )
+      ]
+    )
+  }
+
+  func testSPIAttributeIsMovedToNestedProtocol() {
+    assertFormatting(
+      NoAccessLevelOnExtensionDeclaration.self,
+      input: """
+        @_spi(Something) 1️⃣public extension Foo {
+          2️⃣protocol P {
+            func f()
+          }
+        }
+        """,
+      expected: """
+        extension Foo {
+          @_spi(Something) public protocol P {
+            func f()
+          }
+        }
+        """,
+      findings: [
+        FindingSpec(
+          "1️⃣",
+          message: "move this 'public' access modifier to precede each member inside this extension",
+          notes: [
+            NoteSpec("2️⃣", message: "add 'public' access modifier to this declaration")
+          ]
+        )
+      ]
+    )
+  }
 }


### PR DESCRIPTION
Fixes #1265

## Summary
- apply extension access levels to nested protocol declarations
- avoid descending into protocol requirements, which cannot have explicit access modifiers
- regenerate the rule pipeline and documentation

## Testing
- added coverage for ordinary protocols, explicit access levels, private extensions, and `@_spi`
- `swift test --filter NoAccessLevelOnExtensionDeclarationTests` (19 tests, 0 failures)
- full suite: 948 tests passed