### PR TITLE
Add BlankLinePolicy rule for configurable blank line enforcement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .build/
+.build-*/
 .swiftpm/
 swift-format.xcodeproj/
 Package.resolved

--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -310,6 +310,42 @@ too long.
 
 ---
 
+### `blankLinePolicy`
+**type:** object
+
+**description:** Configuration for the `BlankLinePolicy` rule, which governs where blank lines are required, forbidden, or left to the author's discretion. Each axis accepts the primitive values `"none"` (blank lines are forbidden and will be removed), `"exactlyOne"` (exactly one blank line is required; it will be inserted if missing and extras removed), and `"optional"` (the author may choose zero or one; the formatter does nothing), unless its bullet below lists a different set; the axes that describe gaps rather than separations (`scopeEdges`, `afterCaseLabel`, `attributes`, `expressions`, `conditionalCompilationEdges`, and `beforeElse`) only accept `"none"` and `"optional"`. Blank lines inside multi-line string literals and comments are content and are never modified.
+
+- `betweenDeclarations` _(string)_: Between top-level declarations (and between the declarations inside a top-level conditional compilation block). In addition to the primitive values, accepts `"scopeSeparated"`: exactly one blank line between scope-like declarations and at kind transitions, and `"optional"` between list-like declarations of the same kind (for example consecutive imports).
+- `scopeEdges` _(string)_: Directly after an opening brace and directly before a closing brace. Set `"none"` to enforce brace edges here instead of via the overlapping `NoEmptyLinesOpeningClosingBraces` rule.
+- `members` _(string)_: Between members of a type, extension, or protocol, including within `#if` regions. In addition to the primitive values, accepts `"scopeSeparated"`: exactly one blank line between scope-like members (functions, initializers, computed properties, nested types) and at kind transitions, and `optional` between list-like members (stored properties, enum cases, typealiases).
+- `marks` _(object)_: Blank lines around `// MARK:` comments, with `before` and `after` sub-values. A MARK comment takes precedence over the policy of the boundary it appears at.
+- `switchCases` _(string)_: Between the cases of a `switch` statement. In addition to the primitive values, accepts `"auto"`: exactly one blank line between adjacent cases when either case is multiline, and `"none"` between adjacent single-line cases.
+- `afterCaseLabel` _(string)_: Between a `case` label and its first statement.
+- `attributes` _(string)_: Between adjacent attributes and between an attribute list and the declaration it annotates.
+- `expressions` _(string)_: Between the elements of multiline argument lists (including tuples) and collection literals.
+- `conditionalCompilationEdges` _(string)_: Directly after a `#if`/`#elseif`/`#else` directive and directly before `#endif`.
+- `guardPrologue` _(string)_: Around leading `guard` statements in the body of a function, closure, or other braced statement. Accepts `"separated"` (consecutive leading guards are kept tight and exactly one blank line follows the final leading guard) or `"optional"`.
+- `beforeElse` _(string)_: Between `}` and a following `else` or `catch` keyword.
+
+**default:**
+```javascript
+{
+    "betweenDeclarations": "scopeSeparated",
+    "scopeEdges": "optional",
+    "members": "scopeSeparated",
+    "marks": { "before": "exactlyOne", "after": "none" },
+    "switchCases": "auto",
+    "afterCaseLabel": "none",
+    "attributes": "none",
+    "expressions": "none",
+    "conditionalCompilationEdges": "none",
+    "guardPrologue": "separated",
+    "beforeElse": "none"
+}
+```
+
+---
+
 > TODO: Add support for enabling/disabling specific syntax transformations in
 > the pipeline.
 

