### PR TITLE
Keep inline code from hiding sentence boundaries in doc summaries

### DIFF
--- a/Sources/SwiftFormat/Rules/BeginDocumentationCommentWithOneLineSummary.swift
+++ b/Sources/SwiftFormat/Rules/BeginDocumentationCommentWithOneLineSummary.swift
@@ -92,19 +92,19 @@ public final class BeginDocumentationCommentWithOneLineSummary: SyntaxLintRule {
 
   /// Diagnose documentation comments that don't start with one sentence summary.
   private func diagnoseDocComments(in decl: DeclSyntax) {
-    // Extract the summary from a documentation comment, if it exists, and strip
-    // out any inline code segments (which shouldn't be considered when looking
-    // for the end of a sentence).
-    var inlineCodeRemover = InlineCodeRemover()
+    // Extract the summary from a documentation comment, if it exists, and neutralize any inline
+    // code segments, whose punctuation shouldn't be considered when looking for the end of a
+    // sentence.
+    var inlineCodeSanitizer = InlineCodeSanitizer()
     guard
       let docComment = DocumentationComment(extractedFrom: decl),
       let briefSummary = docComment.briefSummary,
-      let noInlineCodeSummary = inlineCodeRemover.visit(briefSummary) as? Paragraph
+      let sanitizedSummary = inlineCodeSanitizer.visit(briefSummary) as? Paragraph
     else { return }
 
     // For the purposes of checking the sentence structure of the comment, we can operate on the
     // plain text; we don't need any of the styling.
-    let trimmedText = noInlineCodeSummary.plainText
+    let trimmedText = sanitizedSummary.plainText
       .trimmingCharacters(in: .whitespacesAndNewlines)
     let (commentSentences, trailingText) = sentences(in: trimmedText)
     if commentSentences.count == 0 {
@@ -184,7 +184,7 @@ public final class BeginDocumentationCommentWithOneLineSummary: SyntaxLintRule {
   /// halfwidth forms, which are the ordinary full stops in CJK text. The linguistic APIs on Apple
   /// platforms already report all of these as sentence terminators, so recognizing them here keeps
   /// the two implementations in agreement.
-  private static let fullStops: Set<Character> = [
+  fileprivate static let fullStops: Set<Character> = [
     "\u{002E}",  // FULL STOP
     "\u{3002}",  // IDEOGRAPHIC FULL STOP
     "\u{FF0E}",  // FULLWIDTH FULL STOP
@@ -244,8 +244,32 @@ extension Finding.Message {
   }
 }
 
-struct InlineCodeRemover: MarkupRewriter {
+/// Replaces each inline code segment with its text, minus the characters that would otherwise
+/// steer sentence segmentation.
+///
+/// A code segment is written as code, not as prose, so punctuation like the period in
+/// `x.kind` must not terminate a sentence. Dropping the segment altogether would do that too, but
+/// it also joins the words around it, which hides a real sentence boundary from the segmenter when
+/// a sentence begins with a code segment.
+struct InlineCodeSanitizer: MarkupRewriter {
+  /// The characters that are removed from an inline code segment.
+  ///
+  /// Besides the sentence terminators themselves, this contains the quotation marks that the
+  /// linguistic tagger pairs up: an unbalanced quotation mark inside a code segment would make it
+  /// treat the rest of the summary as quoted text and swallow the terminators in it.
+  private static let charactersToRemove: Set<Character> =
+    BeginDocumentationCommentWithOneLineSummary.fullStops.union([
+      "!",
+      "?",
+      "\"",
+      "'",
+      "\u{2018}",  // LEFT SINGLE QUOTATION MARK
+      "\u{2019}",  // RIGHT SINGLE QUOTATION MARK
+      "\u{201C}",  // LEFT DOUBLE QUOTATION MARK
+      "\u{201D}",  // RIGHT DOUBLE QUOTATION MARK
+    ])
+
   mutating func visitInlineCode(_ inlineCode: InlineCode) -> Markup? {
-    nil
+    Text(inlineCode.code.filter { !Self.charactersToRemove.contains($0) })
   }
 }

--- a/Tests/SwiftFormatTests/Rules/BeginDocumentationCommentWithOneLineSummaryTests.swift
+++ b/Tests/SwiftFormatTests/Rules/BeginDocumentationCommentWithOneLineSummaryTests.swift
@@ -234,6 +234,56 @@ final class BeginDocumentationCommentWithOneLineSummaryTests: LintOrFormatRuleTe
     )
   }
 
+  func testInlineCodeDoesNotHideSentenceBoundaries() {
+    assertLint(
+      BeginDocumentationCommentWithOneLineSummary.self,
+      """
+      /// Held in the keychain. `Keychain` is immutable.
+      1️⃣struct CodeSpanStartsSecondSentence {}
+
+      /// Alpha `beta`. Gamma delta.
+      2️⃣struct CodeSpanInsideFirstSentence {}
+
+      /// Pass `"` to escape the delimiter. Callers must balance it.
+      3️⃣struct UnbalancedQuoteInsideCodeSpan {}
+
+      /// Uses `x.kind != Subject.kind` to compare two instances.
+      struct PunctuationStaysInsideCodeSpan {}
+      """,
+      findings: [
+        FindingSpec("1️⃣", message: #"add a blank comment line after this sentence: "Held in the keychain.""#),
+        FindingSpec("2️⃣", message: #"add a blank comment line after this sentence: "Alpha beta.""#),
+        FindingSpec("3️⃣", message: #"add a blank comment line after this sentence: "Pass  to escape the delimiter.""#),
+      ]
+    )
+  }
+
+  func testInlineCodeDoesNotHideSentenceBoundariesInFallbackMode() {
+    BeginDocumentationCommentWithOneLineSummary._forcesFallbackModeForTesting = true
+
+    assertLint(
+      BeginDocumentationCommentWithOneLineSummary.self,
+      """
+      /// Held in the keychain. `Keychain` is immutable.
+      1️⃣struct CodeSpanStartsSecondSentence {}
+
+      /// Alpha `beta`. Gamma delta.
+      2️⃣struct CodeSpanInsideFirstSentence {}
+
+      /// Pass `"` to escape the delimiter. Callers must balance it.
+      3️⃣struct UnbalancedQuoteInsideCodeSpan {}
+
+      /// Uses `x.kind != Subject.kind` to compare two instances.
+      struct PunctuationStaysInsideCodeSpan {}
+      """,
+      findings: [
+        FindingSpec("1️⃣", message: #"add a blank comment line after this sentence: "Held in the keychain.""#),
+        FindingSpec("2️⃣", message: #"add a blank comment line after this sentence: "Alpha beta.""#),
+        FindingSpec("3️⃣", message: #"add a blank comment line after this sentence: "Pass  to escape the delimiter.""#),
+      ]
+    )
+  }
+
   func testSentenceTerminationInsideQuotes() {
     assertLint(
       BeginDocumentationCommentWithOneLineSummary.self,


### PR DESCRIPTION
Fixes #1268.

`BeginDocumentationCommentWithOneLineSummary` deletes every inline code segment from the brief summary before splitting it into sentences, so that punctuation inside a segment cannot terminate one (#669). Deleting the segment also joins the words around it, though:

```swift
/// Held in the keychain. `Keychain` is immutable.
struct CodeSpanStartsSecondSentence {}
```

The summary becomes `Held in the keychain.  is immutable.` Its second sentence now starts with a lowercase word, `NLTagger` reports the text as a single sentence, and the two-sentence summary goes undiagnosed — while the same summary written without the backticks is diagnosed. Where a summary is still diagnosed, the reported sentence has the segments cut out of it: a summary of ``Alpha `beta`. Gamma delta.``  is reported as `"Alpha ."`.

This replaces each segment with its own text instead, minus the characters that steer sentence segmentation: the full stops, `!`, `?`, and the quotation marks that the tagger pairs up. An unbalanced quotation mark inside a segment would otherwise make the tagger treat the rest of the summary as quoted text and swallow the terminators in it — that case is covered by a test. Punctuation inside a segment still cannot end a sentence (the `x.kind != Subject.kind` case from #669 stays undiagnosed), the words around a segment stay separated, and a reported sentence now keeps the segment's text.

Tested on macOS (the `NLTagger` path) and in the forced fallback mode used on other platforms; both are covered by new tests, since the two paths disagreed on this input before the fix. Full suite: 950 XCTest (1 skipped) + 64 swift-testing, all passing.
