### PR TITLE
Fix trailing comma line-length calculation

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
@@ -586,6 +586,9 @@ public class PrettyPrinter {
   public func prettyPrint() -> String {
     // Keep track of the indices of the .open and .break token locations.
     var delimIndexStack = [Int]()
+    // Keep track of the delimiter stack at the start of each comma-delimited region. Delimiters
+    // that remain active through the end of a region decide whether that region becomes multiline.
+    var commaDelimitedRegionDelimiterStack = [[Int]]()
     // Keep a running total of the token lengths.
     var total = 0
 
@@ -700,17 +703,24 @@ public class PrettyPrinter {
 
       case .commaDelimitedRegionStart:
         lengths.append(0)
+        commaDelimitedRegionDelimiterStack.append(delimIndexStack)
 
       case .commaDelimitedRegionEnd(let isCollection, _, let isSingleElement):
-        // The token's length is only necessary when a comma will be printed, but it's impossible to
-        // know at this point whether the region-start token will be on the same line as this token.
-        // Without adding this length to the total, it would be possible for this comma to be
-        // printed in column `maxLineLength`. Unfortunately, this can cause breaks to fire
-        // unnecessarily when the enclosed tokens comma would fit within `maxLineLength`.
-        if shouldHandleCommaDelimitedRegion(isCollection: isCollection) == true {
-          let length = isSingleElement ? 0 : 1
-          total += length
-          lengths.append(length)
+        guard let delimiterIndicesAtStart = commaDelimitedRegionDelimiterStack.popLast() else {
+          fatalError("Found trailing comma end with no corresponding start.")
+        }
+
+        // A trailing comma is only inserted if the region breaks across multiple lines. Exclude its
+        // width from delimiters that enclose the entire region so it cannot cause that first break,
+        // while retaining the width in nested break lengths that must reserve space once the region
+        // is multiline.
+        if shouldHandleCommaDelimitedRegion(isCollection: isCollection) == true && !isSingleElement {
+          for (startIndex, endIndex) in zip(delimiterIndicesAtStart, delimIndexStack) {
+            guard startIndex == endIndex else { break }
+            lengths[startIndex] -= 1
+          }
+          total += 1
+          lengths.append(1)
         } else {
           lengths.append(0)
         }

--- a/Tests/SwiftFormatTests/PrettyPrint/ArrayDeclTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/ArrayDeclTests.swift
@@ -64,17 +64,9 @@ final class ArrayDeclTests: PrettyPrintTestCase {
         "One", "Two", "Three", "Four", "Five",
         "Six", "Seven", "Eight",
       ]
+      let a = [11111111, 2222222, 33333333, 444444]
 
       """
-        // Ideally, this array would be left on 1 line without a trailing comma. We don't know if the
-        // comma is required when calculating the length of array elements, so the comma's length is
-        // always added to last element and that 1 character causes the newlines inside of the array.
-        + """
-        let a = [
-          11111111, 2222222, 33333333, 444444,
-        ]
-
-        """
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
   }
@@ -288,17 +280,9 @@ final class ArrayDeclTests: PrettyPrintTestCase {
         ("this", "str"),
         ("is", "lng"),
       ]
+      a = [("az", "by"), ("cf", "de")]
 
       """
-        // Ideally, this array would be left on 1 line without a trailing comma. We don't know if the
-        // comma is required when calculating the length of array elements, so the comma's length is
-        // always added to last element and that 1 character causes the newlines inside of the array.
-        + """
-        a = [
-          ("az", "by"), ("cf", "de"),
-        ]
-
-        """
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 32)
   }

--- a/Tests/SwiftFormatTests/PrettyPrint/CommaTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/CommaTests.swift
@@ -1139,6 +1139,48 @@ final class CommaTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: configuration)
   }
 
+  func testMultilineTrailingCommaBehaviorDoesNotAffectLineLength() {
+    let input =
+      """
+      f(0, 0)
+
+      """
+
+    let expected = input
+
+    var configuration = Configuration.forTesting
+    configuration.multilineTrailingCommaBehavior = .alwaysUsed
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 7, configuration: configuration)
+
+    configuration.multilineTrailingCommaBehavior = .neverUsed
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 7, configuration: configuration)
+
+    configuration.multilineTrailingCommaBehavior = .keptAsWritten
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 7, configuration: configuration)
+  }
+
+  func testInsertedTrailingCommaIsIncludedInBrokenLineLength() {
+    let input =
+      """
+      f(0, foo.bar)
+
+      """
+
+    let expected =
+      """
+      f(
+        0,
+        foo
+          .bar,
+      )
+
+      """
+
+    var configuration = Configuration.forTesting
+    configuration.multilineTrailingCommaBehavior = .alwaysUsed
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 9, configuration: configuration)
+  }
+
   func testAlwaysMultilineTrailingCommaBehaviorOverridesMultiElementCollectionTrailingCommas() {
     let input =
       """

--- a/Tests/SwiftFormatTests/PrettyPrint/DictionaryDeclTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/DictionaryDeclTests.swift
@@ -69,18 +69,9 @@ final class DictionaryDeclTests: PrettyPrintTestCase {
         1: "a", 2: "b", 3: "c", 4: "d", 5: "e", 6: "f",
         7: "g", 8: "i",
       ]
+      let a = [10000: "abc", 20000: "def", 30000: "ghi"]
 
       """
-        // Ideally, this dictionary would be left on 1 line without a trailing comma. We don't know if
-        // the comma is required when calculating the length of elements, so the comma's length is
-        // always added to last element and that 1 character causes the newlines inside of the
-        // dictionary.
-        + """
-        let a = [
-          10000: "abc", 20000: "def", 30000: "ghi",
-        ]
-
-        """
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
   }
@@ -287,18 +278,9 @@ final class DictionaryDeclTests: PrettyPrintTestCase {
         key1: ("ab", "z"),
         key2: ("b ", "y"),
       ]
+      a = [k1: ("ab", "z"), k2: ("bc", "y")]
 
       """
-        // Ideally, this dictionary would be left on 1 line without a trailing comma. We don't know if
-        // the comma is required when calculating the length of elements, so the comma's length is
-        // always added to last element and that 1 character causes the newlines inside of the
-        // dictionary.
-        + """
-        a = [
-          k1: ("ab", "z"), k2: ("bc", "y"),
-        ]
-
-        """
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 38)
   }


### PR DESCRIPTION
## Summary

- exclude a conditional trailing comma from the delimiter lengths that decide whether its region becomes multiline
- retain the comma width in nested break lengths so an inserted comma cannot exceed `lineLength`
- cover exact-limit behavior across trailing-comma configurations and update existing exact-fit collection expectations

## Testing

- `swift test --parallel` (950 XCTest tests and 64 Swift Testing tests passed)
- `swift test --filter 'CommaTests|ArrayDeclTests/testBasicArrays|ArrayDeclTests/testInnerElementBreakingFromComma|DictionaryDeclTests/testBasicDictionaries|DictionaryDeclTests/testInnerElementBreakingFromComma|FunctionCallTests/testSingleUnlabeledArgumentWithDelimiters'`
- `swift-format lint --strict` on all four changed files
- original issue reproduction linted with no warnings using `lineLength: 120` and `multilineTrailingCommaBehavior: alwaysUsed`

Fixes #1219