--- a/Documentation/RuleDocumentation.md
+++ b/Documentation/RuleDocumentation.md
@@ -16,6 +16,7 @@ Here's the list of available rules:
 - [AmbiguousTrailingClosureOverload](#AmbiguousTrailingClosureOverload)
 - [AvoidRetroactiveConformances](#AvoidRetroactiveConformances)
 - [BeginDocumentationCommentWithOneLineSummary](#BeginDocumentationCommentWithOneLineSummary)
+- [BlankLinePolicy](#BlankLinePolicy)
 - [DoNotUseSemicolons](#DoNotUseSemicolons)
 - [DontRepeatTypeInStaticProperties](#DontRepeatTypeInStaticProperties)
 - [FileScopedDeclarationPrivacy](#FileScopedDeclarationPrivacy)
@@ -115,6 +116,36 @@ All documentation comments must begin with a one-line summary of the declaration
 Lint: If a comment does not begin with a single-line summary, a lint error is raised.
 
 `BeginDocumentationCommentWithOneLineSummary` is a linter-only rule.
+
+### BlankLinePolicy
+
+Enforces a configurable policy for blank lines at the significant syntactic boundaries of a
+source file.
+
+The policy is expressed through the `blankLinePolicy` configuration object. Each of its axes
+covers one kind of boundary and accepts the primitive values `none` (blank lines are
+forbidden), `exactlyOne` (exactly one blank line is required), and `optional` (the author may
+choose zero or one), along with a few named expansions of those primitives:
+
+  - `betweenDeclarations: "scopeSeparated"` and `members: "scopeSeparated"` apply
+    `exactlyOne` between scope-like declarations (functions, initializers, computed
+    properties, nested types) and at kind transitions, and `optional` between list-like
+    declarations of the same kind (stored properties, enum cases, typealiases, imports).
+  - `switchCases: "auto"` applies `exactlyOne` between adjacent cases when either case is
+    multiline and `none` between adjacent single-line cases.
+  - `guardPrologue: "separated"` keeps consecutive leading guard statements tight and applies
+    `exactlyOne` after the final leading guard statement.
+
+Blank lines inside multi-line string literals and comments are content and are never
+modified. The `scopeEdges` axis generalizes the `NoEmptyLinesOpeningClosingBraces` rule; it
+defaults to `optional` so that enabling both does not produce duplicate findings.
+
+Lint: Blank lines that violate the configured policy yield a lint error.
+
+Format: Blank lines that violate the configured policy are removed, and required blank lines
+are inserted.
+
+`BlankLinePolicy` rule can format your code automatically.
 
 ### DoNotUseSemicolons
 

--- a/Sources/SwiftFormat/API/Configuration+Default.swift
+++ b/Sources/SwiftFormat/API/Configuration+Default.swift
@@ -45,5 +45,6 @@ extension Configuration {
     self.indentBlankLines = false
     self.orderedImports = OrderedImportsConfiguration()
     self.swiftTestingNamingConventions = SwiftTestingNamingConventionsConfiguration()
+    self.blankLinePolicy = BlankLinePolicyConfiguration()
   }
 }

--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -50,6 +50,7 @@ public struct Configuration: Codable, Equatable {
     case indentBlankLines
     case orderedImports
     case swiftTestingNamingConventions
+    case blankLinePolicy
   }
 
   /// A dictionary containing the default enabled/disabled states of rules, keyed by the rules'
@@ -311,6 +312,10 @@ public struct Configuration: Codable, Equatable {
   /// Configuration for the `SwiftTestingNamingConventions` rule.
   public var swiftTestingNamingConventions: SwiftTestingNamingConventionsConfiguration
 
+  /// Configuration for the `BlankLinePolicy` rule, which governs where blank lines are required,
+  /// forbidden, or left to the author's discretion.
+  public var blankLinePolicy: BlankLinePolicyConfiguration
+
   /// Creates a new `Configuration` by loading it from a configuration file.
   public init(contentsOf url: URL) throws {
     let data = try Data(contentsOf: url)
@@ -467,6 +472,13 @@ public struct Configuration: Codable, Equatable {
       )
       ?? defaults.swiftTestingNamingConventions
 
+    self.blankLinePolicy =
+      try container.decodeIfPresent(
+        BlankLinePolicyConfiguration.self,
+        forKey: .blankLinePolicy
+      )
+      ?? defaults.blankLinePolicy
+
     // If the `rules` key is not present at all, default it to the built-in set
     // so that the behavior is the same as if the configuration had been
     // default-initialized. To get an empty rules dictionary, one can explicitly
@@ -509,6 +521,7 @@ public struct Configuration: Codable, Equatable {
     try container.encode(indentBlankLines, forKey: .indentBlankLines)
     try container.encode(orderedImports, forKey: .orderedImports)
     try container.encode(swiftTestingNamingConventions, forKey: .swiftTestingNamingConventions)
+    try container.encode(blankLinePolicy, forKey: .blankLinePolicy)
     try container.encode(rules, forKey: .rules)
   }
 
@@ -601,4 +614,217 @@ public struct SwiftTestingNamingConventionsConfiguration: Codable, Equatable {
   public var requireRawIdentifierTestNames = false
 
   public init() {}
+}
+
+/// The primitive policies that can be applied to blank lines at a syntactic boundary.
+///
+/// Every other policy in `BlankLinePolicyConfiguration` is one of these primitives or a named
+/// expansion that picks between them per boundary.
+public enum BlankLinePolicyValue: String, Codable, Equatable {
+  /// Blank lines are forbidden at this boundary; any that exist will be removed.
+  case none
+  /// Exactly one blank line is required at this boundary; it will be inserted if missing and any
+  /// extra blank lines will be removed.
+  case exactlyOne
+  /// The author may choose to have zero or one blank line at this boundary; the formatter will
+  /// neither insert nor remove one. The global `maximumBlankLines` limit still applies.
+  case optional
+}
+
+/// The policy for blank lines between the members of a type, extension, or protocol, and
+/// between top-level declarations.
+public enum DeclarationBlankLinePolicy: String, Codable, Equatable {
+  /// An expansion of the primitive values applied per-boundary: exactly one blank line is
+  /// required between scope-like declarations (functions, initializers, computed properties,
+  /// nested types) and at kind transitions, while list-like declarations of the same kind
+  /// (stored properties, enum cases, typealiases, imports) may be grouped with or without blank
+  /// lines.
+  case scopeSeparated
+  /// Blank lines between the declarations are forbidden.
+  case none
+  /// Exactly one blank line is required between all declarations.
+  case exactlyOne
+  /// The author chooses where blank lines go.
+  case optional
+}
+
+/// The policy for blank lines between the cases of a `switch` statement.
+public enum SwitchCaseBlankLinePolicy: String, Codable, Equatable {
+  /// An expansion of the primitive values applied per-boundary: exactly one blank line is
+  /// required between adjacent cases when either case is multiline, and blank lines are
+  /// forbidden between adjacent single-line cases.
+  case auto
+  /// Blank lines between cases are forbidden.
+  case none
+  /// Exactly one blank line is required between all cases.
+  case exactlyOne
+  /// The author chooses where blank lines go between cases.
+  case optional
+}
+
+/// The policy for blank lines around leading `guard` statements in the body of a function,
+  /// closure, or other braced statement.
+public enum GuardPrologueBlankLinePolicy: String, Codable, Equatable {
+  /// An expansion of the primitive values: consecutive leading guard statements are kept tight
+  /// (no blank lines between them) and exactly one blank line separates the final leading guard
+  /// from the rest of the body.
+  case separated
+  /// The author chooses where blank lines go around guard statements.
+  case optional
+}
+
+/// The policy for blank lines around `// MARK:` comments. A MARK comment takes precedence over
+/// the policy of the boundary it appears at.
+public struct MarkBlankLinePolicy: Codable, Equatable {
+  public enum CodingKeys: CodingKey {
+    case before
+    case after
+  }
+
+  /// The policy for blank lines before a `// MARK:` comment.
+  public var before: BlankLinePolicyValue = .exactlyOne
+
+  /// The policy for blank lines between a `// MARK:` comment and the declaration or member that
+  /// follows it.
+  public var after: BlankLinePolicyValue = .none
+
+  public init() {}
+
+  public init(before: BlankLinePolicyValue, after: BlankLinePolicyValue) {
+    self.before = before
+    self.after = after
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let defaults = MarkBlankLinePolicy()
+    self.before =
+      try container.decodeIfPresent(BlankLinePolicyValue.self, forKey: .before) ?? defaults.before
+    self.after =
+      try container.decodeIfPresent(BlankLinePolicyValue.self, forKey: .after) ?? defaults.after
+  }
+}
+
+/// Configuration for the `BlankLinePolicy` rule.
+///
+/// Each axis governs blank lines at one kind of syntactic boundary; most accept the primitive
+/// values `none`, `exactlyOne`, and `optional` (see `BlankLinePolicyValue`). Axes that describe
+/// gaps rather than separations (`scopeEdges`, `afterCaseLabel`, `attributes`, `expressions`,
+/// `conditionalCompilationEdges`, and `beforeElse`) only accept `none` and `optional`.
+///
+/// Blank lines inside multi-line string literals and comments are content and are never
+/// modified.
+public struct BlankLinePolicyConfiguration: Codable, Equatable {
+  public enum CodingKeys: CodingKey {
+    case betweenDeclarations
+    case scopeEdges
+    case members
+    case marks
+    case switchCases
+    case afterCaseLabel
+    case attributes
+    case expressions
+    case conditionalCompilationEdges
+    case guardPrologue
+    case beforeElse
+  }
+
+  /// The policy for blank lines between top-level declarations (and between the declarations
+  /// inside a top-level conditional compilation block).
+  public var betweenDeclarations: DeclarationBlankLinePolicy = .scopeSeparated
+
+  /// The policy for blank lines directly after an opening brace and directly before a closing
+  /// brace. Defaults to `optional` so that enabling the overlapping
+  /// `NoEmptyLinesOpeningClosingBraces` rule as well does not produce duplicate findings.
+  public var scopeEdges: BlankLinePolicyValue = .optional
+
+  /// The policy for blank lines between members of a type, extension, or protocol, including
+  /// within `#if` regions.
+  public var members: DeclarationBlankLinePolicy = .scopeSeparated
+
+  /// The policy for blank lines around `// MARK:` comments.
+  public var marks: MarkBlankLinePolicy = MarkBlankLinePolicy()
+
+  /// The policy for blank lines between the cases of a `switch` statement.
+  public var switchCases: SwitchCaseBlankLinePolicy = .auto
+
+  /// The policy for blank lines between a `case` label and its first statement.
+  public var afterCaseLabel: BlankLinePolicyValue = .none
+
+  /// The policy for blank lines between adjacent attributes and between an attribute list and
+  /// the declaration it annotates.
+  public var attributes: BlankLinePolicyValue = .none
+
+  /// The policy for blank lines between the elements of multiline argument lists (including
+  /// tuples) and collection literals.
+  public var expressions: BlankLinePolicyValue = .none
+
+  /// The policy for blank lines directly after a `#if`/`#elseif`/`#else` directive and directly
+  /// before `#endif`.
+  public var conditionalCompilationEdges: BlankLinePolicyValue = .none
+
+  /// The policy for blank lines around leading `guard` statements in the body of a function,
+  /// closure, or other braced statement.
+  public var guardPrologue: GuardPrologueBlankLinePolicy = .separated
+
+  /// The policy for blank lines between `}` and a following `else` or `catch` keyword.
+  public var beforeElse: BlankLinePolicyValue = .none
+
+  public init() {}
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let defaults = BlankLinePolicyConfiguration()
+    self.betweenDeclarations =
+      try container.decodeIfPresent(DeclarationBlankLinePolicy.self, forKey: .betweenDeclarations)
+      ?? defaults.betweenDeclarations
+    self.scopeEdges =
+      try container.decodeIfPresent(BlankLinePolicyValue.self, forKey: .scopeEdges)
+      ?? defaults.scopeEdges
+    self.members =
+      try container.decodeIfPresent(DeclarationBlankLinePolicy.self, forKey: .members)
+      ?? defaults.members
+    self.marks =
+      try container.decodeIfPresent(MarkBlankLinePolicy.self, forKey: .marks) ?? defaults.marks
+    self.switchCases =
+      try container.decodeIfPresent(SwitchCaseBlankLinePolicy.self, forKey: .switchCases)
+      ?? defaults.switchCases
+    self.afterCaseLabel =
+      try container.decodeIfPresent(BlankLinePolicyValue.self, forKey: .afterCaseLabel)
+      ?? defaults.afterCaseLabel
+    self.attributes =
+      try container.decodeIfPresent(BlankLinePolicyValue.self, forKey: .attributes)
+      ?? defaults.attributes
+    self.expressions =
+      try container.decodeIfPresent(BlankLinePolicyValue.self, forKey: .expressions)
+      ?? defaults.expressions
+    self.conditionalCompilationEdges =
+      try container.decodeIfPresent(BlankLinePolicyValue.self, forKey: .conditionalCompilationEdges)
+      ?? defaults.conditionalCompilationEdges
+    self.guardPrologue =
+      try container.decodeIfPresent(GuardPrologueBlankLinePolicy.self, forKey: .guardPrologue)
+      ?? defaults.guardPrologue
+    self.beforeElse =
+      try container.decodeIfPresent(BlankLinePolicyValue.self, forKey: .beforeElse)
+      ?? defaults.beforeElse
+
+    // Axes that describe gaps rather than separations cannot meaningfully require a blank line.
+    let gapAxes: [(key: CodingKeys, value: BlankLinePolicyValue)] = [
+      (.scopeEdges, scopeEdges),
+      (.afterCaseLabel, afterCaseLabel),
+      (.attributes, attributes),
+      (.expressions, expressions),
+      (.conditionalCompilationEdges, conditionalCompilationEdges),
+      (.beforeElse, beforeElse),
+    ]
+    for (key, value) in gapAxes where value == .exactlyOne {
+      throw DecodingError.dataCorrupted(
+        .init(
+          codingPath: container.codingPath + [key],
+          debugDescription:
+            "'\(key.stringValue)' cannot be 'exactlyOne'; it accepts 'none' or 'optional'."
+        )
+      )
+    }
+  }
 }

--- a/Sources/SwiftFormat/Core/Pipelines+Generated.swift
+++ b/Sources/SwiftFormat/Core/Pipelines+Generated.swift
@@ -487,6 +487,7 @@ class LintPipeline: SyntaxVisitor {
   override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
     visitIfEnabled(AlwaysUseLowerCamelCase.visit, for: node)
     visitIfEnabled(AmbiguousTrailingClosureOverload.visit, for: node)
+    visitIfEnabled(BlankLinePolicy.visit, for: node)
     visitIfEnabled(FileScopedDeclarationPrivacy.visit, for: node)
     visitIfEnabled(NeverForceUnwrap.visit, for: node)
     visitIfEnabled(NeverUseForceTry.visit, for: node)
@@ -497,6 +498,7 @@ class LintPipeline: SyntaxVisitor {
   override func visitPost(_ node: SourceFileSyntax) {
     onVisitPost(rule: AlwaysUseLowerCamelCase.self, for: node)
     onVisitPost(rule: AmbiguousTrailingClosureOverload.self, for: node)
+    onVisitPost(rule: BlankLinePolicy.self, for: node)
     onVisitPost(rule: FileScopedDeclarationPrivacy.self, for: node)
     onVisitPost(rule: NeverForceUnwrap.self, for: node)
     onVisitPost(rule: NeverUseForceTry.self, for: node)
@@ -642,6 +644,7 @@ extension FormatPipeline {
   func rewrite(_ node: Syntax) -> Syntax {
     var node = node
     node = AlwaysUseLiteralForEmptyCollectionInit(context: context).rewrite(node)
+    node = BlankLinePolicy(context: context).rewrite(node)
     node = DoNotUseSemicolons(context: context).rewrite(node)
     node = FileScopedDeclarationPrivacy(context: context).rewrite(node)
     node = FullyIndirectEnum(context: context).rewrite(node)

--- a/Sources/SwiftFormat/Core/RuleNameCache+Generated.swift
+++ b/Sources/SwiftFormat/Core/RuleNameCache+Generated.swift
@@ -21,6 +21,7 @@ public let ruleNameCache: [ObjectIdentifier: String] = [
   ObjectIdentifier(AmbiguousTrailingClosureOverload.self): "AmbiguousTrailingClosureOverload",
   ObjectIdentifier(AvoidRetroactiveConformances.self): "AvoidRetroactiveConformances",
   ObjectIdentifier(BeginDocumentationCommentWithOneLineSummary.self): "BeginDocumentationCommentWithOneLineSummary",
+  ObjectIdentifier(BlankLinePolicy.self): "BlankLinePolicy",
   ObjectIdentifier(DoNotUseSemicolons.self): "DoNotUseSemicolons",
   ObjectIdentifier(DontRepeatTypeInStaticProperties.self): "DontRepeatTypeInStaticProperties",
   ObjectIdentifier(FileScopedDeclarationPrivacy.self): "FileScopedDeclarationPrivacy",

--- a/Sources/SwiftFormat/Core/RuleRegistry+Generated.swift
+++ b/Sources/SwiftFormat/Core/RuleRegistry+Generated.swift
@@ -20,6 +20,7 @@
     "AmbiguousTrailingClosureOverload": true,
     "AvoidRetroactiveConformances": true,
     "BeginDocumentationCommentWithOneLineSummary": false,
+    "BlankLinePolicy": false,
     "DoNotUseSemicolons": true,
     "DontRepeatTypeInStaticProperties": true,
     "FileScopedDeclarationPrivacy": true,

--- a/Sources/SwiftFormat/Rules/BlankLinePolicy.swift
+++ b/Sources/SwiftFormat/Rules/BlankLinePolicy.swift
@@ -1,0 +1,904 @@
+import SwiftSyntax
+
+/// Enforces a configurable policy for blank lines at the significant syntactic boundaries of a
+/// source file.
+///
+/// The policy is expressed through the `blankLinePolicy` configuration object. Each of its axes
+/// covers one kind of boundary and accepts the primitive values `none` (blank lines are
+/// forbidden), `exactlyOne` (exactly one blank line is required), and `optional` (the author may
+/// choose zero or one), along with a few named expansions of those primitives:
+///
+///   - `betweenDeclarations: "scopeSeparated"` and `members: "scopeSeparated"` apply
+///     `exactlyOne` between scope-like declarations (functions, initializers, computed
+///     properties, nested types) and at kind transitions, and `optional` between list-like
+///     declarations of the same kind (stored properties, enum cases, typealiases, imports).
+///   - `switchCases: "auto"` applies `exactlyOne` between adjacent cases when either case is
+///     multiline and `none` between adjacent single-line cases.
+///   - `guardPrologue: "separated"` keeps consecutive leading guard statements tight and applies
+///     `exactlyOne` after the final leading guard statement.
+///
+/// Blank lines inside multi-line string literals and comments are content and are never
+/// modified. The `scopeEdges` axis generalizes the `NoEmptyLinesOpeningClosingBraces` rule; it
+/// defaults to `optional` so that enabling both does not produce duplicate findings.
+///
+/// Lint: Blank lines that violate the configured policy yield a lint error.
+///
+/// Format: Blank lines that violate the configured policy are removed, and required blank lines
+/// are inserted.
+@_spi(Rules)
+public final class BlankLinePolicy: SyntaxFormatRule {
+  public override class var isOptIn: Bool { true }
+
+  private var policy: BlankLinePolicyConfiguration {
+    context.configuration.blankLinePolicy
+  }
+
+  public override func visit(_ node: SourceFileSyntax) -> SourceFileSyntax {
+    Rewriter(rule: self).run(node)
+  }
+}
+
+extension BlankLinePolicy {
+  /// The passes the rule runs over the file.
+  fileprivate enum Phase {
+    /// Walks the original tree unchanged, emitting findings whose locations are computed
+    /// against the unmodified source, and recording the planned leading-trivia edits.
+    case collect
+    /// Walks the tree again, applying the recorded edits.
+    case apply
+  }
+
+  /// A change made to the blank lines at a boundary, for diagnostics.
+  fileprivate enum Change {
+    case inserted
+    case removed(Int)
+  }
+
+  /// Performs the policy's two passes over a file.
+  ///
+  /// Entering at the root of the file is what drives this rewriter; it is never dispatched
+  /// per-node by a pipeline, so it needs no guards against reentrant visits.
+  fileprivate final class Rewriter: SyntaxRewriter {
+    private let rule: BlankLinePolicy
+
+    /// The pass that the rewriter is currently performing.
+    private var phase: Phase = .collect
+
+    /// The leading-trivia edits recorded during the collect pass, keyed by the depth-first index
+    /// of the node whose leading trivia must be replaced.
+    ///
+    /// A full `SyntaxIdentifier` cannot be used as the key: edits made during the apply pass
+    /// rebuild the tree, which changes the root identifier that it is based on. The depth-first
+    /// index is stable, though, because the rule's edits only replace tokens (trivia) and never
+    /// insert or remove nodes — the scenario in which SwiftSyntax guarantees that indices can be
+    /// shared between the original and mutated trees.
+    private var pendingLeadingTrivia: [SyntaxIdentifier.SyntaxIndexInTree: Trivia] = [:]
+
+    private var context: Context {
+      rule.context
+    }
+
+    private var policy: BlankLinePolicyConfiguration {
+      rule.policy
+    }
+
+    init(rule: BlankLinePolicy) {
+      self.rule = rule
+    }
+
+    func run(_ node: SourceFileSyntax) -> SourceFileSyntax {
+      phase = .collect
+      pendingLeadingTrivia.removeAll()
+      _ = visit(node)
+      phase = .apply
+      return visit(node)
+    }
+
+    // MARK: Top-level declarations
+
+    override func visit(_ node: SourceFileSyntax) -> SourceFileSyntax {
+      stageBoundaries(node.statements, boundary: "between declarations", targetFor: topLevelTarget)
+      return super.visit(node)
+    }
+
+    // MARK: Brace scopes
+
+    override func visit(_ node: CodeBlockSyntax) -> CodeBlockSyntax {
+      var adjusted = node
+      if policy.scopeEdges == .none {
+        adjusted = trimmingClosingBrace(adjusted, brace: \CodeBlockSyntax.rightBrace)
+        stageFirstBoundaryEdit(adjusted.statements)
+      }
+      stageGuardPrologueEdits(adjusted.statements)
+      return super.visit(adjusted)
+    }
+
+    override func visit(_ node: MemberBlockSyntax) -> MemberBlockSyntax {
+      var adjusted = node
+      if policy.scopeEdges == .none {
+        adjusted = trimmingClosingBrace(adjusted, brace: \MemberBlockSyntax.rightBrace)
+        stageFirstBoundaryEdit(adjusted.members)
+      }
+      stageBoundaries(adjusted.members, boundary: "between members", targetFor: memberTarget)
+      return super.visit(adjusted)
+    }
+
+    override func visit(_ node: ClosureExprSyntax) -> ExprSyntax {
+      var adjusted = node
+      if policy.scopeEdges == .none {
+        adjusted = trimmingClosingBrace(adjusted, brace: \ClosureExprSyntax.rightBrace)
+        stageFirstBoundaryEdit(adjusted.statements)
+      }
+      stageGuardPrologueEdits(adjusted.statements)
+      return super.visit(adjusted)
+    }
+
+    override func visit(_ node: AccessorBlockSyntax) -> AccessorBlockSyntax {
+      var adjusted = node
+      if policy.scopeEdges == .none {
+        adjusted = trimmingClosingBrace(adjusted, brace: \AccessorBlockSyntax.rightBrace)
+        switch adjusted.accessors {
+        case .accessors(let accessors):
+          stageFirstBoundaryEdit(accessors)
+        case .getter(let statements):
+          // A computed property without an explicit getter still has a brace scope.
+          stageFirstBoundaryEdit(statements)
+        }
+      }
+      return super.visit(adjusted)
+    }
+
+    override func visit(_ node: PrecedenceGroupDeclSyntax) -> DeclSyntax {
+      var adjusted = node
+      if policy.scopeEdges == .none {
+        adjusted = trimmingClosingBrace(adjusted, brace: \PrecedenceGroupDeclSyntax.rightBrace)
+        // The attribute list's elements have no dedicated item visits, so the staged edit for
+        // its first element is applied here; precedence groups are rare and tiny.
+        stageFirstBoundaryEdit(adjusted.groupAttributes, boundary: "after '{'")
+        if phase == .apply, var first = adjusted.groupAttributes.first,
+          let trivia = pendingLeadingTrivia[first.id.indexInTree]
+        {
+          first.leadingTrivia = trivia
+          adjusted.groupAttributes[adjusted.groupAttributes.startIndex] = first
+        }
+      }
+      return super.visit(adjusted)
+    }
+
+    // MARK: Switch statements
+
+    override func visit(_ node: SwitchExprSyntax) -> ExprSyntax {
+      var adjusted = node
+      if policy.scopeEdges == .none {
+        adjusted = trimmingClosingBrace(adjusted, brace: \SwitchExprSyntax.rightBrace)
+        stageFirstBoundaryEdit(adjusted.cases)
+      }
+      stageBoundaries(adjusted.cases, boundary: "between switch cases", targetFor: switchCaseTarget)
+      return super.visit(adjusted)
+    }
+
+    override func visit(_ node: SwitchCaseSyntax) -> SwitchCaseSyntax {
+      var adjusted = applyingPendingTrivia(node)
+      if policy.afterCaseLabel == .none {
+        stageFirstBoundaryEdit(adjusted.statements, boundary: "after case label")
+      }
+      return super.visit(adjusted)
+    }
+
+    // MARK: Conditional compilation
+
+    override func visit(_ node: IfConfigClauseSyntax) -> IfConfigClauseSyntax {
+      var adjusted = node
+      switch adjusted.elements {
+      case .none:
+        break
+      case .statements(let statements):
+        if policy.conditionalCompilationEdges == .none {
+          stageFirstBoundaryEdit(
+            statements,
+            boundary: "after a conditional compilation directive"
+          )
+        }
+        if Self.isTopLevelClause(node) {
+          // At the top level of a file the payload holds declarations, even though they are
+          // wrapped in code block items.
+          stageBoundaries(
+            statements,
+            boundary: "between declarations",
+            targetFor: topLevelTarget
+          )
+        } else {
+          stageGuardPrologueEdits(statements)
+        }
+      case .switchCases(let switchCases):
+        if policy.conditionalCompilationEdges == .none {
+          stageFirstBoundaryEdit(
+            switchCases,
+            boundary: "after a conditional compilation directive"
+          )
+        }
+        stageBoundaries(
+          switchCases,
+          boundary: "between switch cases",
+          targetFor: switchCaseTarget
+        )
+      case .decls(let members):
+        // Declaration payloads occur for `#if` blocks inside type bodies, so their boundaries
+        // are governed by the `members` policy.
+        if policy.conditionalCompilationEdges == .none {
+          stageFirstBoundaryEdit(
+            members,
+            boundary: "after a conditional compilation directive"
+          )
+        }
+        stageBoundaries(members, boundary: "between members", targetFor: memberTarget)
+      case .attributes(let attributes):
+        if policy.conditionalCompilationEdges == .none {
+          stageFirstBoundaryEdit(
+            attributes,
+            boundary: "after a conditional compilation directive"
+          )
+        }
+      case .postfixExpression(let original):
+        var expression = original
+        if policy.conditionalCompilationEdges == .none {
+          let key = original.id.indexInTree
+          switch phase {
+          case .collect:
+            if context.shouldFormat(BlankLinePolicy.self, node: Syntax(original)) {
+              let (trivia, change) = Self.rewritingFirstNewlineRun(
+                in: original.leadingTrivia,
+                target: 1
+              )
+              if let change {
+                diagnoseChange(
+                  change,
+                  on: original,
+                  boundary: "after a conditional compilation directive",
+                  anchor: .leadingTrivia(0)
+                )
+                pendingLeadingTrivia[key] = trivia
+              }
+            }
+          case .apply:
+            if let trivia = pendingLeadingTrivia[key] {
+              expression.leadingTrivia = trivia
+              adjusted.elements = .postfixExpression(expression)
+            }
+          }
+        }
+      }
+      return super.visit(adjusted)
+    }
+
+    override func visit(_ node: IfConfigDeclSyntax) -> DeclSyntax {
+      var adjusted = node
+      if policy.conditionalCompilationEdges == .none {
+        let poundEndif = node.poundEndif
+        let key = poundEndif.id.indexInTree
+        switch phase {
+        case .collect:
+          if context.shouldFormat(BlankLinePolicy.self, node: Syntax(poundEndif)) {
+            let (trivia, change) = Self.rewritingFirstNewlineRun(
+              in: poundEndif.leadingTrivia,
+              target: 1
+            )
+            if let change {
+              diagnoseChange(change, on: poundEndif, boundary: "before '#endif'", anchor: .start)
+              pendingLeadingTrivia[key] = trivia
+            }
+          }
+        case .apply:
+          if let trivia = pendingLeadingTrivia[key] {
+            adjusted.poundEndif = poundEndif.with(\.leadingTrivia, trivia)
+          }
+        }
+      }
+      return super.visit(adjusted)
+    }
+
+    // MARK: Expressions
+
+    override func visit(_ node: LabeledExprListSyntax) -> LabeledExprListSyntax {
+      if policy.expressions == .none {
+        stageBoundaries(node, boundary: "between arguments", marksEnabled: false) { _, _ in 1 }
+      }
+      return super.visit(node)
+    }
+
+    override func visit(_ node: ArrayElementListSyntax) -> ArrayElementListSyntax {
+      if policy.expressions == .none {
+        stageBoundaries(node, boundary: "between collection elements", marksEnabled: false) { _, _ in 1 }
+      }
+      return super.visit(node)
+    }
+
+    override func visit(_ node: DictionaryElementListSyntax) -> DictionaryElementListSyntax {
+      if policy.expressions == .none {
+        stageBoundaries(node, boundary: "between collection elements", marksEnabled: false) { _, _ in 1 }
+      }
+      return super.visit(node)
+    }
+
+    // MARK: Collection items (apply pass)
+
+    // During the apply pass these visits perform the edits staged by the boundary helpers,
+    // letting the rewriter batch each parent collection's rebuild.
+    override func visit(_ node: CodeBlockItemSyntax) -> CodeBlockItemSyntax {
+      super.visit(applyingPendingTrivia(node))
+    }
+
+    override func visit(_ node: MemberBlockItemSyntax) -> MemberBlockItemSyntax {
+      super.visit(applyingPendingTrivia(node))
+    }
+
+    override func visit(_ node: LabeledExprSyntax) -> LabeledExprSyntax {
+      super.visit(applyingPendingTrivia(node))
+    }
+
+    override func visit(_ node: ArrayElementSyntax) -> ArrayElementSyntax {
+      super.visit(applyingPendingTrivia(node))
+    }
+
+    override func visit(_ node: DictionaryElementSyntax) -> DictionaryElementSyntax {
+      super.visit(applyingPendingTrivia(node))
+    }
+
+    override func visit(_ node: AttributeSyntax) -> AttributeSyntax {
+      super.visit(applyingPendingTrivia(node))
+    }
+
+    override func visit(_ node: AccessorDeclSyntax) -> DeclSyntax {
+      super.visit(applyingPendingTrivia(node))
+    }
+
+    // MARK: Tokens: attribute gaps and control flow keywords
+
+    override func visit(_ token: TokenSyntax) -> TokenSyntax {
+      var result = token
+
+      // The gap policies only ever remove blank lines, which requires a newline in the leading
+      // trivia; checking for one first avoids walking to the previous token for every token in
+      // the file.
+      if policy.attributes == .none,
+        result.leadingTrivia.contains(where: { $0.isAnyNewline }),
+        let previous = result.previousToken(viewMode: .sourceAccurate),
+        Self.isLastTokenOfAttribute(previous)
+      {
+        result = trimmingTokenGap(result, boundary: "after an attribute")
+      }
+
+      if policy.beforeElse == .none {
+        switch result.tokenKind {
+        case .keyword(.else), .keyword(.catch):
+          result = trimmingTokenGap(
+            result,
+            boundary: result.tokenKind == .keyword(.else) ? "before 'else'" : "before 'catch'"
+          )
+        default:
+          break
+        }
+      }
+
+      return result
+    }
+
+    // MARK: Guard prologue
+
+    private func stageGuardPrologueEdits(_ statements: CodeBlockItemListSyntax) {
+      guard policy.guardPrologue == .separated else { return }
+      let items = Array(statements)
+      guard items.count > 1 else { return }
+
+      var guardCount = 0
+      while guardCount < items.count, items[guardCount].item.is(GuardStmtSyntax.self) {
+        guardCount += 1
+      }
+      guard guardCount > 0 else { return }
+
+      let indices = Array(statements.indices)
+      if guardCount < items.count {
+        stageBoundaryEdit(
+          statements,
+          at: indices[guardCount],
+          boundary: "after guard statements",
+          target: 2
+        )
+      }
+      if guardCount > 1 {
+        for i in stride(from: guardCount - 1, through: 1, by: -1) {
+          stageBoundaryEdit(
+            statements,
+            at: indices[i],
+            boundary: "between guard statements",
+            target: 1
+          )
+        }
+      }
+    }
+
+    // MARK: Shared machinery
+
+    /// Stages the edits for the blank lines before each item (except the first) of a syntax
+    /// collection.
+    ///
+    /// `targetFor` receives the previous and current items and returns the number of newlines
+    /// that must separate the previous item from the current one, or nil to leave the boundary
+    /// alone. If `marksEnabled` is true and the current item's leading trivia contains a
+    /// `// MARK:` comment, the `marks` policies govern the boundaries around the comment instead
+    /// (MARK policies are meaningless inside expressions, hence the parameter).
+    private func stageBoundaries<C: SyntaxCollection>(
+      _ collection: C,
+      boundary: String,
+      marksEnabled: Bool = true,
+      targetFor: (C.Element, C.Element) -> Int?
+    ) {
+      guard phase == .collect else { return }
+      let elements = Array(collection)
+      let indices = Array(collection.indices)
+
+      for i in 0..<elements.count {
+        let current = elements[i]
+
+        if marksEnabled, Self.markCommentIndex(in: current.leadingTrivia) != nil {
+          // A `// MARK:` comment governs its own boundaries instead of the axis's policy; both
+          // of its edits compose into a single staged trivia for the item, on top of anything
+          // another axis has already staged for it. On the first item the scope-edge policy owns
+          // the boundary before the comment, so only `after` applies there.
+          let key = current.id.indexInTree
+          guard context.shouldFormat(BlankLinePolicy.self, node: Syntax(current)) else {
+            continue
+          }
+          var trivia = pendingLeadingTrivia[key] ?? current.leadingTrivia
+          var changed = false
+
+          if i > 0, let target = policy.marks.before.targetNewlines {
+            let (newTrivia, change) = Self.rewritingFirstNewlineRun(in: trivia, target: target)
+            if let change {
+              diagnoseChange(
+                change,
+                on: current,
+                boundary: "before 'MARK:'",
+                anchor: .leadingTrivia(0)
+              )
+              trivia = newTrivia
+              changed = true
+            }
+          }
+          if let target = policy.marks.after.targetNewlines,
+            let commentIndex = Self.markCommentIndex(in: trivia)
+          {
+            let (newTrivia, change) = Self.rewritingFirstNewlineRun(
+              in: trivia,
+              atOrAfter: commentIndex + 1,
+              target: target
+            )
+            if let change {
+              diagnoseChange(change, on: current, boundary: "after 'MARK:'", anchor: .start)
+              trivia = newTrivia
+              changed = true
+            }
+          }
+          if changed {
+            pendingLeadingTrivia[key] = trivia
+          }
+        } else if i > 0, let target = targetFor(elements[i - 1], current) {
+          stageBoundaryEdit(collection, at: indices[i], boundary: boundary, target: target)
+        }
+      }
+    }
+
+    /// Stages the edit that gives the item at `index` the given newline target.
+    ///
+    /// The edit is recorded, keyed by the item's depth-first index, and a finding is emitted
+    /// against the unmodified source; recorded edits are performed during the apply pass by the
+    /// items' own visits, so that the rewriter rebuilds each parent collection at most once. The
+    /// rule mask is only consulted here: re-checking it during the apply pass would compare
+    /// positions in the already-mutated tree against the mask's original-source ranges, silently
+    /// dropping edits near ignored regions.
+    private func stageBoundaryEdit<C: SyntaxCollection>(
+      _ collection: C,
+      at index: C.Index,
+      boundary: String,
+      target: Int
+    ) {
+      guard phase == .collect else { return }
+      let item = collection[index]
+      let key = item.id.indexInTree
+      guard context.shouldFormat(BlankLinePolicy.self, node: Syntax(item)) else {
+        return
+      }
+      let base = pendingLeadingTrivia[key] ?? item.leadingTrivia
+      let (trivia, change) = Self.rewritingFirstNewlineRun(in: base, target: target)
+      guard let change else { return }
+      diagnoseChange(change, on: item, boundary: boundary, anchor: .leadingTrivia(0))
+      pendingLeadingTrivia[key] = trivia
+    }
+
+    /// Returns the node with its staged leading trivia applied, for use by the item visits of the
+    /// apply pass.
+    private func applyingPendingTrivia<Node: SyntaxProtocol>(_ node: Node) -> Node {
+      guard phase == .apply, let trivia = pendingLeadingTrivia[node.id.indexInTree] else {
+        return node
+      }
+      var adjusted = node
+      adjusted.leadingTrivia = trivia
+      return adjusted
+    }
+
+    /// Stages the removal of any blank line between the start of a scope and its first item.
+    private func stageFirstBoundaryEdit<C: SyntaxCollection>(
+      _ collection: C,
+      boundary: String = "after '{'"
+    ) {
+      guard collection.first != nil else { return }
+      stageBoundaryEdit(collection, at: collection.startIndex, boundary: boundary, target: 1)
+    }
+
+    /// Removes any blank line between the last item of a scope and its closing brace.
+    private func trimmingClosingBrace<Node: SyntaxProtocol>(
+      _ node: Node,
+      brace: WritableKeyPath<Node, TokenSyntax>
+    ) -> Node {
+      guard policy.scopeEdges == .none else { return node }
+      let token = node[keyPath: brace]
+      let key = token.id.indexInTree
+      switch phase {
+      case .collect:
+        guard context.shouldFormat(BlankLinePolicy.self, node: Syntax(token)) else {
+          return node
+        }
+        let (trivia, change) = Self.rewritingLastNewlineRun(in: token.leadingTrivia, target: 1)
+        guard let change else { return node }
+        diagnoseChange(change, on: token, boundary: "before '}'", anchor: .start)
+        pendingLeadingTrivia[key] = trivia
+        return node
+      case .apply:
+        guard let trivia = pendingLeadingTrivia[key] else { return node }
+        var result = node
+        result[keyPath: brace] = token.with(\.leadingTrivia, trivia)
+        return result
+      }
+    }
+
+    /// Removes any blank lines in the leading trivia of a token (a gap boundary).
+    private func trimmingTokenGap(_ token: TokenSyntax, boundary: String) -> TokenSyntax {
+      let key = token.id.indexInTree
+      switch phase {
+      case .collect:
+        guard context.shouldFormat(BlankLinePolicy.self, node: Syntax(token)) else {
+          return token
+        }
+        let (trivia, change) = Self.rewritingFirstNewlineRun(in: token.leadingTrivia, target: 1)
+        guard let change else { return token }
+        diagnoseChange(change, on: token, boundary: boundary, anchor: .start)
+        pendingLeadingTrivia[key] = trivia
+        return token
+      case .apply:
+        guard let trivia = pendingLeadingTrivia[key] else { return token }
+        return token.with(\.leadingTrivia, trivia)
+      }
+    }
+
+    /// Returns whether the declaration is "scope-like": it introduces a brace body or otherwise
+    /// behaves like a function (computed properties, subscripts). List-like members (stored
+    /// properties, enum cases, typealiases, bodyless protocol requirements) group tightly.
+    private func isScopeLike(_ decl: DeclSyntax) -> Bool {
+      if decl.is(ClassDeclSyntax.self)
+        || decl.is(StructDeclSyntax.self)
+        || decl.is(EnumDeclSyntax.self)
+        || decl.is(ProtocolDeclSyntax.self)
+        || decl.is(ActorDeclSyntax.self)
+        || decl.is(ExtensionDeclSyntax.self)
+      {
+        return true
+      }
+      if let function = decl.as(FunctionDeclSyntax.self) {
+        return function.body != nil
+      }
+      if let initializer = decl.as(InitializerDeclSyntax.self) {
+        return initializer.body != nil
+      }
+      if decl.is(DeinitializerDeclSyntax.self) {
+        return true
+      }
+      if let subscriptDecl = decl.as(SubscriptDeclSyntax.self) {
+        return subscriptDecl.accessorBlock != nil
+      }
+      if let variable = decl.as(VariableDeclSyntax.self) {
+        return variable.bindings.contains { $0.accessorBlock != nil }
+      }
+      return false
+    }
+
+    /// The boundary target between two top-level (or top-level `#if`-region) items under the
+    /// `betweenDeclarations` policy.
+    private func topLevelTarget(
+      _ previous: CodeBlockItemSyntax,
+      _ current: CodeBlockItemSyntax
+    ) -> Int? {
+      declarationTarget(Syntax(previous.item), Syntax(current.item))
+    }
+
+    /// The shared core of `betweenDeclarations`: scope-like declarations and kind transitions
+    /// are separated by exactly one blank line; the boundary between list-like declarations of
+    /// the same kind (for example consecutive imports) and around top-level statements (script
+    /// code) is left to the author.
+    private func declarationTarget(_ previousItem: Syntax, _ currentItem: Syntax) -> Int? {
+      switch policy.betweenDeclarations {
+      case .scopeSeparated:
+        switch (declaration(inside: previousItem), declaration(inside: currentItem)) {
+        case (let previousDecl?, let currentDecl?):
+          if isScopeLike(previousDecl) || isScopeLike(currentDecl) {
+            return 2
+          }
+          return previousDecl.kind != currentDecl.kind ? 2 : nil
+        default:
+          // Items that are not declarations (script code) group with everything; the axis
+          // governs declarations.
+          return nil
+        }
+      case .none:
+        return 1
+      case .exactlyOne:
+        return 2
+      case .optional:
+        return nil
+      }
+    }
+
+    /// The boundary target between two members under the `members` policy: scope-like members
+    /// and kind transitions are separated by exactly one blank line; the boundary between
+    /// list-like members of the same kind is left to the author.
+    private func memberTarget(
+      _ previous: MemberBlockItemSyntax,
+      _ current: MemberBlockItemSyntax
+    ) -> Int? {
+      switch policy.members {
+      case .scopeSeparated:
+        if isScopeLike(previous.decl) || isScopeLike(current.decl) {
+          return 2
+        }
+        return previous.decl.kind != current.decl.kind ? 2 : nil
+      case .none:
+        return 1
+      case .exactlyOne:
+        return 2
+      case .optional:
+        return nil
+      }
+    }
+
+    /// The boundary target between two adjacent switch cases.
+    private func switchCaseTarget(
+      _ previous: SwitchCaseListSyntax.Element,
+      _ current: SwitchCaseListSyntax.Element
+    ) -> Int? {
+      switch policy.switchCases {
+      case .auto:
+        return (isMultilineCase(previous) || isMultilineCase(current)) ? 2 : 1
+      case .none:
+        return 1
+      case .exactlyOne:
+        return 2
+      case .optional:
+        return nil
+      }
+    }
+
+    /// Returns the declaration carried by a top-level item, or nil if the item is a statement
+    /// (script code).
+    private func declaration(inside item: Syntax) -> DeclSyntax? {
+      var inner = item
+      if let codeBlockItem = item.as(CodeBlockItemSyntax.self) {
+        inner = Syntax(codeBlockItem.item)
+      }
+      return inner.as(DeclSyntax.self)
+    }
+
+    /// Returns whether the given clause's conditional compilation block sits at the top level of
+    /// the file, so that its payload declarations are governed by `betweenDeclarations` rather
+    /// than being treated as ordinary statements.
+    private static func isTopLevelClause(_ node: IfConfigClauseSyntax) -> Bool {
+      // Walk up through the clause list to the enclosing `#if` declaration, then keep walking to
+      // determine whether it sits at the top level of the file.
+      var ancestor: Syntax? = Syntax(node).parent
+      var sawIfConfigDecl = false
+      while let current = ancestor {
+        if current.is(IfConfigDeclSyntax.self) {
+          sawIfConfigDecl = true
+        } else if sawIfConfigDecl {
+          switch current.kind {
+          case .sourceFile:
+            return true
+          case .codeBlock, .memberBlock, .closureExpr, .accessorBlock:
+            return false
+          default:
+            break
+          }
+        }
+        ancestor = current.parent
+      }
+      return false
+    }
+
+    private func isMultilineCase(_ element: SwitchCaseListSyntax.Element) -> Bool {
+      if case .switchCase(let switchCase) = element {
+        return switchCase.trimmedDescription.contains("\n")
+      }
+      return true
+    }
+
+    /// Returns whether the token is the last token of an attribute, so that the gap following it
+    /// is governed by the `attributes` policy.
+    private static func isLastTokenOfAttribute(_ token: TokenSyntax) -> Bool {
+      var ancestor: Syntax? = Syntax(token)
+      // Attribute arguments are shallowly nested; the small bound keeps this walk cheap for the
+      // common case where the previous token is not part of an attribute at all.
+      for _ in 0..<6 {
+        guard let parent = ancestor?.parent else { return false }
+        if parent.is(AttributeSyntax.self) {
+          return parent.lastToken(viewMode: .sourceAccurate) == token
+        }
+        ancestor = parent
+      }
+      return false
+    }
+
+    /// Returns the index of the first `// MARK:` comment in the trivia, if any.
+    private static func markCommentIndex(in trivia: Trivia) -> Int? {
+      for (index, piece) in trivia.pieces.enumerated() {
+        guard case .lineComment(let text) = piece else { continue }
+        let body = text.dropFirst(2).drop(while: { $0 == " " || $0 == "\t" })
+        if body.hasPrefix("MARK:") || body.hasPrefix("- MARK:") {
+          return index
+        }
+      }
+      return nil
+    }
+
+    private struct NewlineRun {
+      let index: Int
+      let pieceCount: Int
+      let newlines: Int
+    }
+
+    /// Rewrites the first newline run at or after the boundary so it contains exactly `target`
+    /// newlines, and returns the resulting trivia and a description of the change.
+    ///
+    /// A newline run of *n* newlines corresponds to *n - 1* blank lines, so a target of 1 removes
+    /// any blank lines and a target of 2 leaves exactly one. When the trivia contains no newline
+    /// run at all (the item continues the previous line), only a target of 2 or more inserts one.
+    private static func rewritingFirstNewlineRun(
+      in trivia: Trivia,
+      atOrAfter start: Int = 0,
+      target: Int
+    ) -> (trivia: Trivia, change: Change?) {
+      var pieces = Array(trivia)
+      guard let run = newlineRun(in: pieces, atOrAfter: start) else {
+        guard target > 1 else { return (trivia, nil) }
+        pieces.insert(.newlines(target), at: min(start, pieces.count))
+        return (Trivia(pieces: pieces), .inserted)
+      }
+      guard run.newlines != target else { return (trivia, nil) }
+      pieces.replaceSubrange(run.index..<(run.index + run.pieceCount), with: [.newlines(target)])
+      let change: Change = run.newlines < target ? .inserted : .removed(run.newlines - target)
+      return (Trivia(pieces: pieces), change)
+    }
+
+    /// Rewrites the last newline run in the trivia so it contains exactly `target` newlines.
+    private static func rewritingLastNewlineRun(
+      in trivia: Trivia,
+      target: Int
+    ) -> (trivia: Trivia, change: Change?) {
+      var pieces = Array(trivia)
+      guard let run = lastNewlineRun(in: pieces), run.newlines != target else {
+        return (trivia, nil)
+      }
+      pieces.replaceSubrange(run.index..<(run.index + run.pieceCount), with: [.newlines(target)])
+      let change: Change = run.newlines < target ? .inserted : .removed(run.newlines - target)
+      return (Trivia(pieces: pieces), change)
+    }
+
+    /// Finds the first run of newlines at or after `start`. A blank line that contains spaces or
+    /// tabs is part of the run, so that rewriting the run removes those lines entirely instead of
+    /// leaving whitespace-only lines behind.
+    private static func newlineRun(in pieces: [TriviaPiece], atOrAfter start: Int) -> NewlineRun? {
+      var index = start
+      while index < pieces.count, !pieces[index].isAnyNewline {
+        index += 1
+      }
+      guard index < pieces.count else { return nil }
+
+      var end = index
+      var newlines = 0
+      while end < pieces.count {
+        if pieces[end].isAnyNewline {
+          newlines += pieces[end].newlineCount
+          end += 1
+        } else if pieces[end].isSpaceOrTab,
+          end + 1 < pieces.count,
+          pieces[end + 1].isAnyNewline
+        {
+          // Whitespace that occupies a line of its own belongs to the blank-line run.
+          end += 1
+        } else {
+          break
+        }
+      }
+      return NewlineRun(index: index, pieceCount: end - index, newlines: newlines)
+    }
+
+    /// Finds the last run of newlines, absorbing whitespace-only lines as in `newlineRun`.
+    private static func lastNewlineRun(in pieces: [TriviaPiece]) -> NewlineRun? {
+      guard let last = pieces.lastIndex(where: { $0.isAnyNewline }) else { return nil }
+      var first = last
+      while first >= 2, pieces[first - 1].isSpaceOrTab, pieces[first - 2].isAnyNewline {
+        first -= 2
+      }
+      while first > 0, pieces[first - 1].isAnyNewline {
+        first -= 1
+      }
+      let newlines = pieces[first...last].reduce(0) { $0 + $1.newlineCount }
+      return NewlineRun(index: first, pieceCount: last - first + 1, newlines: newlines)
+    }
+
+    private func diagnoseChange<SyntaxType: SyntaxProtocol>(
+      _ change: Change,
+      on node: SyntaxType?,
+      boundary: String,
+      anchor: FindingAnchor
+    ) {
+      // An anchor inside the leading trivia is meaningless when there is none (an item that
+      // continues the previous line, such as a statement after a semicolon); anchor on the node's
+      // content instead of trapping.
+      let anchor: FindingAnchor = node?.leadingTrivia.isEmpty == true ? .start : anchor
+      switch change {
+      case .inserted:
+        rule.diagnose(.insertBlankLine(boundary), on: node, anchor: anchor)
+      case .removed(let count):
+        rule.diagnose(.removeBlankLines(count, at: boundary), on: node, anchor: anchor)
+      }
+    }
+  }
+}
+
+extension BlankLinePolicyValue {
+  /// The number of newlines that must separate the previous content from a boundary item, or nil
+  /// when the formatter should leave the boundary alone.
+  fileprivate var targetNewlines: Int? {
+    switch self {
+    case .none: 1
+    case .exactlyOne: 2
+    case .optional: nil
+    }
+  }
+}
+
+extension TriviaPiece {
+  fileprivate var isAnyNewline: Bool {
+    switch self {
+    case .newlines, .carriageReturns, .carriageReturnLineFeeds, .formfeeds: true
+    default: false
+    }
+  }
+
+  fileprivate var newlineCount: Int {
+    switch self {
+    case .newlines(let count): count
+    case .carriageReturns(let count), .carriageReturnLineFeeds(let count), .formfeeds(let count):
+      count
+    default: 0
+    }
+  }
+}
+
+extension Finding.Message {
+  fileprivate static func removeBlankLines(_ count: Int, at boundary: String) -> Finding.Message {
+    "remove \(count > 1 ? "\(count) blank lines" : "1 blank line") \(boundary)"
+  }
+
+  fileprivate static func insertBlankLine(_ boundary: String) -> Finding.Message {
+    "insert a blank line \(boundary)"
+  }
+}

--- a/Tests/SwiftFormatTests/Rules/BlankLinePolicyTests.swift
+++ b/Tests/SwiftFormatTests/Rules/BlankLinePolicyTests.swift
@@ -1,0 +1,1014 @@
+import Foundation
+@_spi(Rules) import SwiftFormat
+import XCTest
+import _SwiftFormatTestSupport
+
+final class BlankLinePolicyTests: LintOrFormatRuleTestCase {
+  func testBetweenDeclarationsInsertsRequiredBlankLine() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        struct A {}1️⃣
+        struct B {}
+        """,
+      expected: """
+        struct A {}
+
+        struct B {}
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "insert a blank line between declarations")
+      ]
+    )
+  }
+
+  func testBetweenDeclarationsCollapsesExtraBlankLines() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        struct A {}1️⃣
+
+
+        struct B {}
+        """,
+      expected: """
+        struct A {}
+
+        struct B {}
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "remove 1 blank line between declarations")
+      ]
+    )
+  }
+
+  func testScopeEdgesInFunctionBody() {
+    var configuration = Configuration.forTesting(enabledRule: BlankLinePolicy.self.ruleName)
+    configuration.blankLinePolicy.scopeEdges = .none
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        func f() {1️⃣
+
+          let x = 1
+
+        2️⃣}
+        """,
+      expected: """
+        func f() {
+          let x = 1
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "remove 1 blank line after '{'"),
+        FindingSpec("2️⃣", message: "remove 1 blank line before '}'"),
+      ],
+      configuration: configuration
+    )
+  }
+
+  func testScopeEdgesInTypeBody() {
+    var configuration = Configuration.forTesting(enabledRule: BlankLinePolicy.self.ruleName)
+    configuration.blankLinePolicy.scopeEdges = .none
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        struct S {1️⃣
+
+          let x: Int
+
+        2️⃣}
+        """,
+      expected: """
+        struct S {
+          let x: Int
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "remove 1 blank line after '{'"),
+        FindingSpec("2️⃣", message: "remove 1 blank line before '}'"),
+      ],
+      configuration: configuration
+    )
+  }
+
+  func testMembersScopeSeparated() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        struct S {
+          let a = 1
+          let b = 21️⃣
+          func f() {}2️⃣
+          func g() {}
+        }
+        """,
+      expected: """
+        struct S {
+          let a = 1
+          let b = 2
+
+          func f() {}
+
+          func g() {}
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "insert a blank line between members"),
+        FindingSpec("2️⃣", message: "insert a blank line between members"),
+      ]
+    )
+  }
+
+  func testMembersScopeSeparatedLeavesListLikeMembersAlone() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        enum E {
+          case a
+
+          case b
+        }
+        """,
+      expected: """
+        enum E {
+          case a
+
+          case b
+        }
+        """,
+      findings: []
+    )
+  }
+
+  func testMarksBeforeAndAfter() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        struct S {
+          let a = 11️⃣
+          // MARK: Stuff
+
+          2️⃣func f() {}
+        }
+        """,
+      expected: """
+        struct S {
+          let a = 1
+
+          // MARK: Stuff
+          func f() {}
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "insert a blank line before 'MARK:'"),
+        FindingSpec("2️⃣", message: "remove 1 blank line after 'MARK:'"),
+      ]
+    )
+  }
+
+  func testSwitchCasesAutoTightensSingleLineCases() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        func f(v: Int) {
+          switch v {
+          case 1: print(1)1️⃣
+
+          case 2: print(2)
+          }
+        }
+        """,
+      expected: """
+        func f(v: Int) {
+          switch v {
+          case 1: print(1)
+          case 2: print(2)
+          }
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "remove 1 blank line between switch cases")
+      ]
+    )
+  }
+
+  func testSwitchCasesAutoSeparatesMultilineCases() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        func f(v: Int) {
+          switch v {
+          case 1:
+            print(1)1️⃣
+          case 2:
+            print(2)
+          }
+        }
+        """,
+      expected: """
+        func f(v: Int) {
+          switch v {
+          case 1:
+            print(1)
+
+          case 2:
+            print(2)
+          }
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "insert a blank line between switch cases")
+      ]
+    )
+  }
+
+  func testAfterCaseLabel() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        func f(v: Int) {
+          switch v {
+          case 1:1️⃣
+
+            print(1)
+          }
+        }
+        """,
+      expected: """
+        func f(v: Int) {
+          switch v {
+          case 1:
+            print(1)
+          }
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "remove 1 blank line after case label")
+      ]
+    )
+  }
+
+  func testAttributes() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        @available(iOS 13, *)
+
+        1️⃣@objc
+
+        2️⃣func f() {}
+        """,
+      expected: """
+        @available(iOS 13, *)
+        @objc
+        func f() {}
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "remove 1 blank line after an attribute"),
+        FindingSpec("2️⃣", message: "remove 1 blank line after an attribute"),
+      ]
+    )
+  }
+
+  func testExpressions() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        func f() {
+          print(
+            "a",1️⃣
+
+            "b"
+          )
+          let xs = [
+            1,2️⃣
+
+            2,
+          ]
+        }
+        """,
+      expected: """
+        func f() {
+          print(
+            "a",
+            "b"
+          )
+          let xs = [
+            1,
+            2,
+          ]
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "remove 1 blank line between arguments"),
+        FindingSpec("2️⃣", message: "remove 1 blank line between collection elements"),
+      ]
+    )
+  }
+
+  func testConditionalCompilationEdges() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        #if os(macOS)1️⃣
+
+        func f() {}
+
+        2️⃣#endif
+        """,
+      expected: """
+        #if os(macOS)
+        func f() {}
+        #endif
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "remove 1 blank line after a conditional compilation directive"),
+        FindingSpec("2️⃣", message: "remove 1 blank line before '#endif'"),
+      ]
+    )
+  }
+
+  func testGuardPrologue() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        func f(x: Int?) {
+          guard let y = x else { return }1️⃣
+
+          guard y > 0 else { return }2️⃣
+          use(y)
+        }
+        """,
+      expected: """
+        func f(x: Int?) {
+          guard let y = x else { return }
+          guard y > 0 else { return }
+
+          use(y)
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "remove 1 blank line between guard statements"),
+        FindingSpec("2️⃣", message: "insert a blank line after guard statements"),
+      ]
+    )
+  }
+
+  func testBeforeElse() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        func f(v: Bool) {
+          if v {
+            print(1)
+          }
+
+          1️⃣else {
+            print(2)
+          }
+        }
+        """,
+      expected: """
+        func f(v: Bool) {
+          if v {
+            print(1)
+          }
+          else {
+            print(2)
+          }
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "remove 1 blank line before 'else'")
+      ]
+    )
+  }
+
+  func testMembersNoneConfiguration() {
+    var configuration = Configuration.forTesting(enabledRule: BlankLinePolicy.self.ruleName)
+    configuration.blankLinePolicy.members = .none
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        struct S {
+          func f() {}1️⃣
+
+          func g() {}
+        }
+        """,
+      expected: """
+        struct S {
+          func f() {}
+          func g() {}
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "remove 1 blank line between members")
+      ],
+      configuration: configuration
+    )
+  }
+
+  func testMembersOptionalConfiguration() {
+    var configuration = Configuration.forTesting(enabledRule: BlankLinePolicy.self.ruleName)
+    configuration.blankLinePolicy.members = .optional
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        struct S {
+          func f() {}
+          func g() {}
+        }
+        """,
+      expected: """
+        struct S {
+          func f() {}
+          func g() {}
+        }
+        """,
+      findings: [],
+      configuration: configuration
+    )
+  }
+
+  func testGapAxesRejectExactlyOne() {
+    let gapAxes = [
+      "scopeEdges", "afterCaseLabel", "attributes", "expressions",
+      "conditionalCompilationEdges", "beforeElse",
+    ]
+    for axis in gapAxes {
+      let json = #"{"rules": {"BlankLinePolicy": true}, "blankLinePolicy": {"\#(axis)": "exactlyOne"}}"#
+      XCTAssertThrowsError(try Configuration(data: Data(json.utf8))) { error in
+        guard case DecodingError.dataCorrupted(let context) = error else {
+          return XCTFail("expected dataCorrupted for \(axis), got \(error)")
+        }
+        XCTAssertTrue(
+          context.debugDescription.contains("cannot be 'exactlyOne'"),
+          "unexpected message for \(axis): \(context.debugDescription)"
+        )
+      }
+    }
+  }
+
+  func testSemicolonJoinedMembersGetInsertedBlankLine() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        struct S { let a = 1; 1️⃣func f() {} }
+        """,
+      expected: """
+        struct S { let a = 1;
+
+        func f() {} }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "insert a blank line between members")
+      ]
+    )
+  }
+
+  func testSemicolonJoinedGuardPrologueGetsInsertedBlankLine() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        func f(x: Int?) {
+          guard let y = x else { return }; 1️⃣use(y)
+        }
+        """,
+      expected: """
+        func f(x: Int?) {
+          guard let y = x else { return };
+
+        use(y)
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "insert a blank line after guard statements")
+      ]
+    )
+  }
+
+  func testGetterOnlyAccessorScopeEdges() {
+    var configuration = Configuration.forTesting(enabledRule: BlankLinePolicy.self.ruleName)
+    configuration.blankLinePolicy.scopeEdges = .none
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        struct S {
+          var x: Int {1️⃣
+
+            return 1
+
+          2️⃣}
+        }
+        """,
+      expected: """
+        struct S {
+          var x: Int {
+            return 1
+          }
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "remove 1 blank line after '{'"),
+        FindingSpec("2️⃣", message: "remove 1 blank line before '}'"),
+      ],
+      configuration: configuration
+    )
+  }
+
+  func testClosureScopeEdges() {
+    var configuration = Configuration.forTesting(enabledRule: BlankLinePolicy.self.ruleName)
+    configuration.blankLinePolicy.scopeEdges = .none
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        func f() {
+          let c = {1️⃣
+
+            print(1)
+
+          2️⃣}
+        }
+        """,
+      expected: """
+        func f() {
+          let c = {
+            print(1)
+          }
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "remove 1 blank line after '{'"),
+        FindingSpec("2️⃣", message: "remove 1 blank line before '}'"),
+      ],
+      configuration: configuration
+    )
+  }
+
+  func testDictionaryElements() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        let d = [
+          "a": 1,1️⃣
+
+          "b": 2,
+        ]
+        """,
+      expected: """
+        let d = [
+          "a": 1,
+          "b": 2,
+        ]
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "remove 1 blank line between collection elements")
+      ]
+    )
+  }
+
+  func testBeforeCatch() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        func f() {
+          do {
+            print(1)
+          }
+
+          1️⃣catch {
+            print(2)
+          }
+        }
+        """,
+      expected: """
+        func f() {
+          do {
+            print(1)
+          }
+          catch {
+            print(2)
+          }
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "remove 1 blank line before 'catch'")
+      ]
+    )
+  }
+
+  func testElseClauseDirectiveEdge() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        #if FOO
+        func f() {}
+        #else1️⃣
+
+        func g() {}
+
+        2️⃣#endif
+        """,
+      expected: """
+        #if FOO
+        func f() {}
+        #else
+        func g() {}
+        #endif
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "remove 1 blank line after a conditional compilation directive"),
+        FindingSpec("2️⃣", message: "remove 1 blank line before '#endif'"),
+      ]
+    )
+  }
+
+  func testDeclarationsInsideConditionalCompilationBlock() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        #if FOO
+        struct A {}1️⃣
+        struct B {}
+        #endif
+        """,
+      expected: """
+        #if FOO
+        struct A {}
+
+        struct B {}
+        #endif
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "insert a blank line between declarations")
+      ]
+    )
+  }
+
+  func testKindTransitionBetweenListLikeMembers() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        struct S {
+          let a = 11️⃣
+          typealias T = Int
+        }
+        """,
+      expected: """
+        struct S {
+          let a = 1
+
+          typealias T = Int
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "insert a blank line between members")
+      ]
+    )
+  }
+
+  func testImportsGroupAtTopLevel() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        import Alpha
+        import Beta1️⃣
+        struct S {}
+        """,
+      expected: """
+        import Alpha
+        import Beta
+
+        struct S {}
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "insert a blank line between declarations")
+      ]
+    )
+  }
+
+  func testMarkDashVariant() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        struct S {
+          let a = 11️⃣
+          // MARK: - Section
+
+          2️⃣func f() {}
+        }
+        """,
+      expected: """
+        struct S {
+          let a = 1
+
+          // MARK: - Section
+          func f() {}
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "insert a blank line before 'MARK:'"),
+        FindingSpec("2️⃣", message: "remove 1 blank line after 'MARK:'"),
+      ]
+    )
+  }
+
+  func testMarkOnFirstMemberAppliesOnlyAfterPolicy() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        struct S {
+          // MARK: Only
+
+          1️⃣func f() {}
+        }
+        """,
+      expected: """
+        struct S {
+          // MARK: Only
+          func f() {}
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "remove 1 blank line after 'MARK:'")
+      ]
+    )
+  }
+
+  func testIgnoreCommentIsRespected() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        struct S {
+          let a = 1
+          // swift-format-ignore
+          func f() {}
+        }
+        """,
+      expected: """
+        struct S {
+          let a = 1
+          // swift-format-ignore
+          func f() {}
+        }
+        """,
+      findings: []
+    )
+  }
+
+  func testCRLFCompliantBoundaryIsLeftAlone() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: "struct A {}\r\n\r\nstruct B {}\r\n",
+      expected: "struct A {}\r\n\r\nstruct B {}\r\n",
+      findings: []
+    )
+  }
+
+  func testPrecedenceGroupScopeEdges() {
+    var configuration = Configuration.forTesting(enabledRule: BlankLinePolicy.self.ruleName)
+    configuration.blankLinePolicy.scopeEdges = .none
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        precedencegroup P {1️⃣
+
+          associativity: left
+
+          higherThan: Q
+
+        2️⃣}
+        """,
+      expected: """
+        precedencegroup P {
+          associativity: left
+
+          higherThan: Q
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "remove 1 blank line after '{'"),
+        FindingSpec("2️⃣", message: "remove 1 blank line before '}'"),
+      ],
+      configuration: configuration
+    )
+  }
+
+  func testGuardPrologueInClosure() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        func f(x: Int?) {
+          let c = { (y: Int?) in
+            guard let z = y else { return }1️⃣
+            return z
+          }
+          _ = c(x)
+        }
+        """,
+      expected: """
+        func f(x: Int?) {
+          let c = { (y: Int?) in
+            guard let z = y else { return }
+
+            return z
+          }
+          _ = c(x)
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "insert a blank line after guard statements")
+      ]
+    )
+  }
+
+  func testWhitespaceOnlyBlankLinesAreRemoved() {
+    var configuration = Configuration.forTesting(enabledRule: BlankLinePolicy.self.ruleName)
+    configuration.blankLinePolicy.scopeEdges = .none
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: "func f() {1️⃣\n  \n  let x = 1\n  \n2️⃣}\n",
+      expected: "func f() {\n  let x = 1\n}\n",
+      findings: [
+        FindingSpec("1️⃣", message: "remove 1 blank line after '{'"),
+        FindingSpec("2️⃣", message: "remove 1 blank line before '}'"),
+      ],
+      configuration: configuration
+    )
+  }
+
+  func testMembersPolicyAppliesInsideTypeLevelIfConfig() {
+    var configuration = Configuration.forTesting(enabledRule: BlankLinePolicy.self.ruleName)
+    configuration.blankLinePolicy.members = .none
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        struct S {
+        #if os(Linux)
+          let a = 11️⃣
+
+          func f() {}
+        #endif
+        }
+        """,
+      expected: """
+        struct S {
+        #if os(Linux)
+          let a = 1
+          func f() {}
+        #endif
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "remove 1 blank line between members")
+      ],
+      configuration: configuration
+    )
+  }
+
+  func testConditionalCompilationEdgesOptionalKeepsSiblingAxes() {
+    var configuration = Configuration.forTesting(enabledRule: BlankLinePolicy.self.ruleName)
+    configuration.blankLinePolicy.conditionalCompilationEdges = .optional
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        #if FOO
+        struct A {}1️⃣
+        struct B {}
+        #endif
+        """,
+      expected: """
+        #if FOO
+        struct A {}
+
+        struct B {}
+        #endif
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "insert a blank line between declarations")
+      ],
+      configuration: configuration
+    )
+  }
+
+  func testTopLevelStatementsGroup() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        let x = 1
+        x += 1
+        print(x)
+        """,
+      expected: """
+        let x = 1
+        x += 1
+        print(x)
+        """,
+      findings: []
+    )
+  }
+
+  func testBetweenDeclarationsNoneConfiguration() {
+    var configuration = Configuration.forTesting(enabledRule: BlankLinePolicy.self.ruleName)
+    configuration.blankLinePolicy.betweenDeclarations = .none
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        struct A {}1️⃣
+
+        struct B {}
+        """,
+      expected: """
+        struct A {}
+        struct B {}
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "remove 1 blank line between declarations")
+      ],
+      configuration: configuration
+    )
+  }
+
+  func testMarksDisabledConfiguration() {
+    var configuration = Configuration.forTesting(enabledRule: BlankLinePolicy.self.ruleName)
+    configuration.blankLinePolicy.marks = MarkBlankLinePolicy(before: .none, after: .none)
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        struct S {
+          let a = 1
+          // MARK: X
+          func f() {}
+        }
+        """,
+      expected: """
+        struct S {
+          let a = 1
+          // MARK: X
+          func f() {}
+        }
+        """,
+      findings: [],
+      configuration: configuration
+    )
+  }
+
+  func testGuardPrologueOptionalConfiguration() {
+    var configuration = Configuration.forTesting(enabledRule: BlankLinePolicy.self.ruleName)
+    configuration.blankLinePolicy.guardPrologue = .optional
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        func f(x: Int?) {
+          guard let y = x else { return }
+          use(y)
+        }
+        """,
+      expected: """
+        func f(x: Int?) {
+          guard let y = x else { return }
+          use(y)
+        }
+        """,
+      findings: [],
+      configuration: configuration
+    )
+  }
+
+  func testLintPipelineEmitsEachFindingOnce() {
+    var findings: [Finding] = []
+    let linter = SwiftLinter(
+      configuration: Configuration.forTesting(enabledRule: BlankLinePolicy.self.ruleName),
+      findingConsumer: { findings.append($0) }
+    )
+    try! linter.lint(
+      source: "struct A {}\nstruct B {}\n",
+      assumingFileURL: URL(fileURLWithPath: "test.swift")
+    )
+    XCTAssertEqual(findings.count, 1)
+    XCTAssertEqual("\(findings.first!.message)", "insert a blank line between declarations")
+  }
+
+  func testScopeEdgesDefaultsToOptional() {
+    assertFormatting(
+      BlankLinePolicy.self,
+      input: """
+        struct S {
+
+          let x: Int
+
+        }
+        """,
+      expected: """
+        struct S {
+
+          let x: Int
+
+        }
+        """,
+      findings: []
+    )
+  }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `BlankLinePolicy` format rule that enforces a configurable policy for blank lines at Swift's syntactic boundaries, along with a `blankLinePolicy` configuration object.

