### PR TITLE
Fix cmake-smoke-test on Linux noble (CMake 3.29 required)

### DIFF
--- a/.github/scripts/prebuild.sh
+++ b/.github/scripts/prebuild.sh
@@ -41,7 +41,19 @@ elif command -v apt-get >/dev/null 2>&1 ; then # bookworm, noble, jammy
     apt-get install -y libc6-dbg
 
     if [[ "$INSTALL_CMAKE" == "1" ]] ; then
-        apt-get install -y cmake ninja-build
+        mkdir -p "$RUNNER_TOOL_CACHE"
+        if ! command -v cmake >/dev/null 2>&1 ; then
+            curl -fsSLO https://github.com/Kitware/CMake/releases/download/v4.1.2/cmake-4.1.2-linux-x86_64.tar.gz
+            echo '773cc679c3a7395413bd096523f8e5d6c39f8718af4e12eb4e4195f72f35e4ab cmake-4.1.2-linux-x86_64.tar.gz' > cmake-4.1.2-linux-x86_64.tar.gz.sha256
+            sha256sum -c cmake-4.1.2-linux-x86_64.tar.gz.sha256
+            tar -xf cmake-4.1.2-linux-x86_64.tar.gz
+            ln -s "$PWD/cmake-4.1.2-linux-x86_64/bin/cmake" "$RUNNER_TOOL_CACHE/cmake"
+            ln -s "$PWD/cmake-4.1.2-linux-x86_64/bin/ctest" "$RUNNER_TOOL_CACHE/ctest"
+            ln -s "$PWD/cmake-4.1.2-linux-x86_64/bin/cpack" "$RUNNER_TOOL_CACHE/cpack"
+        fi
+        if ! command -v ninja >/dev/null 2>&1 ; then
+            apt-get install -y ninja-build
+        fi
     fi
 elif command -v dnf >/dev/null 2>&1 ; then # rhel-ubi9
     dnf update -y


### PR DESCRIPTION
Fixes #1267

### Problem

`swift-syntax` bumped the minimum CMake to 3.29 (swiftlang/swift-syntax#3321) and `swift-format`'s `CMakeLists.txt` now requires it, but the Linux `noble` runner still installs the distro's 3.28.3 via `apt-get install -y cmake` in `.github/scripts/prebuild.sh`. The `cmake-smoke-test / Linux (nightly-main - noble - x86_64)` job fails with:

```
CMake Error: CMake 3.29 or higher is required.  You are running version 3.28.3
```

### Change

On Ubuntu (`apt-get` hosts), install CMake 4.1.2 from Kitware's binary tarball when `INSTALL_CMAKE=1`, mirroring the existing macOS logic (which already downloads 4.1.2). The tarball is verified via SHA256 and linked into `$RUNNER_TOOL_CACHE` so `cmake`/`ctest`/`cpack` are found. `ninja-build` continues to be installed via `apt`.

### Validation

- `bash -n .github/scripts/prebuild.sh` passes
- Change is isolated to the `INSTALL_CMAKE` block; the `cmake-smoke-test.sh` invocation is unchanged and will now find CMake 4.1.2 on `noble`
