### PR TITLE
Preserve a comment trailing a case label in NoCasesWithOnlyFallthrough

### DIFF
--- a/Sources/SwiftFormat/Rules/NoCasesWithOnlyFallthrough.swift
+++ b/Sources/SwiftFormat/Rules/NoCasesWithOnlyFallthrough.swift
@@ -151,6 +151,17 @@ public final class NoCasesWithOnlyFallthrough: SyntaxFormatRule {
       return false
     }
 
+    // Check for a comment that trails the `case` label on the same line, before
+    // the `fallthrough` on the following line, e.g. `case 1:  // trailing`.
+    // Such a comment lives in the statement's preceding trivia ahead of the
+    // first newline; the check above deliberately skips that same-line prefix,
+    // so without this the comment would be silently dropped when merging.
+    if onlyStatement.allPrecedingTrivia
+      .prefix(while: { !$0.isNewline }).contains(where: { $0.isComment })
+    {
+      return false
+    }
+
     // Check for any comments that are inline on the fallthrough statement.
     if onlyStatement.allFollowingTrivia
       .prefix(while: { !$0.isNewline }).contains(where: { $0.isComment })

--- a/Tests/SwiftFormatTests/Rules/NoCasesWithOnlyFallthroughTests.swift
+++ b/Tests/SwiftFormatTests/Rules/NoCasesWithOnlyFallthroughTests.swift
@@ -157,6 +157,53 @@ final class NoCasesWithOnlyFallthroughTests: LintOrFormatRuleTestCase {
     )
   }
 
+  func testCaseWithTrailingCommentOnLabelIsNotCombined() {
+    // A comment trailing the `case` label on the same line, with `fallthrough`
+    // on the following line, must prevent the merge so the comment isn't
+    // silently dropped. Regression test for the case where the comment lives in
+    // the fallthrough statement's leading trivia before the first newline.
+    assertFormatting(
+      NoCasesWithOnlyFallthrough.self,
+      input: """
+        switch x {
+        case 1:  // trail on 1
+          fallthrough
+        case 2:
+          print("hi")
+        default:
+          break
+        }
+        switch y {
+        case 1:  /* block trail */
+          fallthrough
+        case 2:
+          print("hi")
+        default:
+          break
+        }
+        """,
+      expected: """
+        switch x {
+        case 1:  // trail on 1
+          fallthrough
+        case 2:
+          print("hi")
+        default:
+          break
+        }
+        switch y {
+        case 1:  /* block trail */
+          fallthrough
+        case 2:
+          print("hi")
+        default:
+          break
+        }
+        """,
+      findings: []
+    )
+  }
+
   func testNestedSwitches() {
     assertFormatting(
       NoCasesWithOnlyFallthrough.self,


### PR DESCRIPTION
Fixes #1274.

## Problem

When `NoCasesWithOnlyFallthrough` merges a fallthrough-only case into the following one, a comment trailing the `case` label on the same line is dropped from the output entirely — not moved, not preserved.

Input:

```swift
switch x {
case 1:  // trail on 1
  fallthrough
case 2:
  print("hi")
default:
  break
}
```

Output before this change:

```swift
switch x {
case 1, 2:
  print("hi")
default:
  break
}
```

`// trail on 1` is gone. The same happens with a block comment, and `lint` reports only the ordinary "combine..." finding, so nothing warns that applying the fix discards source text.

## Root cause

`isMergeableFallthroughOnly(_:)` already declines to merge when it finds a comment in three regions: the case's leading trivia, the fallthrough statement's leading trivia *after* the first newline, and the fallthrough's trailing (same-line) trivia. A comment written after the `case` label on the label's own line lands in the fallthrough statement's **leading** trivia *before* the first newline — exactly the same-line prefix the existing leading-trivia check skips with `.drop(while: { !$0.isNewline })`. So that quadrant was unchecked and the case merged anyway.

## Fix

Add a check for a comment in the same-line prefix of the fallthrough statement's preceding trivia (`.prefix(while: { !$0.isNewline })`). When present, the case is left un-merged and the comment is preserved. Covers both `//` and `/* */` comments.

## Test

Adds `testCaseWithTrailingCommentOnLabelIsNotCombined`, covering both a line and a block trailing comment; the cases must be left unchanged with no findings.

## Verification (local, Swift 6.1.2 on Linux)

- **RED→GREEN**: built `swift-format` without the change and confirmed the CLI drops `// trail on 1` and merges to `case 1, 2:`; with the change the comment is preserved and the case is left as-is.
- `swift test --filter NoCasesWithOnlyFallthroughTests` — all 10 tests pass (the new one plus the existing 9), no regressions.
- `swift-format lint` on both changed files is clean.