## Configuration

Each axis accepts `none` (blank lines removed), `exactlyOne` (inserted if missing, extras removed), or `optional` (left to the author), with named expansions that pick between them per boundary:

| Axis | Governs | Default |
|---|---|---|
| `betweenDeclarations` | Top-level declarations (incl. top-level `#if` regions) | `scopeSeparated` |
| `members` | Members of a type (incl. `#if` regions) | `scopeSeparated` |
| `switchCases` | Cases of a `switch` | `auto` |
| `marks` | `// MARK:` comments (`before`/`after`) | `exactlyOne` / `none` |
| `guardPrologue` | Leading `guard` statements | `separated` |
| `scopeEdges` | After `{`, before `}` | `optional` |
| `afterCaseLabel` | Between `case:` and its first statement | `none` |
| `attributes` | Between/after attributes | `none` |
| `expressions` | Argument lists (incl. tuples), collection literals | `none` |
| `conditionalCompilationEdges` | After `#if`/`#else`, before `#endif` | `none` |
| `beforeElse` | Before `else`/`catch` | `none` |

Gap axes (last six) accept only `none` and `optional`; invalid combinations are rejected at config load. Blank lines inside multi-line strings and comments are never touched. `maximumBlankLines` still applies globally.

## Implementation notes

- The rule visits the file from its root (like `OrderedImports`) in two passes: findings are diagnosed against the unmodified source, then the recorded edits are applied, so finding locations never drift from earlier edits in the same run.
- `scopeSeparated`/`auto`/`separated` are expansions of the three primitives applied per boundary.
- `// swift-format-ignore` regions and selections are respected per boundary item.
- Idempotent on format, handles CRLF and whitespace-only blank lines, and scales linearly on large files.
- 43 rule tests; `scopeEdges` defaults to `optional` because it generalizes `NoEmptyLinesOpeningClosingBraces` (enable one or the other to avoid duplicate findings).
